### PR TITLE
fix: fix wallet cant connect after disconnect

### DIFF
--- a/packages/wallet-ui/src/slices/walletSlice.ts
+++ b/packages/wallet-ui/src/slices/walletSlice.ts
@@ -87,9 +87,10 @@ export const walletSlice = createSlice({
     clearAccounts: (state) => {
       state.accounts = [];
     },
-    resetWallet: () => {
+    resetWallet: (state) => {
       return {
         ...initialState,
+        provider: state.provider,
         forceReconnect: true,
       };
     },


### PR DESCRIPTION
**Description**:
The snap not able to reconnect to the wallet ui after disconnected 
Issue: https://consensyssoftware.atlassian.net/browse/SF-573

**Resolution**:
the root cause is the "ethereum" provider reset after disconnected, and there is no operation to re-init the provider, hence the screen freeze when try to use the provider to request snap connect

to address the problem, not to reset the provider even disconnect, as the provider is not part of the snap wallet, it is the permanent connection with metamask 

**Limitation**:
a user disconnect the app and remove/disable the metamask, and try to click the re-connect button will not take effect 


