### PR TITLE
fix: get correct balance on snap homepage

### DIFF
--- a/packages/starknet-snap/snap.manifest.json
+++ b/packages/starknet-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/ConsenSys/starknet-snap.git"
   },
   "source": {
-    "shasum": "lLTHMW/oau9o6LzRE+2n+2qHCooLpe1RSJJPR/6UOEU=",
+    "shasum": "A3cyal6PKAzEQQ3ptdBUK106XMp5jQVh4kydh87u7AA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/starknet-snap/src/index.ts
+++ b/packages/starknet-snap/src/index.ts
@@ -265,7 +265,7 @@ export const onHomePage: OnHomePageHandler = async () => {
 
     let accContract: AccContract;
     if (state.currentNetwork) {
-      accContract = state.accContracts.find(n => n.chainId == state.currentNetwork.chainId);
+      accContract = state.accContracts.find((n) => n.chainId == state.currentNetwork.chainId);
     } else {
       accContract = state.accContracts[0];
     }
@@ -287,6 +287,7 @@ export const onHomePage: OnHomePageHandler = async () => {
           requestParams: {
             tokenAddress: ercToken.address,
             userAddress: userAddress,
+            chainId: network.chainId,
           },
         };
         const balance = await getErc20TokenBalance(params);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3155,7 +3155,7 @@ __metadata:
 
 "@consensys/starknet-snap@file:../starknet-snap::locator=wallet-ui%40workspace%3Apackages%2Fwallet-ui":
   version: 2.5.1
-  resolution: "@consensys/starknet-snap@file:../starknet-snap#../starknet-snap::hash=f43351&locator=wallet-ui%40workspace%3Apackages%2Fwallet-ui"
+  resolution: "@consensys/starknet-snap@file:../starknet-snap#../starknet-snap::hash=195ab3&locator=wallet-ui%40workspace%3Apackages%2Fwallet-ui"
   dependencies:
     "@metamask/snaps-sdk": 3.0.1
     async-mutex: ^0.3.2
@@ -3163,7 +3163,7 @@ __metadata:
     ethers: ^5.5.1
     starknet: ^5.14.0
     starknet_v4.22.0: "npm:starknet@4.22.0"
-  checksum: f6c425fa95f59effaa3cb47e30e5f5a339fb47e9cd5b0337f229213642436efb5fe8dc6b4df4de75a9b4e4524793145c78914514ff2d11bd055f365c2ce180d5
+  checksum: dc8a3354e0ec4863c9ff6d2841abeb0ea841f69519202d1c1b904308024a7ff76f3d44a1cfa91d043739ce807aa7b8513d06baf7cb357475450d653a39f89efd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR is to fix the incorrect balance showing from the Metamask SNAP homepage screen