### PR TITLE
feat: sf 549 update all method to support upgraded address

### DIFF
--- a/packages/starknet-snap/src/estimateFees.ts
+++ b/packages/starknet-snap/src/estimateFees.ts
@@ -20,7 +20,7 @@ export async function estimateFees(params: ApiParams) {
       senderAddress,
       senderPrivateKey,
       requestParamsObj.invocations,
-      requestParamsObj.invocationDetails ? requestParamsObj.invocationDetails : undefined,
+      requestParamsObj.invocationDetails,
     );
 
     return fees.map((fee) => ({

--- a/packages/starknet-snap/src/recoverAccounts.ts
+++ b/packages/starknet-snap/src/recoverAccounts.ts
@@ -1,6 +1,6 @@
 import { toJson } from './utils/serializer';
 import { num } from 'starknet';
-import { getKeysFromAddressIndex, getCorrectContractAddress, isUpgradeRequired } from './utils/starknetUtils';
+import { getKeysFromAddressIndex, getCorrectContractAddress } from './utils/starknetUtils';
 import { getNetworkFromChainId, getValidNumber, upsertAccount } from './utils/snapUtils';
 import { AccContract } from './types/snapState';
 import { ApiParams, RecoverAccountsRequestParams } from './types/snapApi';
@@ -29,17 +29,15 @@ export async function recoverAccounts(params: ApiParams) {
         state,
         i,
       );
-      const { address: contractAddress, signerPubKey: signerPublicKey } = await getCorrectContractAddress(
+      const { address: contractAddress, signerPubKey: signerPublicKey, upgradeRequired } = await getCorrectContractAddress(
         network,
         publicKey,
       );
-      logger.log(`recoverAccounts: index ${i}:\ncontractAddress = ${contractAddress}\npublicKey = ${publicKey}`);
+      logger.log(`recoverAccounts: index ${i}:\ncontractAddress = ${contractAddress}\npublicKey = ${publicKey}\nisUpgradeRequired = ${upgradeRequired}`);
 
-      let _isUpgradeRequired = false;
       if (signerPublicKey) {
-        _isUpgradeRequired = await isUpgradeRequired(network, contractAddress);
         logger.log(
-          `recoverAccounts: index ${i}:\ncontractAddress = ${contractAddress}\nisUpgradeRequired = ${_isUpgradeRequired}`,
+          `recoverAccounts: index ${i}:\ncontractAddress = ${contractAddress}\n`,
         );
         if (num.toBigInt(signerPublicKey) === num.toBigInt(publicKey)) {
           logger.log(`recoverAccounts: index ${i} matched\npublicKey: ${publicKey}`);
@@ -57,7 +55,7 @@ export async function recoverAccounts(params: ApiParams) {
         derivationPath,
         deployTxnHash: '',
         chainId: network.chainId,
-        upgradeRequired: _isUpgradeRequired,
+        upgradeRequired: upgradeRequired,
       };
 
       logger.log(`recoverAccounts: index ${i}\nuserAccount: ${toJson(userAccount)}`);

--- a/packages/starknet-snap/src/utils/constants.ts
+++ b/packages/starknet-snap/src/utils/constants.ts
@@ -137,3 +137,7 @@ export const PRELOADED_NETWORKS = [STARKNET_MAINNET_NETWORK, STARKNET_TESTNET_NE
 export const PROXY_CONTRACT_HASH = '0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918'; // for cairo 0 proxy contract
 
 export const MIN_ACC_CONTRACT_VERSION = [0, 3, 0];
+
+export const CAIRO_VERSION = '1';
+
+export const CAIRO_VERSION_LEGACY = '0';

--- a/packages/starknet-snap/src/utils/starknetUtils.ts
+++ b/packages/starknet-snap/src/utils/starknetUtils.ts
@@ -32,6 +32,7 @@ import {
   Abi,
   DeclareSignerDetails,
   DeployAccountSignerDetails,
+  CairoVersion,
 } from 'starknet';
 import type { Hex } from '@noble/curves/abstract/utils';
 import { Network, SnapState, Transaction, TransactionType } from '../types/snapState';
@@ -41,6 +42,8 @@ import {
   MIN_ACC_CONTRACT_VERSION,
   ACCOUNT_CLASS_HASH_V0,
   ACCOUNT_CLASS_HASH_V1,
+  CAIRO_VERSION,
+  CAIRO_VERSION_LEGACY,
 } from './constants';
 import { getAddressKey } from './keyPair';
 import { getAccount, getAccounts, getTransactionFromVoyagerUrl, getTransactionsFromVoyagerUrl } from './snapUtils';
@@ -110,7 +113,7 @@ export const estimateFee = async (
   txnInvocation: Call | Call[],
 ): Promise<EstimateFee> => {
   const provider = getProvider(network);
-  const account = new Account(provider, senderAddress, privateKey, '1');
+  const account = new Account(provider, senderAddress, privateKey, CAIRO_VERSION);
   return account.estimateInvokeFee(txnInvocation, { blockIdentifier: 'latest' });
 };
 
@@ -124,7 +127,7 @@ export const estimateFeeBulk = async (
   // ensure always calling the sequencer endpoint since the rpc endpoint and
   // starknet.js are not supported yet.
   const provider = getProvider(network);
-  const account = new Account(provider, senderAddress, privateKey, '1');
+  const account = new Account(provider, senderAddress, privateKey, CAIRO_VERSION);
   return account.estimateFeeBulk(txnInvocation, invocationsDetails);
 };
 
@@ -137,7 +140,7 @@ export const executeTxn = async (
   invocationsDetails?: InvocationsDetails,
 ): Promise<InvokeFunctionResponse> => {
   const provider = getProvider(network);
-  const account = new Account(provider, senderAddress, privateKey, '1');
+  const account = new Account(provider, senderAddress, privateKey, CAIRO_VERSION);
   return account.execute(txnInvocation, abis, invocationsDetails);
 };
 
@@ -150,7 +153,7 @@ export const deployAccount = async (
   maxFee: num.BigNumberish,
 ): Promise<DeployContractResponse> => {
   const provider = getProvider(network);
-  const account = new Account(provider, contractAddress, privateKey, '1');
+  const account = new Account(provider, contractAddress, privateKey, CAIRO_VERSION);
   const deployAccountPayload = {
     classHash: ACCOUNT_CLASS_HASH_V1,
     contractAddress: contractAddress,
@@ -168,7 +171,7 @@ export const estimateAccountDeployFee = async (
   privateKey: string | Uint8Array,
 ): Promise<EstimateFee> => {
   const provider = getProvider(network);
-  const account = new Account(provider, contractAddress, privateKey, '1');
+  const account = new Account(provider, contractAddress, privateKey, CAIRO_VERSION);
   const deployAccountPayload = {
     classHash: ACCOUNT_CLASS_HASH_V1,
     contractAddress: contractAddress,
@@ -191,6 +194,10 @@ export const getVersion = async (userAccAddress: string, network: Network): Prom
 export const getOwner = async (userAccAddress: string, network: Network): Promise<string> => {
   const resp = await callContract(network, userAccAddress, 'get_owner');
   return resp.result[0];
+};
+
+export const getContractOwner = async (userAccAddress: string, network: Network, version: CairoVersion): Promise<string> => {
+  return version === '0' ? getSigner(userAccAddress, network) : getOwner(userAccAddress, network);
 };
 
 export const getBalance = async (address: string, tokenAddress: string, network: Network) => {
@@ -423,7 +430,7 @@ export const getNextAddressIndex = (chainId: string, state: SnapState, derivatio
 };
 
 /**
- * calculate contract address by publicKey, supported for carioVersions [1]
+ * calculate contract address by publicKey
  *
  * @param  publicKey - address's publicKey.
  * @returns - address and calldata.
@@ -446,12 +453,12 @@ export const getAccContractAddressAndCallData = (publicKey) => {
 };
 
 /**
- * calculate contract address by publicKey, supported for carioVersions [0]
+ * calculate contract address by publicKey
  *
  * @param  publicKey - address's publicKey.
  * @returns - address and calldata.
  */
-export const getAccContractAddressAndCallDataCairo0 = (publicKey) => {
+export const getAccContractAddressAndCallDataLegacy = (publicKey) => {
   const callData = CallData.compile({
     implementation: ACCOUNT_CLASS_HASH_V0,
     selector: hash.getSelectorFromName('initialize'),
@@ -510,7 +517,7 @@ export const getKeysFromAddressIndex = async (
 };
 
 /**
- * Check address is deployed by using getVersion, supported for carioVersions [0,1]
+ * Check address is deployed by using getVersion
  *
  * @param  network - Network.
  * @param  address - Input address.
@@ -552,7 +559,7 @@ export const validateAndParseAddress = (address: num.BigNumberish, length = 63) 
 };
 
 /**
- * Find address index from the keyDeriver, supported for carioVersions [0,1]
+ * Find address index from the keyDeriver
  *
  * @param  chainId - Network ChainId.
  * @param  address - Input address.
@@ -572,8 +579,8 @@ export const findAddressIndex = async (
   for (let i = 0; i < maxScan; i++) {
     const { publicKey } = await getKeysFromAddressIndex(keyDeriver, chainId, state, i);
     const { address: calculatedAddress } = getAccContractAddressAndCallData(publicKey);
-    const { address: calculatedAddressCairo0 } = getAccContractAddressAndCallDataCairo0(publicKey);
-    if (num.toBigInt(calculatedAddress) === bigIntAddress || num.toBigInt(calculatedAddressCairo0) === bigIntAddress) {
+    const { address: calculatedAddressLegacy } = getAccContractAddressAndCallDataLegacy(publicKey);
+    if (num.toBigInt(calculatedAddress) === bigIntAddress || num.toBigInt(calculatedAddressLegacy) === bigIntAddress) {
       logger.log(`findAddressIndex:\nFound address in scan: ${i} ${address}`);
       return {
         index: i,
@@ -585,7 +592,7 @@ export const findAddressIndex = async (
 };
 
 /**
- * Check address needed upgrade by using getVersion and compare with MIN_ACC_CONTRACT_VERSION, supported for carioVersions [0,1]
+ * Check address needed upgrade by using getVersion and compare with MIN_ACC_CONTRACT_VERSION
  *
  * @param  network - Network.
  * @param  address - Input address.
@@ -595,22 +602,30 @@ export const isUpgradeRequired = async (network: Network, address: string) => {
   try {
     logger.log(`isUpgradeRequired: address = ${address}`);
     const hexResp = await getVersion(address, network);
-    const version = hexToString(hexResp);
-    logger.log(`isUpgradeRequired: hexResp = ${hexResp}, version = ${version}`);
-    const versionArr = version.split('.');
-    return Number(versionArr[1]) < MIN_ACC_CONTRACT_VERSION[1];
+    return isGTEMinVersion(hexToString(hexResp)) ? false : true;
   } catch (err) {
     if (!err.message.includes('Contract not found')) {
       throw err;
     }
-    logger.error(`isUpgradeRequired: error:`, err);
-    //[TODO] if address is cario0 but not deployed we should throw error
+    //[TODO] if address is cairo0 but not deployed we should throw error
     return false;
   }
 };
 
 /**
- * Get user address by public key, return address if the address has deployed, prioritize cario 1 over cario 0, supported for carioVersions [0,1]
+ * Compare version number with MIN_ACC_CONTRACT_VERSION
+ *
+ * @param  version - version, e.g (2.3.0).
+ * @returns - boolean.
+ */
+export const isGTEMinVersion = (version: string) => {
+  logger.log(`isGTEMinVersion: version = ${version}`);
+  const versionArr = version.split('.');
+  return Number(versionArr[1]) >= MIN_ACC_CONTRACT_VERSION[1];
+};
+
+/**
+ * Get user address by public key, return address if the address has deployed, prioritize cairo 1 over cairo 0, supported for cairoVersions [0,1]
  *
  * @param  network - Network.
  * @param  publicKey - address's public key.
@@ -618,57 +633,44 @@ export const isUpgradeRequired = async (network: Network, address: string) => {
  */
 export const getCorrectContractAddress = async (network: Network, publicKey: string) => {
   const { address: contractAddress } = getAccContractAddressAndCallData(publicKey);
-  const { address: contractAddressCairo0 } = getAccContractAddressAndCallDataCairo0(publicKey);
-  let pk = '';
+  const { address: contractAddressLegacy } = getAccContractAddressAndCallDataLegacy(publicKey);
+  
   logger.log(
-    `getContractAddressByKey: contractAddressCario1 = ${contractAddress}\ncontractAddressCairo0 = ${contractAddressCairo0}\npublicKey = ${publicKey}`,
+    `getContractAddressByKey: contractAddressCairo1 = ${contractAddress}\ncontractAddressLegacy = ${contractAddressLegacy}\npublicKey = ${publicKey}`,
   );
 
-  //test if it is a cairo 1 account
+  let address = contractAddress;
+  let upgradeRequired = false;
+  let pk = '';
+
   try {
-    pk = await getOwner(contractAddress, network);
-    logger.log(`getContractAddressByKey: cairo 1 contract found`);
-  } catch (err) {
-    if (!err.message.includes('Contract not found')) {
-      throw err;
+    await getVersion(contractAddress, network);
+    pk = await getContractOwner(address, network, CAIRO_VERSION);
+  } catch (e) {
+    if (!e.message.includes('Contract not found')) {
+      throw e;
     }
-    logger.log(`getContractAddressByKey: cairo 1 contract not found`);
+  
+    logger.log(`getContractAddressByKey: cairo ${CAIRO_VERSION} contract cant found, try cairo ${CAIRO_VERSION_LEGACY}`);
 
-    //test if it is a upgraded cairo 0 account
     try {
-      pk = await getOwner(contractAddressCairo0, network);
-      logger.log(`getContractAddressByKey: upgraded cairo 0 contract found`);
-      return {
-        address: contractAddressCairo0,
-        signerPubKey: pk,
-      };
-    } catch (err) {
-      if (!err.message.includes('Contract not found')) {
-        throw err;
+      const version = await getVersion(contractAddressLegacy, network);
+      upgradeRequired = isGTEMinVersion(hexToString(version)) ? false : true;
+      pk = await getContractOwner(contractAddressLegacy, network, upgradeRequired ? CAIRO_VERSION_LEGACY : CAIRO_VERSION);
+      address = contractAddressLegacy
+    } catch (e) {
+      if (!e.message.includes('Contract not found')) {
+        throw e;
       }
-      logger.log(`getContractAddressByKey: upgraded cairo 0 contract not found`);
-    }
 
-    //test if it is a deployed cairo 0 account
-    try {
-      pk = await getSigner(contractAddressCairo0, network);
-      logger.log(`getContractAddressByKey: cairo 0 contract found`);
-      return {
-        address: contractAddressCairo0,
-        signerPubKey: pk,
-      };
-    } catch (err) {
-      if (!err.message.includes('Contract not found')) {
-        throw err;
-      }
-      logger.log(`getContractAddressByKey: cairo 0 contract not found`);
+      logger.log(`getContractAddressByKey: no deployed contract found, fallback to cairo ${CAIRO_VERSION}`);
     }
   }
 
-  //return new/deployed cairo 1 account
   return {
-    address: contractAddress,
+    address,
     signerPubKey: pk,
+    upgradeRequired: upgradeRequired,
   };
 };
 

--- a/packages/starknet-snap/test/constants.test.ts
+++ b/packages/starknet-snap/test/constants.test.ts
@@ -60,7 +60,7 @@ export const account4: AccContract = {
   chainId: constants.StarknetChainId.SN_GOERLI,
 };
 
-export const Cario1Account1: AccContract = {
+export const Cairo1Account1: AccContract = {
   address: '0x043e3d703b005b8367a9783fb680713349c519202aa01e9beb170bdf710ae20b',
   addressSalt: '0x019e59f349e1aa813ab4556c5836d0472e5e1ae82d1e5c3b3e8aabfeb290befd',
   addressIndex: 1,
@@ -99,7 +99,7 @@ export const signature1 =
 export const signature2 =
   '30440220052956ac852275b6004c4e8042450f6dce83059f068029b037cc47338c80d062022002bc0e712f03e341bb3532fc356b779d84fcb4dbfe8ed34de2db66e121971d92';
 
-export const signature4Cario1SignMessage = [
+export const signature4Cairo1SignMessage = [
   '2941323345698930086258187297320132789256148405011604592758945785805412997864',
   '1024747634926675542679366527128384456926978174336360356924884281219915547518',
 ];

--- a/packages/starknet-snap/test/src/estimateFee.test.ts
+++ b/packages/starknet-snap/test/src/estimateFee.test.ts
@@ -9,7 +9,7 @@ import { ACCOUNT_CLASS_HASH_V1, STARKNET_TESTNET_NETWORK } from '../../src/utils
 import { getAddressKeyDeriver } from '../../src/utils/keyPair';
 import {
   account2,
-  Cario1Account1,
+  Cairo1Account1,
   estimateDeployFeeResp4,
   estimateFeeResp,
   getBip44EntropyStub,
@@ -138,11 +138,11 @@ describe('Test function: estimateFee', function () {
         sandbox.stub(utils, 'isUpgradeRequired').resolves(false);
       });
 
-      describe('when account is cario1 address', function () {
+      describe('when account is cairo1 address', function () {
         beforeEach(async function () {
           apiParams.requestParams = {
             ...apiParams.requestParams,
-            senderAddress: Cario1Account1.address,
+            senderAddress: Cairo1Account1.address,
           };
         });
 
@@ -178,7 +178,7 @@ describe('Test function: estimateFee', function () {
               apiParams.keyDeriver,
               STARKNET_TESTNET_NETWORK,
               state,
-              Cario1Account1.address,
+              Cairo1Account1.address,
             );
             const { callData } = utils.getAccContractAddressAndCallData(publicKey);
             const apiRequest = apiParams.requestParams as EstimateFeeRequestParams;
@@ -188,7 +188,7 @@ describe('Test function: estimateFee', function () {
                 type: TransactionType.DEPLOY_ACCOUNT,
                 payload: {
                   classHash: ACCOUNT_CLASS_HASH_V1,
-                  contractAddress: Cario1Account1.address,
+                  contractAddress: Cairo1Account1.address,
                   constructorCalldata: callData,
                   addressSalt: publicKey,
                 },
@@ -208,7 +208,7 @@ describe('Test function: estimateFee', function () {
             expect(estimateFeeBulkStub).callCount(1);
             expect(estimateFeeBulkStub).to.be.calledWith(
               STARKNET_TESTNET_NETWORK,
-              Cario1Account1.address,
+              Cairo1Account1.address,
               privateKey,
               expectedBulkTransaction,
             );
@@ -232,7 +232,7 @@ describe('Test function: estimateFee', function () {
         });
       });
 
-      describe('when account is cario0 address', function () {
+      describe('when account is cairo0 address', function () {
         describe('when account is deployed', function () {
           beforeEach(async function () {
             estimateFeeBulkStub = sandbox.stub(utils, 'estimateFeeBulk');
@@ -264,7 +264,7 @@ describe('Test function: estimateFee', function () {
           });
         });
         describe('when account is not deployed', function () {
-          //not support cario0 address if not deployed
+          //not support cairo0 address if not deployed
         });
       });
     });

--- a/packages/starknet-snap/test/src/estimateFee.test.ts
+++ b/packages/starknet-snap/test/src/estimateFee.test.ts
@@ -136,135 +136,94 @@ describe('Test function: estimateFee', function () {
 
       beforeEach(async function () {
         sandbox.stub(utils, 'isUpgradeRequired').resolves(false);
+        apiParams.requestParams = {
+          ...apiParams.requestParams,
+          senderAddress: Cairo1Account1.address,
+        };
       });
 
-      describe('when account is cairo1 address', function () {
+      describe('when account is deployed', function () {
         beforeEach(async function () {
-          apiParams.requestParams = {
-            ...apiParams.requestParams,
-            senderAddress: Cairo1Account1.address,
-          };
+          estimateFeeBulkStub = sandbox.stub(utils, 'estimateFeeBulk');
+          sandbox.stub(utils, 'isAccountDeployed').resolves(true);
         });
 
-        describe('when account is deployed', function () {
-          beforeEach(async function () {
-            estimateFeeBulkStub = sandbox.stub(utils, 'estimateFeeBulk');
-            sandbox.stub(utils, 'isAccountDeployed').resolves(true);
-          });
+        it('should estimate the fee correctly', async function () {
+          estimateFeeStub = sandbox.stub(utils, 'estimateFee').resolves(estimateFeeResp);
+          const result = await estimateFee(apiParams);
+          expect(result.suggestedMaxFee).to.be.eq(estimateFeeResp.suggestedMaxFee.toString(10));
+          expect(estimateFeeStub).callCount(1);
+          expect(estimateFeeBulkStub).callCount(0);
+        });
+      });
 
-          it('should estimate the fee correctly', async function () {
-            estimateFeeStub = sandbox.stub(utils, 'estimateFee').resolves(estimateFeeResp);
-            const result = await estimateFee(apiParams);
-            expect(result.suggestedMaxFee).to.be.eq(estimateFeeResp.suggestedMaxFee.toString(10));
-            expect(estimateFeeStub).callCount(1);
-            expect(estimateFeeBulkStub).callCount(0);
-          });
+      describe('when account is not deployed', function () {
+        beforeEach(async function () {
+          estimateFeeStub = sandbox.stub(utils, 'estimateFee');
+          sandbox.stub(utils, 'isAccountDeployed').resolves(false);
         });
 
-        describe('when account is not deployed', function () {
-          beforeEach(async function () {
-            estimateFeeStub = sandbox.stub(utils, 'estimateFee');
-            sandbox.stub(utils, 'isAccountDeployed').resolves(false);
-          });
+        it('should estimate the fee including deploy txn correctly', async function () {
+          estimateFeeBulkStub = sandbox
+            .stub(utils, 'estimateFeeBulk')
+            .resolves([estimateFeeResp, estimateDeployFeeResp4]);
+          const expectedSuggestedMaxFee = estimateDeployFeeResp4.suggestedMaxFee + estimateFeeResp.suggestedMaxFee;
+          const result = await estimateFee(apiParams);
 
-          it('should estimate the fee including deploy txn correctly', async function () {
-            estimateFeeBulkStub = sandbox
-              .stub(utils, 'estimateFeeBulk')
-              .resolves([estimateFeeResp, estimateDeployFeeResp4]);
-            const expectedSuggestedMaxFee = estimateDeployFeeResp4.suggestedMaxFee + estimateFeeResp.suggestedMaxFee;
-            const result = await estimateFee(apiParams);
+          const { privateKey, publicKey } = await utils.getKeysFromAddress(
+            apiParams.keyDeriver,
+            STARKNET_TESTNET_NETWORK,
+            state,
+            Cairo1Account1.address,
+          );
+          const { callData } = utils.getAccContractAddressAndCallData(publicKey);
+          const apiRequest = apiParams.requestParams as EstimateFeeRequestParams;
 
-            const { privateKey, publicKey } = await utils.getKeysFromAddress(
-              apiParams.keyDeriver,
-              STARKNET_TESTNET_NETWORK,
-              state,
-              Cairo1Account1.address,
-            );
-            const { callData } = utils.getAccContractAddressAndCallData(publicKey);
-            const apiRequest = apiParams.requestParams as EstimateFeeRequestParams;
-
-            const expectedBulkTransaction = [
-              {
-                type: TransactionType.DEPLOY_ACCOUNT,
-                payload: {
-                  classHash: ACCOUNT_CLASS_HASH_V1,
-                  contractAddress: Cairo1Account1.address,
-                  constructorCalldata: callData,
-                  addressSalt: publicKey,
-                },
+          const expectedBulkTransaction = [
+            {
+              type: TransactionType.DEPLOY_ACCOUNT,
+              payload: {
+                classHash: ACCOUNT_CLASS_HASH_V1,
+                contractAddress: Cairo1Account1.address,
+                constructorCalldata: callData,
+                addressSalt: publicKey,
               },
-              {
-                type: TransactionType.INVOKE,
-                payload: {
-                  contractAddress: apiRequest.contractAddress,
-                  entrypoint: apiRequest.contractFuncName,
-                  calldata: utils.getCallDataArray(apiRequest.contractCallData),
-                },
+            },
+            {
+              type: TransactionType.INVOKE,
+              payload: {
+                contractAddress: apiRequest.contractAddress,
+                entrypoint: apiRequest.contractFuncName,
+                calldata: utils.getCallDataArray(apiRequest.contractCallData),
               },
-            ];
+            },
+          ];
 
-            expect(result.suggestedMaxFee).to.be.eq(expectedSuggestedMaxFee.toString(10));
+          expect(result.suggestedMaxFee).to.be.eq(expectedSuggestedMaxFee.toString(10));
+          expect(estimateFeeStub).callCount(0);
+          expect(estimateFeeBulkStub).callCount(1);
+          expect(estimateFeeBulkStub).to.be.calledWith(
+            STARKNET_TESTNET_NETWORK,
+            Cairo1Account1.address,
+            privateKey,
+            expectedBulkTransaction,
+          );
+        });
+
+        it('should throw error if estimateFee failed', async function () {
+          estimateFeeBulkStub = sandbox.stub(utils, 'estimateFeeBulk').throws('Error');
+          apiParams.requestParams = requestObject;
+
+          let result;
+          try {
+            await estimateFee(apiParams);
+          } catch (err) {
+            result = err;
+          } finally {
+            expect(result).to.be.an('Error');
             expect(estimateFeeStub).callCount(0);
             expect(estimateFeeBulkStub).callCount(1);
-            expect(estimateFeeBulkStub).to.be.calledWith(
-              STARKNET_TESTNET_NETWORK,
-              Cairo1Account1.address,
-              privateKey,
-              expectedBulkTransaction,
-            );
-          });
-
-          it('should throw error if estimateFee failed', async function () {
-            estimateFeeBulkStub = sandbox.stub(utils, 'estimateFeeBulk').throws('Error');
-            apiParams.requestParams = requestObject;
-
-            let result;
-            try {
-              await estimateFee(apiParams);
-            } catch (err) {
-              result = err;
-            } finally {
-              expect(result).to.be.an('Error');
-              expect(estimateFeeStub).callCount(0);
-              expect(estimateFeeBulkStub).callCount(1);
-            }
-          });
-        });
-      });
-
-      describe('when account is cairo0 address', function () {
-        describe('when account is deployed', function () {
-          beforeEach(async function () {
-            estimateFeeBulkStub = sandbox.stub(utils, 'estimateFeeBulk');
-            sandbox.stub(utils, 'isAccountDeployed').resolves(true);
-          });
-
-          it('should estimate the fee correctly', async function () {
-            estimateFeeStub = sandbox.stub(utils, 'estimateFee').resolves(estimateFeeResp);
-            const result = await estimateFee(apiParams);
-            expect(result.suggestedMaxFee).to.be.eq(estimateFeeResp.suggestedMaxFee.toString(10));
-            expect(estimateFeeStub).callCount(1);
-            expect(estimateFeeBulkStub).callCount(0);
-          });
-
-          it('should throw error if estimateFee failed', async function () {
-            estimateFeeStub = sandbox.stub(utils, 'estimateFee').throws('Error');
-            apiParams.requestParams = requestObject;
-
-            let result;
-            try {
-              await estimateFee(apiParams);
-            } catch (err) {
-              result = err;
-            } finally {
-              expect(result).to.be.an('Error');
-              expect(estimateFeeStub).callCount(1);
-              expect(estimateFeeBulkStub).callCount(0);
-            }
-          });
-        });
-        describe('when account is not deployed', function () {
-          //not support cairo0 address if not deployed
+          }
         });
       });
     });

--- a/packages/starknet-snap/test/src/estimateFees.test.ts
+++ b/packages/starknet-snap/test/src/estimateFees.test.ts
@@ -40,11 +40,9 @@ describe('Test function: estimateFees', function () {
     sandbox.restore();
   });
 
-  it('should estimate the fee including deploy txn correctly', async function () {
+  it('should estimate fees correctly', async function () {
     const feeResult = [estimateDeployFeeResp2, estimateDeployFeeResp3];
-    sandbox.stub(utils, 'estimateFeeBulk').callsFake(async () => {
-      return feeResult;
-    });
+    sandbox.stub(utils, 'estimateFeeBulk').resolves(feeResult);
     apiParams.requestParams = {
       senderAddress: account2.address,
       chainId: STARKNET_TESTNET_NETWORK.chainId,
@@ -58,6 +56,9 @@ describe('Test function: estimateFees', function () {
           },
         },
       ],
+      invocationsDetails: {
+        nonce: '1'
+      }
     };
     const expectedResult = feeResult.map((fee) => ({
       overall_fee: fee.overall_fee.toString(10) || '0',
@@ -65,14 +66,13 @@ describe('Test function: estimateFees', function () {
       gas_price: fee.gas_price.toString(10) || '0',
       suggestedMaxFee: fee.suggestedMaxFee.toString(10) || '0',
     }));
+
     const result = await estimateFees(apiParams);
+
     expect(result).to.eql(expectedResult);
   });
 
   it('should throw error if estimateFee failed', async function () {
-    sandbox.stub(utils, 'getSigner').callsFake(async () => {
-      return account2.publicKey;
-    });
     sandbox.stub(utils, 'estimateFeeBulk').throws(new Error());
     apiParams.requestParams = {
       senderAddress: account2.address,

--- a/packages/starknet-snap/test/src/extractPrivateKey.test.ts
+++ b/packages/starknet-snap/test/src/extractPrivateKey.test.ts
@@ -126,64 +126,58 @@ describe('Test function: extractPrivateKey', function () {
         sandbox.stub(utils, 'isUpgradeRequired').resolves(false);
       });
 
-      describe('when account is cairo 0', function () {
-        //TODO
+      it('should get the private key of the specified user account correctly', async function () {
+        walletStub.rpcStubs.snap_dialog.resolves(true);
+        const requestObject: ExtractPrivateKeyRequestParams = {
+          userAddress: account1.address,
+        };
+        apiParams.requestParams = requestObject;
+        const result = await extractPrivateKey(apiParams);
+        expect(walletStub.rpcStubs.snap_dialog).to.have.been.calledTwice;
+        expect(walletStub.rpcStubs.snap_manageState).not.to.have.been.called;
+        expect(result).to.be.equal(null);
       });
 
-      describe('when account is cairo 1', function () {
-        it('should get the private key of the specified user account correctly', async function () {
-          walletStub.rpcStubs.snap_dialog.resolves(true);
-          const requestObject: ExtractPrivateKeyRequestParams = {
-            userAddress: account1.address,
-          };
-          apiParams.requestParams = requestObject;
-          const result = await extractPrivateKey(apiParams);
-          expect(walletStub.rpcStubs.snap_dialog).to.have.been.calledTwice;
-          expect(walletStub.rpcStubs.snap_manageState).not.to.have.been.called;
-          expect(result).to.be.equal(null);
-        });
+      it('should get the private key of the unfound user account correctly', async function () {
+        walletStub.rpcStubs.snap_dialog.resolves(true);
+        const requestObject: ExtractPrivateKeyRequestParams = {
+          userAddress: unfoundUserAddress,
+        };
+        apiParams.requestParams = requestObject;
+        const result = await extractPrivateKey(apiParams);
+        expect(walletStub.rpcStubs.snap_dialog).to.have.been.calledTwice;
+        expect(walletStub.rpcStubs.snap_manageState).not.to.have.been.called;
+        expect(result).to.be.eql(null);
+      });
 
-        it('should get the private key of the unfound user account correctly', async function () {
-          walletStub.rpcStubs.snap_dialog.resolves(true);
-          const requestObject: ExtractPrivateKeyRequestParams = {
-            userAddress: unfoundUserAddress,
-          };
-          apiParams.requestParams = requestObject;
-          const result = await extractPrivateKey(apiParams);
-          expect(walletStub.rpcStubs.snap_dialog).to.have.been.calledTwice;
-          expect(walletStub.rpcStubs.snap_manageState).not.to.have.been.called;
-          expect(result).to.be.eql(null);
-        });
+      it('should not get the private key of the specified user account if user rejected', async function () {
+        walletStub.rpcStubs.snap_dialog.resolves(false);
+        const requestObject: ExtractPrivateKeyRequestParams = {
+          userAddress: account1.address,
+        };
+        apiParams.requestParams = requestObject;
+        const result = await extractPrivateKey(apiParams);
+        expect(walletStub.rpcStubs.snap_dialog).to.have.been.calledOnce;
+        expect(walletStub.rpcStubs.snap_manageState).not.to.have.been.called;
+        expect(result).to.be.equal(null);
+      });
 
-        it('should not get the private key of the specified user account if user rejected', async function () {
-          walletStub.rpcStubs.snap_dialog.resolves(false);
-          const requestObject: ExtractPrivateKeyRequestParams = {
-            userAddress: account1.address,
-          };
-          apiParams.requestParams = requestObject;
-          const result = await extractPrivateKey(apiParams);
-          expect(walletStub.rpcStubs.snap_dialog).to.have.been.calledOnce;
-          expect(walletStub.rpcStubs.snap_manageState).not.to.have.been.called;
-          expect(result).to.be.equal(null);
-        });
+      it('should throw error if getKeysFromAddress failed', async function () {
+        sandbox.stub(utils, 'getKeysFromAddress').throws(new Error());
+        walletStub.rpcStubs.snap_dialog.resolves(true);
+        const requestObject: ExtractPrivateKeyRequestParams = {
+          userAddress: account1.address,
+        };
+        apiParams.requestParams = requestObject;
 
-        it('should throw error if getKeysFromAddress failed', async function () {
-          sandbox.stub(utils, 'getKeysFromAddress').throws(new Error());
-          walletStub.rpcStubs.snap_dialog.resolves(true);
-          const requestObject: ExtractPrivateKeyRequestParams = {
-            userAddress: account1.address,
-          };
-          apiParams.requestParams = requestObject;
-
-          let result;
-          try {
-            await extractPrivateKey(apiParams);
-          } catch (err) {
-            result = err;
-          } finally {
-            expect(result).to.be.an('Error');
-          }
-        });
+        let result;
+        try {
+          await extractPrivateKey(apiParams);
+        } catch (err) {
+          result = err;
+        } finally {
+          expect(result).to.be.an('Error');
+        }
       });
     });
   });

--- a/packages/starknet-snap/test/src/extractPublicKey.test.ts
+++ b/packages/starknet-snap/test/src/extractPublicKey.test.ts
@@ -125,47 +125,41 @@ describe('Test function: extractPublicKey', function () {
         sandbox.stub(utils, 'isUpgradeRequired').resolves(false);
       });
 
-      describe('when account is cairo 0', function () {
-        //TODO
+      it('should get the public key of the specified user account correctly', async function () {
+        const requestObject: ExtractPublicKeyRequestParams = {
+          userAddress: account1.address,
+        };
+        apiParams.requestParams = requestObject;
+        const result = await extractPublicKey(apiParams);
+        expect(walletStub.rpcStubs.snap_manageState).not.to.have.been.called;
+        expect(result).to.be.eql(account1.publicKey);
       });
 
-      describe('when account is cairo 1', function () {
-        it('should get the public key of the specified user account correctly', async function () {
-          const requestObject: ExtractPublicKeyRequestParams = {
-            userAddress: account1.address,
-          };
-          apiParams.requestParams = requestObject;
-          const result = await extractPublicKey(apiParams);
-          expect(walletStub.rpcStubs.snap_manageState).not.to.have.been.called;
-          expect(result).to.be.eql(account1.publicKey);
-        });
+      it('should get the public key of the unfound user account correctly', async function () {
+        const requestObject: ExtractPublicKeyRequestParams = {
+          userAddress: unfoundUserAddress,
+        };
+        apiParams.requestParams = requestObject;
+        const result = await extractPublicKey(apiParams);
+        expect(walletStub.rpcStubs.snap_manageState).not.to.have.been.called;
+        expect(result).to.be.eql(unfoundUserPublicKey);
+      });
 
-        it('should get the public key of the unfound user account correctly', async function () {
-          const requestObject: ExtractPublicKeyRequestParams = {
-            userAddress: unfoundUserAddress,
-          };
-          apiParams.requestParams = requestObject;
-          const result = await extractPublicKey(apiParams);
-          expect(walletStub.rpcStubs.snap_manageState).not.to.have.been.called;
-          expect(result).to.be.eql(unfoundUserPublicKey);
-        });
+      it('should throw error if getKeysFromAddress failed', async function () {
+        sandbox.stub(utils, 'getKeysFromAddress').throws(new Error());
+        const requestObject: ExtractPublicKeyRequestParams = {
+          userAddress: unfoundUserAddress,
+        };
+        apiParams.requestParams = requestObject;
 
-        it('should throw error if getKeysFromAddress failed', async function () {
-          sandbox.stub(utils, 'getKeysFromAddress').throws(new Error());
-          const requestObject: ExtractPublicKeyRequestParams = {
-            userAddress: unfoundUserAddress,
-          };
-          apiParams.requestParams = requestObject;
-
-          let result;
-          try {
-            await extractPublicKey(apiParams);
-          } catch (err) {
-            result = err;
-          } finally {
-            expect(result).to.be.an('Error');
-          }
-        });
+        let result;
+        try {
+          await extractPublicKey(apiParams);
+        } catch (err) {
+          result = err;
+        } finally {
+          expect(result).to.be.an('Error');
+        }
       });
     });
   });

--- a/packages/starknet-snap/test/src/sendTransaction.test.ts
+++ b/packages/starknet-snap/test/src/sendTransaction.test.ts
@@ -21,7 +21,7 @@ import {
   token2,
   token3,
   unfoundUserAddress,
-  Cario1Account1,
+  Cairo1Account1,
 } from '../constants.test';
 import { getAddressKeyDeriver } from '../../src/utils/keyPair';
 import { Mutex } from 'async-mutex';
@@ -238,7 +238,7 @@ describe('Test function: sendTransaction', function () {
         });
 
         describe('when account is not deployed', function () {
-          // not support cario0 address not deployed account
+          // not support cairo0 address not deployed account
         });
       });
     });
@@ -249,7 +249,7 @@ describe('Test function: sendTransaction', function () {
       beforeEach(async function () {
         apiParams.requestParams = {
           ...apiParams.requestParams,
-          senderAddress: Cario1Account1.address,
+          senderAddress: Cairo1Account1.address,
         };
         sandbox.stub(utils, 'isUpgradeRequired').resolves(false);
         sandbox.stub(estimateFeeSnap, 'estimateFee').resolves({

--- a/packages/starknet-snap/test/src/sendTransaction.test.ts
+++ b/packages/starknet-snap/test/src/sendTransaction.test.ts
@@ -73,7 +73,7 @@ describe('Test function: sendTransaction', function () {
       apiParams.requestParams = requestObject;
     });
 
-    it('it should show error when request contractAddress is not given', async function () {
+    it('should show error when request contractAddress is not given', async function () {
       invalidRequest.contractAddress = undefined;
       apiParams.requestParams = invalidRequest;
       let result;
@@ -89,7 +89,7 @@ describe('Test function: sendTransaction', function () {
       }
     });
 
-    it('it should show error when request contractAddress is invalid', async function () {
+    it('should show error when request contractAddress is invalid', async function () {
       invalidRequest.contractAddress = '0x0';
       apiParams.requestParams = invalidRequest;
       let result;
@@ -103,7 +103,7 @@ describe('Test function: sendTransaction', function () {
       }
     });
 
-    it('it should show error when request senderAddress is not given', async function () {
+    it('should show error when request senderAddress is not given', async function () {
       invalidRequest.senderAddress = undefined;
       apiParams.requestParams = invalidRequest;
       let result;
@@ -119,7 +119,7 @@ describe('Test function: sendTransaction', function () {
       }
     });
 
-    it('it should show error when request contractAddress is invalid', async function () {
+    it('should show error when request contractAddress is invalid', async function () {
       invalidRequest.senderAddress = '0x0';
       apiParams.requestParams = invalidRequest;
       let result;
@@ -133,7 +133,7 @@ describe('Test function: sendTransaction', function () {
       }
     });
 
-    it('it should show error when request contractFuncName is not given', async function () {
+    it('should show error when request contractFuncName is not given', async function () {
       invalidRequest.contractFuncName = undefined;
       apiParams.requestParams = invalidRequest;
       let result;
@@ -149,7 +149,7 @@ describe('Test function: sendTransaction', function () {
       }
     });
 
-    it('it should show error when request network not found', async function () {
+    it('should show error when request network not found', async function () {
       invalidRequest.chainId = '0x0';
       apiParams.requestParams = invalidRequest;
       let result;
@@ -172,78 +172,41 @@ describe('Test function: sendTransaction', function () {
       apiParams.requestParams = Object.assign({}, requestObject);
     });
 
-    describe('when account is cairo 0', function () {
-      describe('when require upgrade checking fail', function () {
-        it('should throw error', async function () {
-          const isUpgradeRequiredStub = sandbox.stub(utils, 'isUpgradeRequired').throws('network error');
-          let result;
-          try {
-            result = await sendTransaction(apiParams);
-          } catch (err) {
-            result = err;
-          } finally {
-            expect(isUpgradeRequiredStub).to.have.been.calledOnceWith(STARKNET_TESTNET_NETWORK, account1.address);
-            expect(result).to.be.an('Error');
-          }
-        });
-      });
-
-      describe('when account require upgrade', function () {
-        let isUpgradeRequiredStub: sinon.SinonStub;
-        beforeEach(async function () {
-          isUpgradeRequiredStub = sandbox.stub(utils, 'isUpgradeRequired').resolves(true);
-        });
-
-        it('should throw error if upgrade required', async function () {
-          let result;
-          try {
-            result = await sendTransaction(apiParams);
-          } catch (err) {
-            result = err;
-          } finally {
-            expect(isUpgradeRequiredStub).to.have.been.calledOnceWith(STARKNET_TESTNET_NETWORK, account1.address);
-            expect(result).to.be.an('Error');
-          }
-        });
-      });
-
-      describe('when account do not require upgrade', function () {
-        let executeTxnResp;
-        beforeEach(async function () {
-          sandbox.stub(utils, 'isUpgradeRequired').resolves(false);
-          sandbox.stub(estimateFeeSnap, 'estimateFee').resolves({
-            suggestedMaxFee: estimateFeeResp.suggestedMaxFee.toString(10),
-            overallFee: estimateFeeResp.overall_fee.toString(10),
-            gasConsumed: '0',
-            gasPrice: '0',
-            unit: 'wei',
-            includeDeploy: true,
-          });
-          executeTxnResp = sendTransactionResp;
-          sandbox.stub(utils, 'executeTxn').resolves(executeTxnResp);
-          walletStub.rpcStubs.snap_manageState.resolves(state);
-          walletStub.rpcStubs.snap_dialog.resolves(true);
-        });
-        describe('when account is deployed', function () {
-          beforeEach(async function () {
-            sandbox.stub(utils, 'isAccountDeployed').resolves(true);
-          });
-
-          it('should send a transaction for transferring 10 tokens correctly', async function () {
-            const result = await sendTransaction(apiParams);
-            expect(walletStub.rpcStubs.snap_dialog).to.have.been.calledOnce;
-            expect(walletStub.rpcStubs.snap_manageState).to.have.been.called;
-            expect(result).to.be.eql(sendTransactionResp);
-          });
-        });
-
-        describe('when account is not deployed', function () {
-          // not support cairo0 address not deployed account
-        });
+    describe('when require upgrade checking fail', function () {
+      it('should throw error', async function () {
+        const isUpgradeRequiredStub = sandbox.stub(utils, 'isUpgradeRequired').throws('network error');
+        let result;
+        try {
+          result = await sendTransaction(apiParams);
+        } catch (err) {
+          result = err;
+        } finally {
+          expect(isUpgradeRequiredStub).to.have.been.calledOnceWith(STARKNET_TESTNET_NETWORK, account1.address);
+          expect(result).to.be.an('Error');
+        }
       });
     });
 
-    describe('when account is cairo 1', function () {
+    describe('when account require upgrade', function () {
+      let isUpgradeRequiredStub: sinon.SinonStub;
+      beforeEach(async function () {
+        isUpgradeRequiredStub = sandbox.stub(utils, 'isUpgradeRequired').resolves(true);
+      });
+
+      it('should throw error if upgrade required', async function () {
+        let result;
+        try {
+          result = await sendTransaction(apiParams);
+        } catch (err) {
+          result = err;
+        } finally {
+          expect(isUpgradeRequiredStub).to.have.been.calledOnceWith(STARKNET_TESTNET_NETWORK, account1.address);
+          expect(result).to.be.an('Error');
+        }
+      });
+    });
+
+    describe('when account do not require upgrade', function () {
       let executeTxnResp;
       let executeTxnStub: sinon.SinonStub;
       beforeEach(async function () {
@@ -413,7 +376,7 @@ describe('Test function: sendTransaction', function () {
           sandbox.stub(utils, 'isAccountDeployed').resolves(false);
         });
 
-        it('should send a transaction for transferring 10 tokens and a transaction for deploy correctly', async function () {
+        it('send a transaction for transferring 10 tokens and a transaction for deploy correctly', async function () {
           sandbox.stub(utils, 'deployAccount').callsFake(async () => {
             return createAccountProxyResp;
           });

--- a/packages/starknet-snap/test/src/signMessage.test.ts
+++ b/packages/starknet-snap/test/src/signMessage.test.ts
@@ -8,12 +8,12 @@ import typedDataExample from '../../src/typedData/typedDataExample.json';
 import { STARKNET_TESTNET_NETWORK } from '../../src/utils/constants';
 import {
   account1,
-  Cario1Account1,
+  Cairo1Account1,
   getBip44EntropyStub,
   signature4SignMessageWithUnfoundAddress,
   unfoundUserAddress,
   signature4SignMessage,
-  signature4Cario1SignMessage,
+  signature4Cairo1SignMessage,
 } from '../constants.test';
 import { getAddressKeyDeriver } from '../../src/utils/keyPair';
 import * as utils from '../../src/utils/starknetUtils';
@@ -155,7 +155,7 @@ describe('Test function: signMessage', function () {
       beforeEach(async function () {
         apiParams.requestParams = {
           ...apiParams.requestParams,
-          signerAddress: Cario1Account1.address,
+          signerAddress: Cairo1Account1.address,
         };
         sandbox.stub(utils, 'isUpgradeRequired').resolves(false);
       });
@@ -164,7 +164,7 @@ describe('Test function: signMessage', function () {
         const result = await signMessage(apiParams);
         expect(walletStub.rpcStubs.snap_dialog).to.have.been.calledOnce;
         expect(walletStub.rpcStubs.snap_manageState).not.to.have.been.called;
-        expect(result).to.be.eql(signature4Cario1SignMessage);
+        expect(result).to.be.eql(signature4Cairo1SignMessage);
       });
 
       it('should sign a message from an unfound user account correctly', async function () {

--- a/packages/starknet-snap/test/src/verifySignedMessage.test.ts
+++ b/packages/starknet-snap/test/src/verifySignedMessage.test.ts
@@ -132,54 +132,48 @@ describe('Test function: verifySignedMessage', function () {
         sandbox.stub(utils, 'isUpgradeRequired').resolves(false);
       });
 
-      describe('when account is cairo 0', function () {
-        //TODO
+      it('should verify a signed message from an user account correctly', async function () {
+        const requestObject: VerifySignedMessageRequestParams = {
+          signerAddress: account1.address,
+          typedDataMessage: undefined, // will use typedDataExample.json
+          signature: signature1,
+        };
+        apiParams.requestParams = requestObject;
+        const result = await verifySignedMessage(apiParams);
+        expect(walletStub.rpcStubs.snap_manageState).not.to.have.been.called;
+        expect(result).to.be.eql(true);
       });
 
-      describe('when account is cairo 1', function () {
-        it('should verify a signed message from an user account correctly', async function () {
-          const requestObject: VerifySignedMessageRequestParams = {
-            signerAddress: account1.address,
-            typedDataMessage: undefined, // will use typedDataExample.json
-            signature: signature1,
-          };
-          apiParams.requestParams = requestObject;
-          const result = await verifySignedMessage(apiParams);
-          expect(walletStub.rpcStubs.snap_manageState).not.to.have.been.called;
-          expect(result).to.be.eql(true);
-        });
+      it('should verify a signed message from an unfound user account correctly', async function () {
+        const requestObject: VerifySignedMessageRequestParams = {
+          signerAddress: unfoundUserAddress,
+          typedDataMessage: toJson(typedDataExample),
+          signature: signature2,
+        };
+        apiParams.requestParams = requestObject;
+        const result = await verifySignedMessage(apiParams);
+        expect(walletStub.rpcStubs.snap_manageState).not.to.have.been.called;
+        expect(result).to.be.eql(true);
+      });
 
-        it('should verify a signed message from an unfound user account correctly', async function () {
-          const requestObject: VerifySignedMessageRequestParams = {
-            signerAddress: unfoundUserAddress,
-            typedDataMessage: toJson(typedDataExample),
-            signature: signature2,
-          };
-          apiParams.requestParams = requestObject;
-          const result = await verifySignedMessage(apiParams);
-          expect(walletStub.rpcStubs.snap_manageState).not.to.have.been.called;
-          expect(result).to.be.eql(true);
-        });
+      it('should throw error if getKeysFromAddress failed', async function () {
+        sandbox.stub(utils, 'getKeysFromAddress').throws(new Error());
+        const requestObject: VerifySignedMessageRequestParams = {
+          signerAddress: account1.address,
+          typedDataMessage: undefined, // will use typedDataExample.json
+          signature: signature1,
+        };
+        apiParams.requestParams = requestObject;
 
-        it('should throw error if getKeysFromAddress failed', async function () {
-          sandbox.stub(utils, 'getKeysFromAddress').throws(new Error());
-          const requestObject: VerifySignedMessageRequestParams = {
-            signerAddress: account1.address,
-            typedDataMessage: undefined, // will use typedDataExample.json
-            signature: signature1,
-          };
-          apiParams.requestParams = requestObject;
-
-          let result;
-          try {
-            await verifySignedMessage(apiParams);
-          } catch (err) {
-            result = err;
-          } finally {
-            expect(result).to.be.an('Error');
-          }
-          expect(walletStub.rpcStubs.snap_manageState).not.to.have.been.called;
-        });
+        let result;
+        try {
+          await verifySignedMessage(apiParams);
+        } catch (err) {
+          result = err;
+        } finally {
+          expect(result).to.be.an('Error');
+        }
+        expect(walletStub.rpcStubs.snap_manageState).not.to.have.been.called;
       });
     });
   });


### PR DESCRIPTION
- simplify `recoverAccount` to avoid duplicate called on `isUpgradeRequired`
- chore hardcode cairo version 1 to constant `CAIRO_VERSION `
- fix `findAddressIndex` should return address if the address match either cairo0 or cairo{N}
- fix `getCorrectContractAddress`, use getVersion instead of getOwner to determine account has deployed or not
- chore `getCorrectContractAddress` to return upgrade required attribute