### PR TITLE
feat: sf 511 deprecation of status field for UI

### DIFF
--- a/packages/starknet-snap/snap.manifest.json
+++ b/packages/starknet-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/ConsenSys/starknet-snap.git"
   },
   "source": {
-    "shasum": "CZqPSGecVFaWK642xDvpjSjm7ErLQduvl6Qi3j0nNHE=",
+    "shasum": "0xRP/iG1BNeUMMDQV7lo9X8T4Ycm40D5SBZaaqeIpbM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/starknet-snap/snap.manifest.json
+++ b/packages/starknet-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/ConsenSys/starknet-snap.git"
   },
   "source": {
-    "shasum": "qUjSJdXDzmnc8/A0a26/T3g9wcvUpHP40R0xcchskLQ=",
+    "shasum": "CZqPSGecVFaWK642xDvpjSjm7ErLQduvl6Qi3j0nNHE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/starknet-snap/src/getTransactions.ts
+++ b/packages/starknet-snap/src/getTransactions.ts
@@ -94,7 +94,7 @@ export async function getTransactions(params: ApiParams) {
     }
 
     const updateStatusPromises = [];
-    const massagedTxnsMap = snapUtils.toMap<bigint, Transaction>(massagedTxns, 'txnHash', num.toBigInt);
+    const massagedTxnsMap = snapUtils.toMap<bigint, Transaction, string>(massagedTxns, 'txnHash', num.toBigInt);
 
     storedUnsettledTxns.forEach((txn: Transaction) => {
       const foundMassagedTxn = massagedTxnsMap.get(num.toBigInt(txn.txnHash));

--- a/packages/starknet-snap/src/getTransactions.ts
+++ b/packages/starknet-snap/src/getTransactions.ts
@@ -95,56 +95,58 @@ export async function getTransactions(params: ApiParams) {
 
     // For each "unsettled" txn, update the timestamp from the same txn found in massagedTxns
     const requireUpdateStatus = [];
-    if (massagedTxns) {
-      const massagedTxnsMap = snapUtils.toMap<bigint, Transaction>(massagedTxns, 'txnHash');
+    const massagedTxnsMap = snapUtils.toMap<bigint, Transaction>(massagedTxns, 'txnHash', num.toBigInt);
 
-      storedUnsettledTxns.forEach((txn: Transaction, idx: number) => {
-        const foundMassagedTxn = massagedTxnsMap.get(num.toBigInt(txn.txnHash));
-        if (!foundMassagedTxn) {
-          requireUpdateStatus.push(idx);
-        } else {
-          txn.timestamp = foundMassagedTxn?.timestamp;
-          txn.finalityStatus = foundMassagedTxn?.finalityStatus;
-          txn.executionStatus = foundMassagedTxn?.executionStatus;
-          txn.status = ''; // DEPRECATION
-        }
-      });
-    }
+    storedUnsettledTxns.forEach((txn: Transaction, idx: number) => {
+      const foundMassagedTxn = massagedTxnsMap.get(num.toBigInt(txn.txnHash));
+      if (!foundMassagedTxn) {
+        const statusUpdatePromise = async (idx) => {
+          try {
+            // it is possible to fail in getTransactionStatus, but it wont throw error as expected, hence the status will be remain
+            const { finalityStatus, executionStatus } = await utils.getTransactionStatus(
+              storedUnsettledTxns[idx].txnHash,
+              network,
+            );
+            storedUnsettledTxns[idx].finalityStatus = finalityStatus;
+            storedUnsettledTxns[idx].executionStatus = executionStatus;
+            storedUnsettledTxns[idx].status = ''; // DEPRECATION
+            storedUnsettledTxns[idx].failureReason = storedUnsettledTxns[idx].failureReason || '';
+          } catch (e) {
+            logger.error(
+              `Problem found in statusUpdatePromise:\n txn: ${storedUnsettledTxns[idx].txnHash}, err: \n${e.message}`,
+            );
+          } finally {
+            // statusUpdatePromise is run in parallel, hence mutex is require to lock the massagedTxns array
+            return saveMutex.runExclusive(async () => {
+              massagedTxns.push(storedUnsettledTxns[idx]);
+            });
+          }
+        };
+        requireUpdateStatus.push(statusUpdatePromise(idx));
+      } else {
+        txn.timestamp = foundMassagedTxn?.timestamp;
+        txn.finalityStatus = foundMassagedTxn?.finalityStatus;
+        txn.executionStatus = foundMassagedTxn?.executionStatus;
+        txn.status = ''; // DEPRECATION
+      }
+    });
 
     logger.log(`getTransactions\nstoredUnsettledTxns:\n${toJson(storedUnsettledTxns)}`);
 
     // For each "unsettled" txn, get the latest status from the provider (RPC)
     if (requireUpdateStatus) {
-      await Promise.allSettled(
-        requireUpdateStatus.map(async (idx) => {
-          const txn = storedUnsettledTxns[idx];
-          const { finalityStatus, executionStatus } = await utils.getTransactionStatus(txn.txnHash, network);
-          txn.finalityStatus = finalityStatus;
-          txn.executionStatus = executionStatus;
-          txn.status = ''; // DEPRECATION
-          txn.failureReason = txn.failureReason || '';
-          storedUnsettledTxns[idx] = txn;
-        }),
-      );
+      await Promise.allSettled(requireUpdateStatus);
       logger.log(`getTransactions\nstoredUnsettledTxns after updated status:\n${toJson(storedUnsettledTxns)}`);
     }
 
     // Update the transactions in state in a single call
     await snapUtils.upsertTransactions(storedUnsettledTxns, wallet, saveMutex);
 
-    // Filter out massaged txns that are found in the updated stored txns
-    massagedTxns = massagedTxns.filter((massagedTxn) => {
-      return !storedUnsettledTxns.find((txn) => num.toBigInt(txn.txnHash) === num.toBigInt(massagedTxn.txnHash));
-    });
-    logger.log(`getTransactions\nmassagedTxns after filtered total:\n${massagedTxns.length}`);
-
     // Clean up all ACCEPTED_ON_L1 and ACCEPTED_ON_L2 txns from state that has timestamp less than minTimeStamp as they will be retrievable from the Voyager "api/txns" endpoint
     await snapUtils.removeAcceptedTransaction(minTimeStamp, wallet, saveMutex);
 
     // Sort in timestamp descending order
-    massagedTxns = [...massagedTxns, ...storedUnsettledTxns].sort(
-      (a: Transaction, b: Transaction) => b.timestamp - a.timestamp,
-    );
+    massagedTxns = massagedTxns.sort((a: Transaction, b: Transaction) => b.timestamp - a.timestamp);
     logger.log(`getTransactions\nmassagedTxns:\n${toJson(massagedTxns)}`);
 
     return massagedTxns;

--- a/packages/starknet-snap/src/utils/snapUtils.ts
+++ b/packages/starknet-snap/src/utils/snapUtils.ts
@@ -550,9 +550,9 @@ export async function removeAcceptedTransaction(
   });
 }
 
-export function toMap<k, v>(arr: Array<v>, key: string, keyConverter?: (v: any) => k): Map<k, v> {
+export function toMap<k, v, z>(arr: Array<v>, key: string, keyConverter?: (v: z) => k): Map<k, v> {
   return arr.reduce((map, obj: v) => {
-    map.set(keyConverter && typeof keyConverter === 'function' ? keyConverter(obj[key]) : obj[key], obj);
+    map.set(keyConverter && typeof keyConverter === 'function' ? keyConverter(obj[key] as z) : obj[key], obj);
     return map;
   }, new Map<k, v>());
 }

--- a/packages/starknet-snap/src/utils/snapUtils.ts
+++ b/packages/starknet-snap/src/utils/snapUtils.ts
@@ -534,12 +534,11 @@ export async function removeAcceptedTransaction(
 
     state.transactions = state.transactions.filter(
       (txn) =>
-        (txn.status !== TransactionStatus.ACCEPTED_ON_L2 && txn.status !== TransactionStatus.ACCEPTED_ON_L1) ||
         (txn.finalityStatus !== TransactionStatus.ACCEPTED_ON_L2 &&
           txn.finalityStatus !== TransactionStatus.ACCEPTED_ON_L1) ||
-        ((txn.finalityStatus === TransactionStatus.ACCEPTED_ON_L2 || txn.status === TransactionStatus.ACCEPTED_ON_L2) &&
-          txn.timestamp * 1000 >= minTimeStamp),
+        (txn.finalityStatus === TransactionStatus.ACCEPTED_ON_L2 && txn.timestamp * 1000 >= minTimeStamp),
     );
+
     await wallet.request({
       method: 'snap_manageState',
       params: {

--- a/packages/starknet-snap/src/utils/snapUtils.ts
+++ b/packages/starknet-snap/src/utils/snapUtils.ts
@@ -550,9 +550,9 @@ export async function removeAcceptedTransaction(
   });
 }
 
-export function toMap<k, v>(arr: Array<v>, key: string): Map<k, v> {
+export function toMap<k, v>(arr: Array<v>, key: string, keyConverter?: (v: any) => k): Map<k, v> {
   return arr.reduce((map, obj: v) => {
-    map.set(obj[key], obj);
+    map.set(keyConverter && typeof keyConverter === 'function' ? keyConverter(obj[key]) : obj[key], obj);
     return map;
   }, new Map<k, v>());
 }

--- a/packages/starknet-snap/test/constants.test.ts
+++ b/packages/starknet-snap/test/constants.test.ts
@@ -210,6 +210,22 @@ export const RejectedTxn2: Transaction = {
   eventIds: [],
 };
 
+export const unsettedTransactionInMassagedTxn: Transaction = {
+  chainId: STARKNET_TESTNET_NETWORK.chainId,
+  contractAddress: '0x7394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10',
+  contractCallData: ['0x14361d05e560796ad3152e083b609f5205f3bd76039327326746ba7f769a666', '0xde0b6b3a7640000', '0x0'],
+  contractFuncName: 'transfer',
+  senderAddress: '0x5a98ec74a40383cf99896bfea2ec5e6aad16c7eed50025a5f569d585ebb13a2',
+  timestamp: 1655109666,
+  txnHash: '0x1366c2f9f46b1a86ba0c28b5a08fa0aa3750c4d1cbe06e97e72bd46ae2ac1f9',
+  txnType: VoyagerTransactionType.INVOKE,
+  failureReason: '',
+  status: 'RECEIVED',
+  executionStatus: 'RECEIVED',
+  finalityStatus: 'RECEIVED',
+  eventIds: [],
+};
+
 export const txn1: Transaction = {
   chainId: STARKNET_MAINNET_NETWORK.chainId,
   contractAddress: '0x06a09ccb1caaecf3d9683efe335a667b2169a409d19c589ba1eb771cd210af75',

--- a/packages/starknet-snap/test/src/getTransactions.test.ts
+++ b/packages/starknet-snap/test/src/getTransactions.test.ts
@@ -209,7 +209,7 @@ describe('Test function: getTransactions.updateStatus', function () {
   let txns = [];
   beforeEach(function () {
     txns = [{ ...unsettedTransactionInMassagedTxn }];
-    getTransactionStatusStub = sandbox.stub(utils, 'getTransactionStatus').callsFake(async (...args) => {
+    getTransactionStatusStub = sandbox.stub(utils, 'getTransactionStatus').callsFake(async () => {
       return getTxnStatusAcceptL2Resp;
     });
   });

--- a/packages/wallet-ui/src/components/ui/molecule/TransactionsList/TransactionListItem/TransactionListItem.style.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/TransactionsList/TransactionListItem/TransactionListItem.style.tsx
@@ -14,15 +14,17 @@ interface IIconeStyled {
 
 const getStatusColor = (status?: TransactionStatusOptions | string) => {
   switch (status) {
-    case 'Accepted on L1':
-    case 'Accepted on L2':
+    case 'ACCEPTED ON L1':
+    case 'ACCEPTED ON L2':
+    case 'SUCCEEDED':
       return theme.palette.success.dark;
-    case 'Received':
+    case 'RECEIVED':
       return theme.palette.info.main;
-    case 'Rejected':
-    case 'Not Received':
+    case 'REJECTED':
+    case 'NOT RECEIVED':
+    case 'REVERTED':
       return theme.palette.error.main;
-    case 'Pending':
+    case 'PENDING':
       return theme.palette.warning.main;
     default:
       return theme.palette.grey.grey1;

--- a/packages/wallet-ui/src/components/ui/molecule/TransactionsList/TransactionListItem/TransactionListItem.view.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/TransactionsList/TransactionListItem/TransactionListItem.view.tsx
@@ -57,7 +57,6 @@ export const TransactionListItemView = ({ transaction }: Props) => {
   const txnStatus = getTxnStatus(transaction);
   const txnToFromLabel = getTxnToFromLabel(transaction);
   const txnFailureReason = getTxnFailureReason(transaction);
-
   return (
     <Wrapper onClick={() => openExplorerTab(transaction.txnHash, 'tx', transaction.chainId)}>
       <Left>
@@ -68,7 +67,7 @@ export const TransactionListItemView = ({ transaction }: Props) => {
           <Label>{txnName}</Label>
           <Description>
             {txnDate}
-            <Status status={txnStatus}>
+            <Status status={transaction.executionStatus}>
               {' '}
               . {txnStatus}
               {txnFailureReason}

--- a/packages/wallet-ui/src/components/ui/molecule/TransactionsList/TransactionListItem/types.ts
+++ b/packages/wallet-ui/src/components/ui/molecule/TransactionsList/TransactionListItem/types.ts
@@ -35,34 +35,32 @@ export const getTxnDate = (transaction: Transaction): string => {
 };
 
 export const getTxnStatus = (transaction: Transaction): string => {
-  let statusStr = []
+  let statusStr = [];
   if (transaction.finalityStatus === transaction.executionStatus) {
-    return transaction.finalityStatus ? formatStatus(transaction.finalityStatus) : ''
+    return transaction.finalityStatus ? formatStatus(transaction.finalityStatus) : '';
   }
-  if (transaction.finalityStatus)
-  {
-    statusStr.push(formatStatus(transaction.finalityStatus))
+  if (transaction.finalityStatus) {
+    statusStr.push(formatStatus(transaction.finalityStatus));
   }
-  if (transaction.executionStatus)
-  {
-    statusStr.push(formatStatus(transaction.executionStatus))
+  if (transaction.executionStatus) {
+    statusStr.push(formatStatus(transaction.executionStatus));
   }
-  return statusStr.join(' / ')
+  return statusStr.join(' / ');
 };
 
 export const formatStatus = (status: string): string => {
   return status
-  .replaceAll('_', ' ')
-  .split(' ')
-  .map((word) => {
-    word = word.toLowerCase();
-    if (word !== 'on') {
-      word = word.charAt(0).toUpperCase() + word.slice(1);
-    }
-    return word;
-  })
-  .join(' ')
-}
+    .replaceAll('_', ' ')
+    .split(' ')
+    .map((word) => {
+      word = word.toLowerCase();
+      if (word !== 'on') {
+        word = word.charAt(0).toUpperCase() + word.slice(1);
+      }
+      return word;
+    })
+    .join(' ');
+};
 
 export const getTxnToFromLabel = (transaction: Transaction): string => {
   const txnName = getTxnName(transaction);

--- a/packages/wallet-ui/src/components/ui/molecule/TransactionsList/TransactionListItem/types.ts
+++ b/packages/wallet-ui/src/components/ui/molecule/TransactionsList/TransactionListItem/types.ts
@@ -35,20 +35,34 @@ export const getTxnDate = (transaction: Transaction): string => {
 };
 
 export const getTxnStatus = (transaction: Transaction): string => {
-  return transaction.status
-    ? transaction.status
-        .replaceAll('_', ' ')
-        .split(' ')
-        .map((word) => {
-          word = word.toLowerCase();
-          if (word !== 'on') {
-            word = word.charAt(0).toUpperCase() + word.slice(1);
-          }
-          return word;
-        })
-        .join(' ')
-    : '';
+  let statusStr = []
+  if (transaction.finalityStatus === transaction.executionStatus) {
+    return transaction.finalityStatus ? formatStatus(transaction.finalityStatus) : ''
+  }
+  if (transaction.finalityStatus)
+  {
+    statusStr.push(formatStatus(transaction.finalityStatus))
+  }
+  if (transaction.executionStatus)
+  {
+    statusStr.push(formatStatus(transaction.executionStatus))
+  }
+  return statusStr.join(' / ')
 };
+
+export const formatStatus = (status: string): string => {
+  return status
+  .replaceAll('_', ' ')
+  .split(' ')
+  .map((word) => {
+    word = word.toLowerCase();
+    if (word !== 'on') {
+      word = word.charAt(0).toUpperCase() + word.slice(1);
+    }
+    return word;
+  })
+  .join(' ')
+}
 
 export const getTxnToFromLabel = (transaction: Transaction): string => {
   const txnName = getTxnName(transaction);


### PR DESCRIPTION
Background:

Breaking changes introduced in Pathfinder 0.7 and RPC 0.4 for statuses read (deprecation of "status" field for "execution_status" + "finality_status") will be taken into account in a new version of the snap -> Consensys will start working on this in parallel of the MM stable launch and will communicate with Starknet team on expected release date (hard deadline is the v0.13 release in October)

Description:

for get status API, change RPC provider from feeder_gateway to infura
for bulk gas est API, change RPC provider from feeder_gateway to infura
return execution_status and finality_status for snap method starkNet_getTransactionStatus and starkNet_getTransactions

Reference:
https://www.notion.so/Starknet-Snap-update-for-Starknet-v0-12-upgrade-7af534eb6c82410ab6977d209b5cd44e?pvs=4#ea8b9406df194235a07909f0d6c41bb9

update UI:
- update status label display 
- update status colour display

Snap:
- fix get transactions bug where `massagedTxnsMap` should convert the key with bigint
- enhance performance 
  - updating fetch status for transactions into a single pass loop
  - concat massagedTxn in single pass
From:
```
storedUnsettledTxns.forEach((txn: Transaction, idx: number) => {
        const foundMassagedTxn = massagedTxnsMap.get(num.toBigInt(txn.txnHash));
        if (!foundMassagedTxn) {
          requireUpdateStatus.push(idx);
       } else {
          ....
       }
});
if (requireUpdateStatus) {
      await Promise.allSettled(
        requireUpdateStatus.map(async (idx) => {
          const txn = storedUnsettledTxns[idx];
          const { finalityStatus, executionStatus } = await utils.getTransactionStatus(txn.txnHash, network);
          ....
        }),
      );
      await Promise.allSettled(requireUpdateStatus);
}
...
massagedTxns = massagedTxns.filter((massagedTxn) => {
      return !storedUnsettledTxns.find((txn) => num.toBigInt(txn.txnHash) === num.toBigInt(massagedTxn.txnHash));
    });
...
massagedTxns = [...massagedTxns, ...storedUnsettledTxns].sort(
      (a: Transaction, b: Transaction) => b.timestamp - a.timestamp,
    );
```
To:
```

storedUnsettledTxns.forEach((txn: Transaction, idx: number) => {
        const foundMassagedTxn = massagedTxnsMap.get(num.toBigInt(txn.txnHash));
        if (!foundMassagedTxn) {
            updateStatusPromises.push(updateStatus(txn, network));
            massagedTxns.push(txn);
        } else {
          ....
       }
});
...
if (updateStatusPromises) {
      await Promise.allSettled(updateStatusPromises);
      ...
}
...
massagedTxns = massagedTxns.sort(
      (a: Transaction, b: Transaction) => b.timestamp - a.timestamp,
    );
```

- adding new helper `updateStatus` 
- adding new test case to test merged transaction from snap state and on chain

JIRA Ticket:
https://consensyssoftware.atlassian.net/jira/software/projects/SF/boards/472/backlog?selectedIssue=SF-511