### PR TITLE
fix: fix deploy pipeline

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         node-version: [16.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - name: Get Yarn cache directory
@@ -27,7 +27,7 @@ jobs:
         run: echo "::set-output name=YARN_VERSION::$(yarn --version)"
         id: yarn-version
       - name: Cache yarn dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir.outputs.YARN_CACHE_DIR }}
           key: yarn-cache-${{ runner.os }}-${{ steps.yarn-version.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,14 +46,14 @@ jobs:
       - run: yarn lint
       - run: yarn test
       - name: SonarCloud Scan Starknet-Snap
-        uses: SonarSource/sonarcloud-github-action@v1.9
+        uses: SonarSource/sonarcloud-github-action@v1.8
         with:
           projectBaseDir: packages/starknet-snap/
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_STARKNET_SNAP }}
       - name: SonarCloud Scan Wallet-UI
-        uses: SonarSource/sonarcloud-github-action@v1.9
+        uses: SonarSource/sonarcloud-github-action@v1.8
         with:
           projectBaseDir: packages/wallet-ui/
         env:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,14 +46,14 @@ jobs:
       - run: yarn lint
       - run: yarn test
       - name: SonarCloud Scan Starknet-Snap
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarcloud-github-action@1.9
         with:
           projectBaseDir: packages/starknet-snap/
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_STARKNET_SNAP }}
       - name: SonarCloud Scan Wallet-UI
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarcloud-github-action@1.9
         with:
           projectBaseDir: packages/wallet-ui/
         env:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         node-version: [16.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Get Yarn cache directory
@@ -27,7 +27,7 @@ jobs:
         run: echo "::set-output name=YARN_VERSION::$(yarn --version)"
         id: yarn-version
       - name: Cache yarn dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.yarn-cache-dir.outputs.YARN_CACHE_DIR }}
           key: yarn-cache-${{ runner.os }}-${{ steps.yarn-version.outputs.YARN_VERSION }}-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,14 +46,14 @@ jobs:
       - run: yarn lint
       - run: yarn test
       - name: SonarCloud Scan Starknet-Snap
-        uses: SonarSource/sonarcloud-github-action@1.9
+        uses: SonarSource/sonarcloud-github-action@1.8
         with:
           projectBaseDir: packages/starknet-snap/
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_STARKNET_SNAP }}
       - name: SonarCloud Scan Wallet-UI
-        uses: SonarSource/sonarcloud-github-action@1.9
+        uses: SonarSource/sonarcloud-github-action@1.8
         with:
           projectBaseDir: packages/wallet-ui/
         env:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,14 +46,14 @@ jobs:
       - run: yarn lint
       - run: yarn test
       - name: SonarCloud Scan Starknet-Snap
-        uses: SonarSource/sonarcloud-github-action@1.8
+        uses: SonarSource/sonarcloud-github-action@v1.9
         with:
           projectBaseDir: packages/starknet-snap/
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_STARKNET_SNAP }}
       - name: SonarCloud Scan Wallet-UI
-        uses: SonarSource/sonarcloud-github-action@1.8
+        uses: SonarSource/sonarcloud-github-action@v1.9
         with:
           projectBaseDir: packages/wallet-ui/
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,10 +47,10 @@ jobs:
           VERSION=$(node -p "require('./packages/starknet-snap/package.json').version")
           REACT_APP_SNAP_VERSION=${VERSION}-staging yarn workspace wallet-ui build
           
-          yarn workspace @consensys/starknet-snap version --new-version ${VERSION}-staging --no-git-tag-version
+          npm --prefix ./packages/starknet-snap version --new-version ${VERSION}-staging --no-git-tag-version
           yarn workspace @consensys/starknet-snap build
           
-          yarn workspace @consensys/starknet-snap publish --tag staging --access public 2>&1 > /dev/null || :
+          npm publish ./packages/starknet-snap  --tag staging --access public 2>&1 > /dev/null || :
           aws s3 sync ./packages/wallet-ui/build s3://app-staging.starknet-snap.consensys-solutions.net/starknet
           aws s3 sync ./packages/wallet-ui/build s3://staging.snaps.consensys.net/starknet
         env:
@@ -62,10 +62,10 @@ jobs:
           VERSION=$(node -p "require('./packages/starknet-snap/package.json').version")
           REACT_APP_SNAP_VERSION=${VERSION} yarn workspace wallet-ui build
 
-          yarn workspace @consensys/starknet-snap version --new-version ${VERSION} --no-git-tag-version
+          npm --prefix ./packages/starknet-snap version --new-version ${VERSION} --no-git-tag-version
           yarn workspace @consensys/starknet-snap build
           
-          yarn workspace @consensys/starknet-snap publish --tag latest --access public 2>&1 > /dev/null || :
+          npm publish ./packages/starknet-snap --tag latest --access public 2>&1 > /dev/null || :
           aws s3 sync ./packages/wallet-ui/build s3://snaps.consensys.net/starknet
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm-dev.yml
+++ b/.github/workflows/publish-npm-dev.yml
@@ -21,12 +21,12 @@ jobs:
           VERSION=$(node -p "require('../starknet-snap/package.json').version")
           HASH=$(git rev-parse --short HEAD)
           DATE=$(date +%Y%m%d)
-          yarn version --new-version ${VERSION}-dev-${HASH}-${DATE} --no-git-tag-version
+          npm version --new-version ${VERSION}-dev-${HASH}-${DATE} --no-git-tag-version
       - run: yarn build
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: yarn publish --tag dev --access public
+      - run: npm publish --tag dev --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/wallet-ui/src/services/useStarkNetSnap.ts
+++ b/packages/wallet-ui/src/services/useStarkNetSnap.ts
@@ -30,7 +30,7 @@ export const useStarkNetSnap = () => {
   const { ethereum } = window as any;
   const snapId = process.env.REACT_APP_SNAP_ID ? process.env.REACT_APP_SNAP_ID : 'local:http://localhost:8081/';
   const snapVersion = process.env.REACT_APP_SNAP_VERSION ? process.env.REACT_APP_SNAP_VERSION : '*';
-  const minSnapVersion = process.env.REACT_APP_MIN_SNAP_VERSION ? process.env.REACT_APP_MIN_SNAP_VERSION : '1.6.0';
+  const minSnapVersion = process.env.REACT_APP_MIN_SNAP_VERSION ? process.env.REACT_APP_MIN_SNAP_VERSION : '1.7.0';
 
   const connectToSnap = () => {
     dispatch(enableLoadingWithMessage('Connecting...'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1920,8 +1920,8 @@ __metadata:
   linkType: hard
 
 "@consensys/starknet-snap@file:../starknet-snap::locator=wallet-ui%40workspace%3Apackages%2Fwallet-ui":
-  version: 1.6.0
-  resolution: "@consensys/starknet-snap@file:../starknet-snap#../starknet-snap::hash=f76065&locator=wallet-ui%40workspace%3Apackages%2Fwallet-ui"
+  version: 1.7.0
+  resolution: "@consensys/starknet-snap@file:../starknet-snap#../starknet-snap::hash=68831c&locator=wallet-ui%40workspace%3Apackages%2Fwallet-ui"
   dependencies:
     async-mutex: ^0.3.2
     chai: ^4.3.6
@@ -1931,7 +1931,7 @@ __metadata:
     sinon-chai: ^3.7.0
     starknet: ^4.22.0
     starknet_v4.6.0: "npm:starknet@4.6.0"
-  checksum: b5b503020c3156e4ed31d812f397f3623310ac9c9b34c698ae7ec7b501c8be195f90c31e2b670ca1a8d2f3dba7eabad51d48a378eb4ea81065a218ed594cf713
+  checksum: 392d377e5f99620cb0417c40b78879c930300dea2e0b6cf8dab8317cf61ae6e7818599b259cfca66afc9e0655b3d0b7fe3eb1427af28cd4974e7280ec0ce8d69
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
due to yarn 2.0+, yarn version and publish cmd is not support, thus, change yarn to npm for version and publish cmd

Affected file:
- .github/workflows/deploy.yml
- .github/workflows/publish-npm-dev.yml