### PR TITLE
chore: enable starknet id

### DIFF
--- a/packages/starknet-snap/snap.manifest.json
+++ b/packages/starknet-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/ConsenSys/starknet-snap.git"
   },
   "source": {
-    "shasum": "PJ6E3d1eILzFgZu2TWIZwzTWI8E/8nyJzcWfo737V7c=",
+    "shasum": "ZApv1PW/S6Jya3AlOPfeqX0U4Ej8qx7LNyRp65ezWy8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.view.tsx
@@ -22,8 +22,8 @@ import {
 import { openExplorerTab } from 'utils/utils';
 import { useAppSelector } from 'hooks/redux';
 import { AddTokenModal } from '../AddTokenModal';
-// import { useStarkNetSnap } from 'services';
-// import { DUMMY_ADDRESS } from 'utils/constants';
+import { useStarkNetSnap } from 'services';
+import { DUMMY_ADDRESS } from 'utils/constants';
 
 interface Props {
   address: string;
@@ -37,8 +37,8 @@ export const SideBarView = ({ address }: Props) => {
   const [accountDetailsOpen, setAccountDetailsOpen] = useState(false);
   const wallet = useAppSelector((state) => state.wallet);
   const [addTokenOpen, setAddTokenOpen] = useState(false);
-  // const { getStarkName } = useStarkNetSnap();
-  // const [starkName, setStarkName] = useState<string | undefined>(undefined);
+  const { getStarkName } = useStarkNetSnap();
+  const [starkName, setStarkName] = useState<string | undefined>(undefined);
 
   const ref = useRef<HTMLDivElement>();
 
@@ -53,17 +53,18 @@ export const SideBarView = ({ address }: Props) => {
     }
   }, [wallet.erc20TokenBalances]);
 
-  // useEffect(() => {
-  //   if (address && address !== DUMMY_ADDRESS) {
-  //     getStarkName(address, chainId)
-  //       .then((name) => {
-  //         setStarkName(name);
-  //       })
-  //       .catch(() => {
-  //         setStarkName(undefined);
-  //       });
-  //   }
-  // }, [address, chainId, getStarkName]);
+  useEffect(() => {
+    if (address && address !== DUMMY_ADDRESS) {
+      getStarkName(address, chainId)
+        .then((name) => {
+          setStarkName(name);
+        })
+        .catch(() => {
+          setStarkName(undefined);
+        });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [address, chainId]);
 
   return (
     <Wrapper>
@@ -98,7 +99,7 @@ export const SideBarView = ({ address }: Props) => {
       <AccountLabel>My account</AccountLabel>
       <RowDiv>
         <InfoIcon onClick={() => setInfoModalOpen(true)}>i</InfoIcon>
-        <AccountAddress address={address} />
+        <AccountAddress address={address} starkName={starkName} />
       </RowDiv>
       <DivList ref={ref as any}>
         <AssetsList />


### PR DESCRIPTION
This PR is enable back the starknet ID due to using latest SNAP api framework

when no starknet id found, the error will no longer break the snap