### PR TITLE
feat: change account contract to cairo 1

### DIFF
--- a/packages/starknet-snap/snap.manifest.json
+++ b/packages/starknet-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/ConsenSys/starknet-snap.git"
   },
   "source": {
-    "shasum": "+VwOFJaGNMcEVuIMh+hlc5DCpqPxwbflYvfVdhY8hT0=",
+    "shasum": "6MAPpaepoUn4jcXUhYKIF+XnYV1SGbudlJ+Qa+knr5g=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/starknet-snap/src/addErc20Token.ts
+++ b/packages/starknet-snap/src/addErc20Token.ts
@@ -10,6 +10,7 @@ import {
 import { DEFAULT_DECIMAL_PLACES } from './utils/constants';
 import { DialogType } from '@metamask/rpc-methods';
 import { heading, panel, text, copyable } from '@metamask/snaps-ui';
+import { logger } from './utils/logger';
 
 export async function addErc20Token(params: ApiParams) {
   try {
@@ -61,10 +62,10 @@ export async function addErc20Token(params: ApiParams) {
 
     await upsertErc20Token(erc20Token, wallet, saveMutex);
 
-    console.log(`addErc20Token:\nerc20Token: ${toJson(erc20Token)}`);
+    logger.log(`addErc20Token:\nerc20Token: ${toJson(erc20Token)}`);
     return erc20Token;
   } catch (err) {
-    console.error(`Problem found: ${err}`);
+    logger.error(`Problem found: ${err}`);
     throw err;
   }
 }

--- a/packages/starknet-snap/src/estimateFee.ts
+++ b/packages/starknet-snap/src/estimateFee.ts
@@ -13,7 +13,6 @@ import {
   isAccountDeployed,
 } from './utils/starknetUtils';
 
-import { PROXY_CONTRACT_HASH } from './utils/constants';
 import { logger } from './utils/logger';
 
 export async function estimateFee(params: ApiParams) {
@@ -71,7 +70,7 @@ export async function estimateFee(params: ApiParams) {
     if (!accountDeployed) {
       const { callData } = getAccContractAddressAndCallData(network.accountClassHash, publicKey);
       const deployAccountpayload = {
-        classHash: PROXY_CONTRACT_HASH,
+        classHash: network.accountClassHash,
         contractAddress: senderAddress,
         constructorCalldata: callData,
         addressSalt: publicKey,

--- a/packages/starknet-snap/src/signMessage.ts
+++ b/packages/starknet-snap/src/signMessage.ts
@@ -52,8 +52,11 @@ export async function signMessage(params: ApiParams) {
 
     const typedDataSignature = getTypedDataMessageSignature(signerPrivateKey, typedDataMessage, signerAddress);
 
-    logger.log(`signMessage:\ntypedDataSignature: ${toJson(typedDataSignature)}`);
-    return typedDataSignature.toDERHex();
+    const result = typedDataSignature.toDERHex();
+
+    logger.log(`signMessage:\ntypedDataSignature: ${result}`);
+
+    return result;
   } catch (err) {
     logger.error(`Problem found: ${err}`);
     throw err;

--- a/packages/starknet-snap/src/types/snapState.ts
+++ b/packages/starknet-snap/src/types/snapState.ts
@@ -15,6 +15,7 @@ export interface AccContract {
   derivationPath: string;
   deployTxnHash: string; // in hex
   chainId: string; // in hex
+  upgradeRequired?: boolean;
 }
 
 export interface Erc20Token {
@@ -32,6 +33,7 @@ export interface Network {
   nodeUrl: string;
   voyagerUrl: string;
   accountClassHash: string; // in hex
+  accountClassHashV0?: string; // in hex
   useOldAccounts?: boolean;
 }
 

--- a/packages/starknet-snap/src/utils/constants.ts
+++ b/packages/starknet-snap/src/utils/constants.ts
@@ -19,7 +19,8 @@ export const STARKNET_MAINNET_NETWORK: Network = {
   baseUrl: 'https://alpha-mainnet.starknet.io',
   nodeUrl: 'https://starknet-mainnet.infura.io/v3/60c7253fb48147658095fe0460ac9ee9',
   voyagerUrl: 'https://voyager.online',
-  accountClassHash: '0x033434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2', // from argent-x repo
+  accountClassHashV0: '0x033434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2', // from argent-x repo
+  accountClassHash: '0x1a736d6ed154502257f02b1ccdf4d9d1089f80811cd6acad48e6b6a9d1f2003',
 };
 
 export const STARKNET_TESTNET_NETWORK: Network = {
@@ -28,7 +29,8 @@ export const STARKNET_TESTNET_NETWORK: Network = {
   baseUrl: 'https://alpha4.starknet.io',
   nodeUrl: 'https://starknet-goerli.infura.io/v3/60c7253fb48147658095fe0460ac9ee9',
   voyagerUrl: 'https://goerli.voyager.online',
-  accountClassHash: '0x033434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2', // from argent-x repo
+  accountClassHashV0: '0x033434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2', // from argent-x repo
+  accountClassHash: '0x1a736d6ed154502257f02b1ccdf4d9d1089f80811cd6acad48e6b6a9d1f2003',
 };
 
 export const STARKNET_INTEGRATION_NETWORK: Network = {
@@ -37,7 +39,8 @@ export const STARKNET_INTEGRATION_NETWORK: Network = {
   baseUrl: 'https://external.integration.starknet.io',
   nodeUrl: '',
   voyagerUrl: '',
-  accountClassHash: '0x033434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2', // from argent-x repo
+  accountClassHashV0: '0x033434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2', // from argent-x repo
+  accountClassHash: '0x1a736d6ed154502257f02b1ccdf4d9d1089f80811cd6acad48e6b6a9d1f2003',
 };
 
 export const ETHER_MAINNET: Erc20Token = {
@@ -115,4 +118,6 @@ export const TEST_TOKEN_TESTNET: Erc20Token = {
 export const PRELOADED_TOKENS = [ETHER_MAINNET, ETHER_TESTNET];
 export const PRELOADED_NETWORKS = [STARKNET_MAINNET_NETWORK, STARKNET_TESTNET_NETWORK, STARKNET_INTEGRATION_NETWORK];
 
-export const PROXY_CONTRACT_HASH = '0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918'; // from argent-x repo
+export const PROXY_CONTRACT_HASH = '0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918'; // for cairo 0 proxy contract
+
+export const MIN_ACC_CONTRACT_VERSION = [0, 3, 0];

--- a/packages/starknet-snap/src/utils/snapUtils.ts
+++ b/packages/starknet-snap/src/utils/snapUtils.ts
@@ -270,6 +270,7 @@ export async function upsertAccount(userAccount: AccContract, wallet, mutex: Mut
       storedAccount.derivationPath = userAccount.derivationPath;
       storedAccount.publicKey = userAccount.publicKey;
       storedAccount.deployTxnHash = userAccount.deployTxnHash || storedAccount.deployTxnHash;
+      storedAccount.upgradeRequired = userAccount.upgradeRequired;
     }
 
     await wallet.request({

--- a/packages/starknet-snap/src/utils/starknetUtils.ts
+++ b/packages/starknet-snap/src/utils/starknetUtils.ts
@@ -484,7 +484,7 @@ export const getKeysFromAddressIndex = async (
   };
 };
 
-export const isAccountDeployedCario0 = async (network: Network, publicKey: string) => {
+export const isAccountDeployedCairo0 = async (network: Network, publicKey: string) => {
   const { address } = getAccContractAddressAndCallDataCairo0(network.accountClassHash, publicKey);
   return isAccountAddressDeployed(network, address, 0);
 };
@@ -494,10 +494,10 @@ export const isAccountDeployed = async (network: Network, publicKey: string) => 
   return isAccountAddressDeployed(network, address, 1);
 };
 
-export const isAccountAddressDeployed = async (network: Network, address: string, carioVersion = 1) => {
+export const isAccountAddressDeployed = async (network: Network, address: string, cairoVersion = 1) => {
   let accountDeployed = true;
   try {
-    switch (carioVersion) {
+    switch (cairoVersion) {
       case 0:
         await getSigner(address, network);
         break;
@@ -505,7 +505,7 @@ export const isAccountAddressDeployed = async (network: Network, address: string
         await getOwner(address, network);
         break;
       default:
-        throw new Error(`Not supported cairo version ${carioVersion}`);
+        throw new Error(`Not supported cairo version ${cairoVersion}`);
     }
   } catch (err) {
     if (!err.message.includes('Contract not found')) {
@@ -540,10 +540,10 @@ export const validateAndParseAddress = (address: num.BigNumberish, length = 63) 
   return _validateAndParseAddressFn(address);
 };
 
-export const isUpgradeRequired = async (network: Network, cario0address: string) => {
+export const isUpgradeRequired = async (network: Network, cairo0address: string) => {
   try {
-    logger.log(`isUpgradeRequired: cario0address = ${cario0address}`);
-    const version = await getVersion(cario0address, network);
+    logger.log(`isUpgradeRequired: cairo0address = ${cairo0address}`);
+    const version = await getVersion(cairo0address, network);
     const versionArr = version.split('.');
     return Number(versionArr[1]) < MIN_ACC_CONTRACT_VERSION[1];
   } catch (err) {
@@ -556,13 +556,13 @@ export const isUpgradeRequired = async (network: Network, cario0address: string)
 
 export const getCorrectContractAddress = async (network: Network, publicKey: string) => {
   const { address: contractAddress } = getAccContractAddressAndCallData(network.accountClassHash, publicKey);
-  const { address: contractAddressCario0 } = getAccContractAddressAndCallDataCairo0(
+  const { address: contractAddressCairo0 } = getAccContractAddressAndCallDataCairo0(
     network.accountClassHashV0,
     publicKey,
   );
   let pk = '';
   logger.log(
-    `getContractAddressByKey: contractAddressCario1 = ${contractAddress}\ncontractAddressCario0 = ${contractAddressCario0}\npublicKey = ${publicKey}`,
+    `getContractAddressByKey: contractAddressCairo1 = ${contractAddress}\ncontractAddressCairo0 = ${contractAddressCairo0}\npublicKey = ${publicKey}`,
   );
   try {
     pk = await getOwner(contractAddress, network);
@@ -573,10 +573,10 @@ export const getCorrectContractAddress = async (network: Network, publicKey: str
     }
     logger.log(`getContractAddressByKey: cairo 1 contract not found`);
     try {
-      pk = await getSigner(contractAddressCario0, network);
+      pk = await getSigner(contractAddressCairo0, network);
       logger.log(`getContractAddressByKey: cairo 0 contract found`);
       return {
-        address: contractAddressCario0,
+        address: contractAddressCairo0,
         signerPubKey: pk,
       };
     } catch (err) {

--- a/packages/starknet-snap/test/constants.test.ts
+++ b/packages/starknet-snap/test/constants.test.ts
@@ -18,6 +18,7 @@ export const invalidNetwork: Network = {
   nodeUrl: '',
   voyagerUrl: '',
   accountClassHash: '',
+  accountClassHashV0: '',
 };
 
 export const account1: AccContract = {
@@ -87,7 +88,7 @@ export const token3: Erc20Token = {
 export const signature1 =
   '3044022001bbc0696d02f85696608c9029973d7d5cf714be2a8188424578c40016262fff022004e388edeb3ceb1fd023b165c9a91cc39b97d58f77beb53b6b90ee9261d9f90c';
 export const signature2 =
-  '304402200510bd78f928984364253c04201185ab6ccc386278c8fe1aeda0deab7a476e3f02200442916a82f917f520071da038d6dc3eb4446824ce26893355ad4c4a9343729c';
+  '30440220052956ac852275b6004c4e8042450f6dce83059f068029b037cc47338c80d062022002bc0e712f03e341bb3532fc356b779d84fcb4dbfe8ed34de2db66e121971d92';
 
 // Derived from seed phrase: "dog simple gown ankle release anger local pulp rose river approve miracle"
 export const bip44Entropy: JsonBIP44CoinTypeNode = {
@@ -213,7 +214,18 @@ export const RejectedTxn2: Transaction = {
 export const unsettedTransactionInMassagedTxn: Transaction = {
   chainId: STARKNET_TESTNET_NETWORK.chainId,
   contractAddress: '0x7394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10',
-  contractCallData: ['0x14361d05e560796ad3152e083b609f5205f3bd76039327326746ba7f769a666', '0xde0b6b3a7640000', '0x0'],
+  contractCallData: [
+    '0x1',
+    '0x7394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10',
+    '0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e',
+    '0x0',
+    '0x3',
+    '0x3',
+    '0x14361d05e560796ad3152e083b609f5205f3bd76039327326746ba7f769a666',
+    '0xde0b6b3a7640000',
+    '0x0',
+    '0x1',
+  ],
   contractFuncName: 'transfer',
   senderAddress: '0x5a98ec74a40383cf99896bfea2ec5e6aad16c7eed50025a5f569d585ebb13a2',
   timestamp: 1655109666,
@@ -336,8 +348,8 @@ export const estimateFeeResp2 = {
   suggestedMaxFee: num.toBigInt('0x14a5d6744ed9'),
 };
 
-export const unfoundUserAddress = '0x018dfa1955a0154524203f81c5668d6a78c708375ee8908dcb55a49c6ec87190';
-export const unfoundUserPrivateKey = '0x610d87a5c02459f8643f9ad6a9bc70597d1a8a0ab4d645346b7eadc5266ad4d';
+export const unfoundUserAddress = '0x07bb462e1cf8f2eead6a86464fecac1fad84b66da8078fe39d24bdf7c8504070';
+export const unfoundUserPrivateKey = '0x38d36fc25592257d913d143d37e12533dba9f6721db6fa954ed513b0dc3d68b';
 export const unfoundUserPublicKey = '0x4b36a2b0a1e9d2af3416914798de776e37d9e0ab9a50d2dec30485dca64bb8';
 export const foundUserPrivateKey = '0x3cddbb7f3694ce84bd9598820834015d979d78e63474a5b00e59b41b0563f4e';
 
@@ -677,7 +689,18 @@ export const expectedMassagedTxns: Transaction[] = [
     senderAddress: '0x5a98ec74a40383cf99896bfea2ec5e6aad16c7eed50025a5f569d585ebb13a2',
     contractAddress: '0x7394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10',
     contractFuncName: 'transfer',
-    contractCallData: ['0x14361d05e560796ad3152e083b609f5205f3bd76039327326746ba7f769a666', '0xde0b6b3a7640000', '0x0'],
+    contractCallData: [
+      '0x1',
+      '0x7394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10',
+      '0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e',
+      '0x0',
+      '0x3',
+      '0x3',
+      '0x14361d05e560796ad3152e083b609f5205f3bd76039327326746ba7f769a666',
+      '0xde0b6b3a7640000',
+      '0x0',
+      '0x1',
+    ],
     timestamp: 1655109666,
     status: '',
     finalityStatus: 'ACCEPTED_ON_L1',

--- a/packages/starknet-snap/test/src/createAccount.test.ts
+++ b/packages/starknet-snap/test/src/createAccount.test.ts
@@ -17,7 +17,6 @@ import {
   estimateDeployFeeResp,
   getBalanceResp,
   account1,
-  account2,
   estimateDeployFeeResp2,
   estimateDeployFeeResp3,
 } from '../constants.test';
@@ -31,7 +30,7 @@ const sandbox = sinon.createSandbox();
 describe('Test function: createAccount', function () {
   this.timeout(10000);
   const walletStub = new WalletMock();
-  const state: SnapState = {
+  let state: SnapState = {
     accContracts: [],
     erc20Tokens: [],
     networks: [STARKNET_MAINNET_NETWORK, STARKNET_TESTNET_NETWORK],
@@ -55,10 +54,16 @@ describe('Test function: createAccount', function () {
   afterEach(function () {
     walletStub.reset();
     sandbox.restore();
+    state = {
+      accContracts: [],
+      erc20Tokens: [],
+      networks: [STARKNET_MAINNET_NETWORK, STARKNET_TESTNET_NETWORK],
+      transactions: [],
+    };
   });
 
   it('should only return derived address without sending deploy txn correctly in mainnet if deploy is false', async function () {
-    sandbox.stub(utils, 'getSigner').throws(new Error());
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(false);
     const requestObject: CreateAccountRequestParams = {
       chainId: STARKNET_MAINNET_NETWORK.chainId,
     };
@@ -84,9 +89,9 @@ describe('Test function: createAccount', function () {
     sandbox.stub(utils, 'deployAccount').callsFake(async () => {
       return createAccountProxyMainnetResp;
     });
-    sandbox.stub(utils, 'getSigner').throws(new Error());
-    sandbox.stub(utils, 'callContract').callsFake(async () => {
-      return getBalanceResp;
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(false);
+    sandbox.stub(utils, 'getBalance').callsFake(async () => {
+      return getBalanceResp[0];
     });
     sandbox.stub(utils, 'estimateAccountDeployFee').callsFake(async () => {
       return estimateDeployFeeResp;
@@ -115,12 +120,14 @@ describe('Test function: createAccount', function () {
   });
 
   it('should create and store an user account of specific address index with proxy in state correctly in mainnet', async function () {
+    state.accContracts.push(account1);
+    state.transactions.push(createAccountProxyTxn);
     sandbox.stub(utils, 'deployAccount').callsFake(async () => {
       return createAccountProxyMainnetResp2;
     });
-    sandbox.stub(utils, 'getSigner').throws(new Error());
-    sandbox.stub(utils, 'callContract').callsFake(async () => {
-      return getBalanceResp;
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(false);
+    sandbox.stub(utils, 'getBalance').callsFake(async () => {
+      return getBalanceResp[0];
     });
     sandbox.stub(utils, 'estimateAccountDeployFee').callsFake(async () => {
       return estimateDeployFeeResp;
@@ -153,9 +160,9 @@ describe('Test function: createAccount', function () {
     sandbox.stub(utils, 'deployAccount').callsFake(async () => {
       return createAccountProxyResp;
     });
-    sandbox.stub(utils, 'getSigner').throws(new Error());
-    sandbox.stub(utils, 'callContract').callsFake(async () => {
-      return getBalanceResp;
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(false);
+    sandbox.stub(utils, 'getBalance').callsFake(async () => {
+      return getBalanceResp[0];
     });
     sandbox.stub(utils, 'estimateAccountDeployFee').callsFake(async () => {
       return estimateDeployFeeResp;
@@ -172,34 +179,39 @@ describe('Test function: createAccount', function () {
     expect(walletStub.rpcStubs.snap_manageState).to.have.been.callCount(4);
     expect(result.address).to.be.eq(createAccountProxyResp.contract_address);
     expect(result.transaction_hash).to.be.eq(createAccountProxyResp.transaction_hash);
-    expect(state.accContracts.length).to.be.eq(3);
-    expect(state.accContracts[2].address).to.be.eq(createAccountProxyResp.contract_address);
-    expect(state.accContracts[2].deployTxnHash).to.be.eq(createAccountProxyResp.transaction_hash);
-    expect(state.accContracts[2].publicKey).to.be.eq(expectedPublicKey);
-    expect(state.accContracts[2].addressSalt).to.be.eq(expectedPublicKey);
-    expect(state.transactions.length).to.be.eq(3);
+    expect(state.accContracts.length).to.be.eq(1);
+    expect(state.accContracts[0].address).to.be.eq(createAccountProxyResp.contract_address);
+    expect(state.accContracts[0].deployTxnHash).to.be.eq(createAccountProxyResp.transaction_hash);
+    expect(state.accContracts[0].publicKey).to.be.eq(expectedPublicKey);
+    expect(state.accContracts[0].addressSalt).to.be.eq(expectedPublicKey);
+    expect(state.transactions.length).to.be.eq(1);
   });
 
   it('should not create any user account with proxy in state in SN_GOERLI if not in silentMode and user rejected', async function () {
+    sandbox.stub(utils, 'getAccContractAddressAndCallData').callsFake(() => {
+      return {
+        address: account1.address,
+        callData: [],
+      };
+    });
     walletStub.rpcStubs.snap_dialog.resolves(false);
     const requestObject: CreateAccountRequestParams = { deploy: true };
     apiParams.requestParams = requestObject;
+
     const result = await createAccount(apiParams);
     expect(walletStub.rpcStubs.snap_manageState).to.have.been.callCount(0);
-    expect(result.address).to.be.eq(account2.address);
-    expect(state.accContracts.length).to.be.eq(3);
-    expect(state.transactions.length).to.be.eq(3);
+    expect(result.address).to.be.eq(account1.address);
+    expect(state.accContracts.length).to.be.eq(0);
+    expect(state.transactions.length).to.be.eq(0);
   });
 
-  it('should not create any user account with proxy in state in SN_GOERLI if account already initialized with a signer', async function () {
+  it('should not create any user account with proxy in state in SN_GOERLI if account already deployed', async function () {
     sandbox.stub(utils, 'deployAccount').callsFake(async () => {
       return createAccountProxyResp;
     });
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
-      return account1.publicKey;
-    });
-    sandbox.stub(utils, 'callContract').callsFake(async () => {
-      return getBalanceResp;
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(true);
+    sandbox.stub(utils, 'getBalance').callsFake(async () => {
+      return getBalanceResp[0];
     });
     sandbox.stub(utils, 'estimateAccountDeployFee').callsFake(async () => {
       return estimateDeployFeeResp;
@@ -210,17 +222,17 @@ describe('Test function: createAccount', function () {
     expect(walletStub.rpcStubs.snap_manageState).to.have.been.callCount(4);
     expect(result.address).to.be.eq(createAccountProxyResp.contract_address);
     expect(result.transaction_hash).to.be.eq(createAccountProxyResp.transaction_hash);
-    expect(state.accContracts.length).to.be.eq(3);
-    expect(state.transactions.length).to.be.eq(3);
+    expect(state.accContracts.length).to.be.eq(1);
+    expect(state.transactions.length).to.be.eq(1);
   });
 
   it('should not create any user account with proxy in state in SN_GOERLI if account does not have enough ETH balance', async function () {
     sandbox.stub(utils, 'deployAccount').callsFake(async () => {
       return createAccountProxyResp;
     });
-    sandbox.stub(utils, 'getSigner').throws(new Error());
-    sandbox.stub(utils, 'callContract').callsFake(async () => {
-      return getBalanceResp;
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(false);
+    sandbox.stub(utils, 'getBalance').callsFake(async () => {
+      return getBalanceResp[0];
     });
     sandbox.stub(utils, 'estimateAccountDeployFee').callsFake(async () => {
       return estimateDeployFeeResp2;
@@ -228,20 +240,20 @@ describe('Test function: createAccount', function () {
     const requestObject: CreateAccountRequestParams = { deploy: true };
     apiParams.requestParams = requestObject;
     const result = await createAccount(apiParams);
-    expect(walletStub.rpcStubs.snap_manageState).to.have.been.callCount(3);
+    expect(walletStub.rpcStubs.snap_manageState).to.have.been.callCount(4);
     expect(result.address).to.be.eq(createAccountProxyResp.contract_address);
     expect(result.transaction_hash).to.be.eq(createAccountProxyResp.transaction_hash);
-    expect(state.accContracts.length).to.be.eq(3);
-    expect(state.transactions.length).to.be.eq(3);
+    expect(state.accContracts.length).to.be.eq(1);
+    expect(state.transactions.length).to.be.eq(1);
   });
 
   it('should not create any user account with proxy in state in SN_GOERLI if account does not have enough ETH balance for suggestedMaxFee > 0.000001 ETH', async function () {
     sandbox.stub(utils, 'deployAccount').callsFake(async () => {
       return createAccountProxyResp;
     });
-    sandbox.stub(utils, 'getSigner').throws(new Error());
-    sandbox.stub(utils, 'callContract').callsFake(async () => {
-      return getBalanceResp;
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(false);
+    sandbox.stub(utils, 'getBalance').callsFake(async () => {
+      return getBalanceResp[0];
     });
     sandbox.stub(utils, 'estimateAccountDeployFee').callsFake(async () => {
       return estimateDeployFeeResp3;
@@ -249,37 +261,37 @@ describe('Test function: createAccount', function () {
     const requestObject: CreateAccountRequestParams = { deploy: true };
     apiParams.requestParams = requestObject;
     const result = await createAccount(apiParams);
-    expect(walletStub.rpcStubs.snap_manageState).to.have.been.callCount(3);
+    expect(walletStub.rpcStubs.snap_manageState).to.have.been.callCount(4);
     expect(result.address).to.be.eq(createAccountProxyResp.contract_address);
     expect(result.transaction_hash).to.be.eq(createAccountProxyResp.transaction_hash);
-    expect(state.accContracts.length).to.be.eq(3);
-    expect(state.transactions.length).to.be.eq(3);
+    expect(state.accContracts.length).to.be.eq(1);
+    expect(state.transactions.length).to.be.eq(1);
   });
 
   it('should not create any user account with proxy in state in SN_GOERLI if get account ETH balance throws error', async function () {
     sandbox.stub(utils, 'deployAccount').callsFake(async () => {
       return createAccountProxyResp;
     });
-    sandbox.stub(utils, 'getSigner').throws(new Error());
-    sandbox.stub(utils, 'callContract').throws(new Error());
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(false);
+    sandbox.stub(utils, 'getBalance').throws(new Error());
     sandbox.stub(utils, 'estimateAccountDeployFee').callsFake(async () => {
       return estimateDeployFeeResp2;
     });
     const requestObject: CreateAccountRequestParams = { deploy: true };
     apiParams.requestParams = requestObject;
     const result = await createAccount(apiParams);
-    expect(walletStub.rpcStubs.snap_manageState).to.have.been.callCount(3);
+    expect(walletStub.rpcStubs.snap_manageState).to.have.been.callCount(4);
     expect(result.address).to.be.eq(createAccountProxyResp.contract_address);
     expect(result.transaction_hash).to.be.eq(createAccountProxyResp.transaction_hash);
-    expect(state.accContracts.length).to.be.eq(3);
-    expect(state.transactions.length).to.be.eq(3);
+    expect(state.accContracts.length).to.be.eq(1);
+    expect(state.transactions.length).to.be.eq(1);
   });
 
   it('should skip upsert account and transaction if deployTxn response code has no transaction_hash in SN_GOERLI', async function () {
     sandbox.stub(utils, 'deployAccount').callsFake(async () => {
       return createAccountFailedProxyResp;
     });
-    sandbox.stub(utils, 'getSigner').throws(new Error());
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(false);
     sandbox.stub(utils, 'estimateAccountDeployFee').callsFake(async () => {
       return estimateDeployFeeResp;
     });
@@ -289,8 +301,8 @@ describe('Test function: createAccount', function () {
     expect(walletStub.rpcStubs.snap_manageState).to.have.been.callCount(0);
     expect(result.address).to.be.eq(createAccountFailedProxyResp.contract_address);
     expect(result.transaction_hash).to.be.eq(createAccountFailedProxyResp.transaction_hash);
-    expect(state.accContracts.length).to.be.eq(3);
-    expect(state.transactions.length).to.be.eq(3);
+    expect(state.accContracts.length).to.be.eq(0);
+    expect(state.transactions.length).to.be.eq(0);
   });
 
   it('should throw error if upsertAccount failed', async function () {
@@ -298,7 +310,7 @@ describe('Test function: createAccount', function () {
     sandbox.stub(utils, 'deployAccount').callsFake(async () => {
       return createAccountProxyResp;
     });
-    sandbox.stub(utils, 'getSigner').throws(new Error());
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(false);
     sandbox.stub(utils, 'estimateAccountDeployFee').callsFake(async () => {
       return estimateDeployFeeResp;
     });
@@ -311,6 +323,28 @@ describe('Test function: createAccount', function () {
     } catch (err) {
       result = err;
     } finally {
+      expect(result).to.be.an('Error');
+    }
+  });
+
+  it('should throw error if isAccountAddressDeployed failed', async function () {
+    const isAccountAddressDeployedStub = sandbox.stub(utils, 'isAccountAddressDeployed').throws(new Error());
+    const deployAccountStub = sandbox.stub(utils, 'deployAccount');
+    const estimateAccountDeployFeeStub = sandbox.stub(utils, 'estimateAccountDeployFee');
+    const getBalanceStub = sandbox.stub(utils, 'getBalance');
+    const requestObject: CreateAccountRequestParams = { deploy: true };
+    apiParams.requestParams = requestObject;
+
+    let result;
+    try {
+      await createAccount(apiParams);
+    } catch (err) {
+      result = err;
+    } finally {
+      expect(isAccountAddressDeployedStub).to.have.been.callCount(1);
+      expect(deployAccountStub).to.have.been.callCount(0);
+      expect(estimateAccountDeployFeeStub).to.have.been.callCount(0);
+      expect(getBalanceStub).to.have.been.callCount(0);
       expect(result).to.be.an('Error');
     }
   });

--- a/packages/starknet-snap/test/src/estimateFee.test.ts
+++ b/packages/starknet-snap/test/src/estimateFee.test.ts
@@ -53,7 +53,7 @@ describe('Test function: estimateFee', function () {
   });
 
   it('should estimate the fee correctly', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
+    sandbox.stub(utils, 'getOwner').callsFake(async () => {
       return account2.publicKey;
     });
     sandbox.stub(utils, 'estimateFee').callsFake(async () => {
@@ -69,7 +69,7 @@ describe('Test function: estimateFee', function () {
   });
 
   it('should estimate the fee including deploy txn correctly', async function () {
-    sandbox.stub(utils, 'getSigner').throws(new Error());
+    sandbox.stub(utils, 'isAccountDeployed').resolves(false);
     sandbox.stub(utils, 'estimateFeeBulk').callsFake(async () => {
       return [estimateDeployFeeResp4, estimateFeeResp];
     });
@@ -79,7 +79,7 @@ describe('Test function: estimateFee', function () {
   });
 
   it('should estimate the fee without gas consumed and gas price correctly', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
+    sandbox.stub(utils, 'getOwner').callsFake(async () => {
       return account2.publicKey;
     });
     sandbox.stub(utils, 'estimateFee').callsFake(async () => {
@@ -95,7 +95,7 @@ describe('Test function: estimateFee', function () {
   });
 
   it('should throw error if estimateFee failed', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
+    sandbox.stub(utils, 'getOwner').callsFake(async () => {
       return account2.publicKey;
     });
     sandbox.stub(utils, 'estimateFeeBulk').throws(new Error());
@@ -112,7 +112,7 @@ describe('Test function: estimateFee', function () {
   });
 
   it('should throw an error if the function name is undefined', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
+    sandbox.stub(utils, 'getOwner').callsFake(async () => {
       return account2.publicKey;
     });
     apiParams.requestParams = {
@@ -132,7 +132,7 @@ describe('Test function: estimateFee', function () {
   });
 
   it('should throw an error if the contract address is invalid', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
+    sandbox.stub(utils, 'getOwner').callsFake(async () => {
       return account2.publicKey;
     });
     apiParams.requestParams = {
@@ -152,7 +152,7 @@ describe('Test function: estimateFee', function () {
   });
 
   it('should throw an error if the sender address is invalid', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
+    sandbox.stub(utils, 'getOwner').callsFake(async () => {
       return account2.publicKey;
     });
     apiParams.requestParams = {

--- a/packages/starknet-snap/test/src/sendTransaction.test.ts
+++ b/packages/starknet-snap/test/src/sendTransaction.test.ts
@@ -70,9 +70,7 @@ describe('Test function: sendTransaction', function () {
   });
 
   it('should send a transaction for transferring 10 tokens correctly', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
-      return account1.publicKey;
-    });
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(true);
     const requestObject: SendTransactionRequestParams = {
       contractAddress: '0x07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10',
       contractFuncName: 'transfer',
@@ -87,12 +85,12 @@ describe('Test function: sendTransaction', function () {
   });
 
   it('should trigger a deploy txn and send a transaction for transferring 10 tokens correctly', async function () {
-    sandbox.stub(utils, 'getSigner').throws(new Error());
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(false);
     sandbox.stub(utils, 'deployAccount').callsFake(async () => {
       return createAccountProxyResp;
     });
-    sandbox.stub(utils, 'callContract').callsFake(async () => {
-      return getBalanceResp;
+    sandbox.stub(utils, 'getBalance').callsFake(async () => {
+      return getBalanceResp[0];
     });
     sandbox.stub(utils, 'estimateAccountDeployFee').callsFake(async () => {
       return estimateDeployFeeResp;
@@ -111,9 +109,7 @@ describe('Test function: sendTransaction', function () {
   });
 
   it('should return false if user rejected to sign the transaction', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
-      return account1.publicKey;
-    });
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(true);
     walletStub.rpcStubs.snap_dialog.resolves(false);
     const requestObject: SendTransactionRequestParams = {
       contractAddress: '0x07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10',
@@ -129,9 +125,7 @@ describe('Test function: sendTransaction', function () {
   });
 
   it('should send a transaction for transferring 10 tokens but not update snap state if transaction_hash is missing from response', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
-      return account1.publicKey;
-    });
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(true);
     executeTxnResp = sendTransactionFailedResp;
     const requestObject: SendTransactionRequestParams = {
       contractAddress: '0x07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10',
@@ -147,9 +141,7 @@ describe('Test function: sendTransaction', function () {
   });
 
   it('should send a transaction with given max fee for transferring 10 tokens correctly', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
-      return account1.publicKey;
-    });
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(true);
     const requestObject: SendTransactionRequestParams = {
       contractAddress: '0x07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10',
       contractFuncName: 'transfer',
@@ -165,9 +157,7 @@ describe('Test function: sendTransaction', function () {
   });
 
   it('should send a transfer transaction for empty call data', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
-      return account1.publicKey;
-    });
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(true);
     const requestObject: SendTransactionRequestParams = {
       contractAddress: '0x07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10',
       contractFuncName: 'transfer',
@@ -182,9 +172,7 @@ describe('Test function: sendTransaction', function () {
   });
 
   it('should send a transaction for empty call data', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
-      return account1.publicKey;
-    });
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(true);
     const requestObject: SendTransactionRequestParams = {
       contractAddress: account1.address,
       contractFuncName: 'get_signer',
@@ -200,9 +188,7 @@ describe('Test function: sendTransaction', function () {
 
   it('should use heading, text and copyable component', async function () {
     executeTxnResp = sendTransactionFailedResp;
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
-      return account1.publicKey;
-    });
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(true);
     const requestObject: SendTransactionRequestParams = {
       contractAddress: account1.address,
       contractFuncName: 'get_signer',
@@ -265,9 +251,7 @@ describe('Test function: sendTransaction', function () {
   });
 
   it('should send a transaction for transferring 10 tokens from an unfound user correctly', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
-      return account1.publicKey;
-    });
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(true);
     const requestObject: SendTransactionRequestParams = {
       contractAddress: '0x07394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10',
       contractFuncName: 'transfer',
@@ -282,9 +266,7 @@ describe('Test function: sendTransaction', function () {
   });
 
   it('should send a transaction for transferring 10 tokens (token of 10 decimal places) from an unfound user correctly', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
-      return account1.publicKey;
-    });
+    sandbox.stub(utils, 'isAccountAddressDeployed').resolves(true);
     const requestObject: SendTransactionRequestParams = {
       contractAddress: '0x06a09ccb1caaecf3d9683efe335a667b2169a409d19c589ba1eb771cd210af75',
       contractFuncName: 'transfer',
@@ -299,7 +281,7 @@ describe('Test function: sendTransaction', function () {
   });
 
   it('should throw error if upsertTransaction failed', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
+    sandbox.stub(utils, 'getOwner').callsFake(async () => {
       return account1.publicKey;
     });
     sandbox.stub(snapUtils, 'upsertTransaction').throws(new Error());
@@ -322,7 +304,7 @@ describe('Test function: sendTransaction', function () {
   });
 
   it('should throw an error if contract address is undefined', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
+    sandbox.stub(utils, 'getOwner').callsFake(async () => {
       return account1.publicKey;
     });
     const requestObject: SendTransactionRequestParams = {
@@ -343,7 +325,7 @@ describe('Test function: sendTransaction', function () {
   });
 
   it('should throw an error if function name is undefined', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
+    sandbox.stub(utils, 'getOwner').callsFake(async () => {
       return account1.publicKey;
     });
     const requestObject: SendTransactionRequestParams = {
@@ -364,7 +346,7 @@ describe('Test function: sendTransaction', function () {
   });
 
   it('should throw an error if sender address is undefined', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
+    sandbox.stub(utils, 'getOwner').callsFake(async () => {
       return account1.publicKey;
     });
     const requestObject: SendTransactionRequestParams = {
@@ -385,7 +367,7 @@ describe('Test function: sendTransaction', function () {
   });
 
   it('should throw an error if contract address is invalid', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
+    sandbox.stub(utils, 'getOwner').callsFake(async () => {
       return account1.publicKey;
     });
     const requestObject: SendTransactionRequestParams = {
@@ -406,7 +388,7 @@ describe('Test function: sendTransaction', function () {
   });
 
   it('should throw an error if sender address is invalid', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
+    sandbox.stub(utils, 'getOwner').callsFake(async () => {
       return account1.publicKey;
     });
     const requestObject: SendTransactionRequestParams = {
@@ -427,7 +409,7 @@ describe('Test function: sendTransaction', function () {
   });
 
   it('should throw an error when call data entries can not be converted to a bigNumber', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
+    sandbox.stub(utils, 'getOwner').callsFake(async () => {
       return account1.publicKey;
     });
     const requestObject: SendTransactionRequestParams = {

--- a/packages/starknet-snap/test/utils/starknetUtils.test.ts
+++ b/packages/starknet-snap/test/utils/starknetUtils.test.ts
@@ -13,7 +13,7 @@ import {
   account2,
 } from '../constants.test';
 import { SnapState } from '../../src/types/snapState';
-import { Calldata } from 'starknet';
+import { Calldata, num } from 'starknet';
 
 chai.use(sinonChai);
 const sandbox = sinon.createSandbox();
@@ -121,5 +121,250 @@ describe('Test function: validateAndParseAddress', function () {
     expect(() => utils.validateAndParseAddress(largeHex)).to.throw(
       'Address 0x3f679957fd2a034d7c32aecb500b62e9d9b4708ebd1383edaa9534fb36b951a665019a has an invalid length',
     );
+  });
+});
+
+describe('Test function: getVersion', function () {
+  let callContractStub: sinon.SinonStub;
+  const expected = '0.3.0';
+
+  beforeEach(function () {
+    callContractStub = sandbox.stub(utils, 'callContract').callsFake(async () => ({ result: [expected] }));
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it('should trigger callContract correct', async function () {
+    const result = await utils.getVersion(account1.address, STARKNET_TESTNET_NETWORK);
+    expect(result).to.be.eq(expected);
+    expect(callContractStub).to.have.been.calledOnceWith(STARKNET_TESTNET_NETWORK, account1.address, 'getVersion');
+  });
+});
+
+describe('Test function: getOwner', function () {
+  let callContractStub: sinon.SinonStub;
+  const expected = 'pk';
+
+  beforeEach(function () {
+    callContractStub = sandbox.stub(utils, 'callContract').callsFake(async () => ({ result: [expected] }));
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it('should trigger callContract correct', async function () {
+    const result = await utils.getOwner(account1.address, STARKNET_TESTNET_NETWORK);
+    expect(result).to.be.eq(expected);
+    expect(callContractStub).to.have.been.calledOnceWith(STARKNET_TESTNET_NETWORK, account1.address, 'get_owner');
+  });
+});
+
+describe('Test function: getBalance', function () {
+  let callContractStub: sinon.SinonStub;
+  const expected = 'pk';
+
+  beforeEach(function () {
+    callContractStub = sandbox.stub(utils, 'callContract').callsFake(async () => ({ result: [expected] }));
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  it('should trigger callContract correct', async function () {
+    const result = await utils.getBalance(account1.address, account1.address, STARKNET_TESTNET_NETWORK);
+    expect(result).to.be.eq(expected);
+    expect(callContractStub).to.have.been.calledOnceWith(STARKNET_TESTNET_NETWORK, account1.address, 'balanceOf', [
+      num.toBigInt(account1.address).toString(10),
+    ]);
+  });
+});
+
+describe('Test function: isUpgradeRequired', function () {
+  const walletStub = new WalletMock();
+  const userAddress = '0x27f204588cadd08a7914f6a9808b34de0cbfc4cb53aa053663e7fd3a34dbc26';
+
+  afterEach(function () {
+    walletStub.reset();
+    sandbox.restore();
+  });
+
+  it('should return true when upgrade is required', async function () {
+    sandbox.stub(utils, 'getVersion').callsFake(async () => '0.2.3');
+    const result = await utils.isUpgradeRequired(STARKNET_TESTNET_NETWORK, userAddress);
+    expect(result).to.be.eq(true);
+  });
+
+  it('should return false when upgrade is not required', async function () {
+    sandbox.stub(utils, 'getVersion').callsFake(async () => '0.3.0');
+    const result = await utils.isUpgradeRequired(STARKNET_TESTNET_NETWORK, userAddress);
+    expect(result).to.be.eq(false);
+  });
+
+  it('should return false when contract is not deployed', async function () {
+    sandbox.stub(utils, 'getVersion').callsFake(async () => {
+      throw new Error('Contract not found');
+    });
+    const result = await utils.isUpgradeRequired(STARKNET_TESTNET_NETWORK, userAddress);
+    expect(result).to.be.eq(false);
+  });
+
+  it('should throw err when getVersion is throwing unknown error', async function () {
+    sandbox.stub(utils, 'getVersion').callsFake(async () => {
+      throw new Error('network error');
+    });
+    let result = null;
+    try {
+      await utils.isUpgradeRequired(STARKNET_TESTNET_NETWORK, userAddress);
+    } catch (e) {
+      result = e;
+    } finally {
+      expect(result).to.be.an('Error');
+      expect(result?.message).to.be.eq('network error');
+    }
+  });
+});
+
+describe('Test function: getCorrectContractAddress', function () {
+  const walletStub = new WalletMock();
+  let getAccContractAddressAndCallDataStub: sinon.SinonStub;
+  let getAccContractAddressAndCallDataCairo0Stub: sinon.SinonStub;
+  let getOwnerStub: sinon.SinonStub;
+  let getSignerStub: sinon.SinonStub;
+  const PK = 'pk';
+
+  beforeEach(function () {
+    getAccContractAddressAndCallDataStub = sandbox
+      .stub(utils, 'getAccContractAddressAndCallData')
+      .callsFake(() => ({ address: account1.address, callData: [] as Calldata }));
+    getAccContractAddressAndCallDataCairo0Stub = sandbox
+      .stub(utils, 'getAccContractAddressAndCallDataCairo0')
+      .callsFake(() => ({ address: account2.address, callData: [] as Calldata }));
+    getOwnerStub = sandbox.stub(utils, 'getOwner').callsFake(async () => PK);
+    getSignerStub = sandbox.stub(utils, 'getSigner').callsFake(async () => PK);
+  });
+  afterEach(function () {
+    walletStub.reset();
+    sandbox.restore();
+  });
+
+  it('should permutation both Cairo0 and Cario1 address', async function () {
+    await utils.getCorrectContractAddress(STARKNET_TESTNET_NETWORK, PK);
+    expect(getAccContractAddressAndCallDataStub).to.have.been.calledOnceWith(
+      STARKNET_TESTNET_NETWORK.accountClassHash,
+      PK,
+    );
+    expect(getAccContractAddressAndCallDataCairo0Stub).to.have.been.calledOnceWith(
+      STARKNET_TESTNET_NETWORK.accountClassHashV0,
+      PK,
+    );
+  });
+
+  it('should return Cairo1 address with pubic key when Cario1 deployed', async function () {
+    const result = await utils.getCorrectContractAddress(STARKNET_TESTNET_NETWORK, PK);
+    expect(getOwnerStub).to.have.been.calledOnceWith(account1.address, STARKNET_TESTNET_NETWORK);
+    expect(getSignerStub).to.have.been.callCount(0);
+    expect(result.address).to.be.eq(account1.address);
+    expect(result.signerPubKey).to.be.eq(PK);
+  });
+
+  it('should return Cairo0 address with pubic key when Cario1 not deployed', async function () {
+    sandbox.restore();
+    getAccContractAddressAndCallDataStub = sandbox
+      .stub(utils, 'getAccContractAddressAndCallData')
+      .callsFake(() => ({ address: account1.address, callData: [] as Calldata }));
+    getAccContractAddressAndCallDataCairo0Stub = sandbox
+      .stub(utils, 'getAccContractAddressAndCallDataCairo0')
+      .callsFake(() => ({ address: account2.address, callData: [] as Calldata }));
+    getSignerStub = sandbox.stub(utils, 'getSigner').callsFake(async () => PK);
+    getOwnerStub = sandbox.stub(utils, 'getOwner').callsFake(async () => {
+      throw new Error('Contract not found');
+    });
+
+    const result = await utils.getCorrectContractAddress(STARKNET_TESTNET_NETWORK, PK);
+    expect(getOwnerStub).to.have.been.calledOnceWith(account1.address, STARKNET_TESTNET_NETWORK);
+    expect(getSignerStub).to.have.been.calledOnceWith(account2.address, STARKNET_TESTNET_NETWORK);
+    expect(result.address).to.be.eq(account2.address);
+    expect(result.signerPubKey).to.be.eq(PK);
+  });
+
+  it('should return Cairo1 address with no pubic key when Cario1 and Cario0 not deployed', async function () {
+    sandbox.restore();
+    getAccContractAddressAndCallDataStub = sandbox
+      .stub(utils, 'getAccContractAddressAndCallData')
+      .callsFake(() => ({ address: account1.address, callData: [] as Calldata }));
+    getAccContractAddressAndCallDataCairo0Stub = sandbox
+      .stub(utils, 'getAccContractAddressAndCallDataCairo0')
+      .callsFake(() => ({ address: account2.address, callData: [] as Calldata }));
+    getSignerStub = sandbox.stub(utils, 'getSigner').callsFake(async () => {
+      throw new Error('Contract not found');
+    });
+    getOwnerStub = sandbox.stub(utils, 'getOwner').callsFake(async () => {
+      throw new Error('Contract not found');
+    });
+
+    const result = await utils.getCorrectContractAddress(STARKNET_TESTNET_NETWORK, PK);
+    expect(getOwnerStub).to.have.been.calledOnceWith(account1.address, STARKNET_TESTNET_NETWORK);
+    expect(getSignerStub).to.have.been.calledOnceWith(account2.address, STARKNET_TESTNET_NETWORK);
+    expect(result.address).to.be.eq(account1.address);
+    expect(result.signerPubKey).to.be.eq('');
+  });
+
+  it('should throw error when getOwner is throwing unknown error', async function () {
+    sandbox.restore();
+    getAccContractAddressAndCallDataStub = sandbox
+      .stub(utils, 'getAccContractAddressAndCallData')
+      .callsFake(() => ({ address: account1.address, callData: [] as Calldata }));
+    getAccContractAddressAndCallDataCairo0Stub = sandbox
+      .stub(utils, 'getAccContractAddressAndCallDataCairo0')
+      .callsFake(() => ({ address: account2.address, callData: [] as Calldata }));
+    getSignerStub = sandbox.stub(utils, 'getSigner').callsFake(async () => {
+      throw new Error('network error for getSigner');
+    });
+    getOwnerStub = sandbox.stub(utils, 'getOwner').callsFake(async () => {
+      throw new Error('network error for getOwner');
+    });
+    let result = null;
+    try {
+      await utils.getCorrectContractAddress(STARKNET_TESTNET_NETWORK, PK);
+    } catch (e) {
+      result = e;
+    } finally {
+      expect(getOwnerStub).to.have.been.calledOnceWith(account1.address, STARKNET_TESTNET_NETWORK);
+      expect(getSignerStub).to.have.been.callCount(0);
+      expect(result).to.be.an('Error');
+      expect(result?.message).to.be.eq('network error for getOwner');
+    }
+  });
+
+  it('should throw error when getSigner is throwing unknown error', async function () {
+    sandbox.restore();
+    getAccContractAddressAndCallDataStub = sandbox
+      .stub(utils, 'getAccContractAddressAndCallData')
+      .callsFake(() => ({ address: account1.address, callData: [] as Calldata }));
+    getAccContractAddressAndCallDataCairo0Stub = sandbox
+      .stub(utils, 'getAccContractAddressAndCallDataCairo0')
+      .callsFake(() => ({ address: account2.address, callData: [] as Calldata }));
+    getSignerStub = sandbox.stub(utils, 'getSigner').callsFake(async () => {
+      throw new Error('network error for getSigner');
+    });
+    getOwnerStub = sandbox.stub(utils, 'getOwner').callsFake(async () => {
+      throw new Error('Contract not found');
+    });
+
+    let result = null;
+    try {
+      await utils.getCorrectContractAddress(STARKNET_TESTNET_NETWORK, PK);
+    } catch (e) {
+      result = e;
+    } finally {
+      expect(getOwnerStub).to.have.been.calledOnceWith(account1.address, STARKNET_TESTNET_NETWORK);
+      expect(getSignerStub).to.have.been.calledOnceWith(account2.address, STARKNET_TESTNET_NETWORK);
+      expect(result).to.be.an('Error');
+      expect(result?.message).to.be.eq('network error for getSigner');
+    }
   });
 });


### PR DESCRIPTION
- update recover account to return correct address 
  - add upgradeRequired into acc object
  - add update determination by using `isUpgradeRequired` method
  - add determination of cario 1 or cario 0
  - throw error if error of callcontract is not `contract not found`

- update create account to use isAccountAddressDeployed method
- update est gas fee to use new accountClassHash
- fix test case