### PR TITLE
fix: typo for enable autherize

### DIFF
--- a/packages/starknet-snap/src/signDeclareTransaction.ts
+++ b/packages/starknet-snap/src/signDeclareTransaction.ts
@@ -19,7 +19,7 @@ export async function signDeclareTransaction(params: ApiParams): Promise<Signatu
 
     const snapComponents = getSignTxnTxt(signerAddress, network, requestParamsObj.transaction);
 
-    if (requestParamsObj.enableAutherize === true) {
+    if (requestParamsObj.enableAuthorize === true) {
       const response = await wallet.request({
         method: 'snap_dialog',
         params: {

--- a/packages/starknet-snap/src/signDeployAccountTransaction.ts
+++ b/packages/starknet-snap/src/signDeployAccountTransaction.ts
@@ -22,7 +22,7 @@ export async function signDeployAccountTransaction(params: ApiParams): Promise<S
 
     const snapComponents = getSignTxnTxt(signerAddress, network, requestParamsObj.transaction);
 
-    if (requestParamsObj.enableAutherize === true) {
+    if (requestParamsObj.enableAuthorize === true) {
       const response = await wallet.request({
         method: 'snap_dialog',
         params: {

--- a/packages/starknet-snap/src/signMessage.ts
+++ b/packages/starknet-snap/src/signMessage.ts
@@ -34,7 +34,7 @@ export async function signMessage(params: ApiParams) {
     addDialogTxt(components, 'Message', toJson(typedDataMessage));
     addDialogTxt(components, 'Signer Address', signerAddress);
 
-    if (requestParamsObj.enableAutherize === true) {
+    if (requestParamsObj.enableAuthorize === true) {
       const response = await wallet.request({
         method: 'snap_dialog',
         params: {

--- a/packages/starknet-snap/src/signTransaction.ts
+++ b/packages/starknet-snap/src/signTransaction.ts
@@ -19,7 +19,7 @@ export async function signTransaction(params: ApiParams): Promise<Signature | bo
 
     const snapComponents = getSignTxnTxt(signerAddress, network, requestParamsObj.transactions);
 
-    if (requestParamsObj.enableAutherize === true) {
+    if (requestParamsObj.enableAuthorize === true) {
       const response = await wallet.request({
         method: 'snap_dialog',
         params: {

--- a/packages/starknet-snap/src/switchNetwork.ts
+++ b/packages/starknet-snap/src/switchNetwork.ts
@@ -15,7 +15,7 @@ export async function switchNetwork(params: ApiParams) {
     }
     const components = getNetworkTxt(network);
 
-    if (requestParamsObj.enableAutherize === true) {
+    if (requestParamsObj.enableAuthorize === true) {
       const response = await wallet.request({
         method: 'snap_dialog',
         params: {

--- a/packages/starknet-snap/src/types/snapApi.ts
+++ b/packages/starknet-snap/src/types/snapApi.ts
@@ -75,7 +75,7 @@ export interface ExtractPublicKeyRequestParams extends BaseRequestParams {
   userAddress: string;
 }
 
-export interface SignMessageRequestParams extends Autherizeable, SignRequestParams, BaseRequestParams {
+export interface SignMessageRequestParams extends Authorizable, SignRequestParams, BaseRequestParams {
   typedDataMessage: typedData.TypedData;
 }
 
@@ -181,29 +181,29 @@ export interface RpcV4GetTransactionReceiptResponse {
   finality_status?: string;
 }
 
-export interface Autherizeable {
-  enableAutherize?: boolean;
+export interface Authorizable {
+  enableAuthorize?: boolean;
 }
 
 export interface SignRequestParams {
   signerAddress: string;
 }
 
-export interface SignTransactionRequestParams extends Autherizeable, SignRequestParams, BaseRequestParams {
+export interface SignTransactionRequestParams extends Authorizable, SignRequestParams, BaseRequestParams {
   transactions: Call[];
   transactionsDetail: InvocationsSignerDetails;
   abis?: Abi[];
 }
 
-export interface SignDeployAccountTransactionRequestParams extends Autherizeable, SignRequestParams, BaseRequestParams {
+export interface SignDeployAccountTransactionRequestParams extends Authorizable, SignRequestParams, BaseRequestParams {
   transaction: DeployAccountSignerDetails;
 }
 
-export interface SignDeclareTransactionRequestParams extends Autherizeable, SignRequestParams, BaseRequestParams {
+export interface SignDeclareTransactionRequestParams extends Authorizable, SignRequestParams, BaseRequestParams {
   transaction: DeclareSignerDetails;
 }
 
-export interface SwitchNetworkRequestParams extends Autherizeable, BaseRequestParams {
+export interface SwitchNetworkRequestParams extends Authorizable, BaseRequestParams {
   chainId: string;
 }
 

--- a/packages/starknet-snap/test/src/signDeclareTransaction.test.ts
+++ b/packages/starknet-snap/test/src/signDeclareTransaction.test.ts
@@ -46,7 +46,7 @@ describe('Test function: signDeclareTransaction', function () {
       version: '0x0',
       maxFee: 100,
     },
-    enableAutherize: true,
+    enableAuthorize: true,
   };
 
   beforeEach(async function () {
@@ -94,23 +94,23 @@ describe('Test function: signDeclareTransaction', function () {
     expect(result).to.be.eql(false);
   });
 
-  it('should skip dialog if enableAutherize is false', async function () {
+  it('should skip dialog if enableAuthorize is false', async function () {
     sandbox.stub(utils, 'signDeclareTransaction').resolves(signature3);
     const paramsObject = apiParams.requestParams as SignDeclareTransactionRequestParams;
-    paramsObject.enableAutherize = false;
+    paramsObject.enableAuthorize = false;
     const result = await signDeclareTransaction(apiParams);
     expect(walletStub.rpcStubs.snap_dialog).to.have.been.callCount(0);
     expect(result).to.be.eql(signature3);
-    paramsObject.enableAutherize = true;
+    paramsObject.enableAuthorize = true;
   });
 
-  it('should skip dialog if enableAutherize is omit', async function () {
+  it('should skip dialog if enableAuthorize is omit', async function () {
     sandbox.stub(utils, 'signDeclareTransaction').resolves(signature3);
     const paramsObject = apiParams.requestParams as SignDeclareTransactionRequestParams;
-    paramsObject.enableAutherize = undefined;
+    paramsObject.enableAuthorize = undefined;
     const result = await signDeclareTransaction(apiParams);
     expect(walletStub.rpcStubs.snap_dialog).to.have.been.callCount(0);
     expect(result).to.be.eql(signature3);
-    paramsObject.enableAutherize = true;
+    paramsObject.enableAuthorize = true;
   });
 });

--- a/packages/starknet-snap/test/src/signDeployAccountTransaction.test.ts
+++ b/packages/starknet-snap/test/src/signDeployAccountTransaction.test.ts
@@ -48,7 +48,7 @@ describe('Test function: signDeployAccountTransaction', function () {
       version: '0x0',
       maxFee: 100,
     },
-    enableAutherize: true,
+    enableAuthorize: true,
   };
 
   beforeEach(async function () {
@@ -96,23 +96,23 @@ describe('Test function: signDeployAccountTransaction', function () {
     expect(result).to.be.eql(false);
   });
 
-  it('should skip dialog if enableAutherize is false', async function () {
+  it('should skip dialog if enableAuthorize is false', async function () {
     sandbox.stub(utils, 'signDeployAccountTransaction').resolves(signature3);
     const paramsObject = apiParams.requestParams as SignDeployAccountTransactionRequestParams;
-    paramsObject.enableAutherize = false;
+    paramsObject.enableAuthorize = false;
     const result = await signDeployAccountTransaction(apiParams);
     expect(walletStub.rpcStubs.snap_dialog).to.have.been.callCount(0);
     expect(result).to.be.eql(signature3);
-    paramsObject.enableAutherize = true;
+    paramsObject.enableAuthorize = true;
   });
 
-  it('should skip dialog if enableAutherize is omit', async function () {
+  it('should skip dialog if enableAuthorize is omit', async function () {
     sandbox.stub(utils, 'signDeployAccountTransaction').resolves(signature3);
     const paramsObject = apiParams.requestParams as SignDeployAccountTransactionRequestParams;
-    paramsObject.enableAutherize = undefined;
+    paramsObject.enableAuthorize = undefined;
     const result = await signDeployAccountTransaction(apiParams);
     expect(walletStub.rpcStubs.snap_dialog).to.have.been.callCount(0);
     expect(result).to.be.eql(signature3);
-    paramsObject.enableAutherize = true;
+    paramsObject.enableAuthorize = true;
   });
 });

--- a/packages/starknet-snap/test/src/signMessage.test.ts
+++ b/packages/starknet-snap/test/src/signMessage.test.ts
@@ -43,7 +43,7 @@ describe('Test function: signMessage', function () {
     chainId: STARKNET_TESTNET_NETWORK.chainId,
     signerAddress: account1.address,
     typedDataMessage: typedDataExample,
-    enableAutherize: true,
+    enableAuthorize: true,
   };
 
   beforeEach(async function () {
@@ -157,21 +157,21 @@ describe('Test function: signMessage', function () {
     }
   });
 
-  it('should skip dialog if enableAutherize is false', async function () {
+  it('should skip dialog if enableAuthorize is false', async function () {
     const paramsObject = apiParams.requestParams as SignMessageRequestParams;
-    paramsObject.enableAutherize = false;
+    paramsObject.enableAuthorize = false;
     const result = await signMessage(apiParams);
     expect(walletStub.rpcStubs.snap_dialog).to.have.been.callCount(0);
     expect(result).to.be.eql(signature4SignMessage);
-    paramsObject.enableAutherize = true;
+    paramsObject.enableAuthorize = true;
   });
 
-  it('should skip dialog if enableAutherize is omit', async function () {
+  it('should skip dialog if enableAuthorize is omit', async function () {
     const paramsObject = apiParams.requestParams as SignMessageRequestParams;
-    paramsObject.enableAutherize = undefined;
+    paramsObject.enableAuthorize = undefined;
     const result = await signMessage(apiParams);
     expect(walletStub.rpcStubs.snap_dialog).to.have.been.callCount(0);
     expect(result).to.be.eql(signature4SignMessage);
-    paramsObject.enableAutherize = true;
+    paramsObject.enableAuthorize = true;
   });
 });

--- a/packages/starknet-snap/test/src/signTransaction.test.ts
+++ b/packages/starknet-snap/test/src/signTransaction.test.ts
@@ -58,7 +58,7 @@ describe('Test function: signMessage', function () {
       version: '0x0',
       maxFee: 100,
     },
-    enableAutherize: true,
+    enableAuthorize: true,
   };
 
   beforeEach(async function () {
@@ -105,21 +105,21 @@ describe('Test function: signMessage', function () {
     expect(result).to.be.eql(false);
   });
 
-  it('should skip dialog if enableAutherize is false', async function () {
+  it('should skip dialog if enableAuthorize is false', async function () {
     const paramsObject = apiParams.requestParams as SignTransactionRequestParams;
-    paramsObject.enableAutherize = false;
+    paramsObject.enableAuthorize = false;
     const result = await signTransaction(apiParams);
     expect(walletStub.rpcStubs.snap_dialog).to.have.been.callCount(0);
     expect(result).to.be.eql(signature3);
-    paramsObject.enableAutherize = true;
+    paramsObject.enableAuthorize = true;
   });
 
-  it('should skip dialog if enableAutherize is omit', async function () {
+  it('should skip dialog if enableAuthorize is omit', async function () {
     const paramsObject = apiParams.requestParams as SignTransactionRequestParams;
-    paramsObject.enableAutherize = undefined;
+    paramsObject.enableAuthorize = undefined;
     const result = await signTransaction(apiParams);
     expect(walletStub.rpcStubs.snap_dialog).to.have.been.callCount(0);
     expect(result).to.be.eql(signature3);
-    paramsObject.enableAutherize = true;
+    paramsObject.enableAuthorize = true;
   });
 });

--- a/packages/starknet-snap/test/src/switchNetwork.test.ts
+++ b/packages/starknet-snap/test/src/switchNetwork.test.ts
@@ -48,7 +48,7 @@ describe('Test function: switchNetwork', function () {
   it('should switch the network correctly', async function () {
     const requestObject: SwitchNetworkRequestParams = {
       chainId: STARKNET_MAINNET_NETWORK.chainId,
-      enableAutherize: true,
+      enableAuthorize: true,
     };
     apiParams.requestParams = requestObject;
     const result = await switchNetwork(apiParams);
@@ -59,7 +59,7 @@ describe('Test function: switchNetwork', function () {
     expect(state.networks.length).to.be.eql(3);
   });
 
-  it('should skip autherize when enableAutherize is false or omit', async function () {
+  it('should skip autherize when enableAuthorize is false or omit', async function () {
     const requestObject: SwitchNetworkRequestParams = {
       chainId: STARKNET_MAINNET_NETWORK.chainId,
     };
@@ -75,7 +75,7 @@ describe('Test function: switchNetwork', function () {
   it('should throw an error if network not found', async function () {
     const requestObject: SwitchNetworkRequestParams = {
       chainId: '123',
-      enableAutherize: true,
+      enableAuthorize: true,
     };
     apiParams.requestParams = requestObject;
     let result;
@@ -95,7 +95,7 @@ describe('Test function: switchNetwork', function () {
     sandbox.stub(snapUtils, 'setCurrentNetwork').throws(new Error());
     const requestObject: SwitchNetworkRequestParams = {
       chainId: STARKNET_TESTNET_NETWORK.chainId,
-      enableAutherize: true,
+      enableAuthorize: true,
     };
     apiParams.requestParams = requestObject;
     let result;


### PR DESCRIPTION
This PR is to fix the typo in SNAP, including

`enableAutherize` to `enableAuthorize`
`Autherizeable` to `Authorizable`