### PR TITLE
chore: switching to github environment based releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,15 @@
 name: Deployments
 
 on:
-  push:
-    branches:
-      - staging
-      - production
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to deploy'
+        type: environment
+        required: true
 jobs:
   deploy:
+    environment: ${{ inputs.environment }}
     name: Deploy Snap and UI
     runs-on: ubuntu-20.04
     steps:
@@ -51,7 +54,7 @@ jobs:
           aws s3 sync ./packages/wallet-ui/build s3://staging.snaps.consensys.net/starknet
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        if: github.ref_name == 'staging'
+        if: inputs.environment == 'staging'
 
       - name: Production Deployment
         run: |
@@ -66,4 +69,4 @@ jobs:
           aws s3 sync ./packages/wallet-ui/build s3://snaps.consensys.net/starknet
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        if: github.ref_name == 'production'
+        if: inputs.environment == 'production'


### PR DESCRIPTION
Switching to manual action for deployment to staging and production vs branch based deployments: 

![image](https://user-images.githubusercontent.com/13836477/197656554-036a7e84-c3ee-4540-82b9-3147f3a2e1cf.png)

Environments configured to run on protected branch (main) and require approver from @ConsenSys/snaps-factory-reviewers 

Solves the detached head issue with the branch based releases and effectively does the same thing. Could expand this eventually to release based on artifacts which would allow for simple rollbacks and more consistency from potential build discrepancies or undesired new commits.