### PR TITLE
fix: add mock to unit test on estimateFee and createAccount

### DIFF
--- a/packages/starknet-snap/test/src/createAccount.test.ts
+++ b/packages/starknet-snap/test/src/createAccount.test.ts
@@ -279,6 +279,7 @@ describe('Test function: createAccount', function () {
     sandbox.stub(utils, 'deployAccount').callsFake(async () => {
       return createAccountFailedProxyResp;
     });
+    sandbox.stub(utils, 'callContract').resolves(getBalanceResp);
     sandbox.stub(utils, 'getSigner').throws(new Error());
     sandbox.stub(utils, 'estimateAccountDeployFee').callsFake(async () => {
       return estimateDeployFeeResp;
@@ -298,6 +299,7 @@ describe('Test function: createAccount', function () {
     sandbox.stub(utils, 'deployAccount').callsFake(async () => {
       return createAccountProxyResp;
     });
+    sandbox.stub(utils, 'callContract').resolves(getBalanceResp);
     sandbox.stub(utils, 'getSigner').throws(new Error());
     sandbox.stub(utils, 'estimateAccountDeployFee').callsFake(async () => {
       return estimateDeployFeeResp;

--- a/packages/starknet-snap/test/src/estimateFee.test.ts
+++ b/packages/starknet-snap/test/src/estimateFee.test.ts
@@ -13,6 +13,7 @@ import {
   estimateFeeResp,
   estimateFeeResp2,
   getBip44EntropyStub,
+  getBalanceResp,
 } from '../constants.test';
 import { Mutex } from 'async-mutex';
 import { ApiParams, EstimateFeeRequestParams } from '../../src/types/snapApi';
@@ -45,6 +46,7 @@ describe('Test function: estimateFee', function () {
   beforeEach(async function () {
     walletStub.rpcStubs.snap_getBip44Entropy.callsFake(getBip44EntropyStub);
     apiParams.keyDeriver = await getAddressKeyDeriver(walletStub);
+    sandbox.stub(utils, 'callContract').resolves(getBalanceResp);
   });
 
   afterEach(function () {
@@ -98,7 +100,7 @@ describe('Test function: estimateFee', function () {
     sandbox.stub(utils, 'getSigner').callsFake(async () => {
       return account2.publicKey;
     });
-    sandbox.stub(utils, 'estimateFeeBulk').throws(new Error());
+    sandbox.stub(utils, 'estimateFee').throws(new Error());
     apiParams.requestParams = requestObject;
 
     let result;


### PR DESCRIPTION
Get Balance mock is missing in estimateFee and createAccount method
hence, the request will be send to internet during the unit test and cause 1.5 second latency
the fix is to mock the get balance to make skip the actual call