### PR TITLE
feat: transactionV3 support to pay in STRK

### DIFF
--- a/packages/starknet-snap/snap.manifest.json
+++ b/packages/starknet-snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/ConsenSys/starknet-snap.git"
   },
   "source": {
-    "shasum": "w/9IComQVArE5jU1RHIW8Y5CnN//nBoHKBQDFRhM8yI=",
+    "shasum": "YdeDk9lVWyoJcZii48PbyEvrqUWBbYE7CfHFh9v9sWk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/starknet-snap/src/declareContract.ts
+++ b/packages/starknet-snap/src/declareContract.ts
@@ -5,6 +5,7 @@ import { getKeysFromAddress, declareContract as declareContractUtil, isUpgradeRe
 import { DialogType } from '@metamask/rpc-methods';
 import { heading, panel } from '@metamask/snaps-sdk';
 import { logger } from './utils/logger';
+import { constants } from 'starknet';
 
 export async function declareContract(params: ApiParams) {
   try {
@@ -27,6 +28,7 @@ export async function declareContract(params: ApiParams) {
       network,
       requestParamsObj.contractPayload,
       requestParamsObj.invocationsDetails,
+      requestParamsObj.transactionVersion === constants.TRANSACTION_VERSION.V3 ? 'STRK' : 'ETH',
     );
 
     const response = await wallet.request({

--- a/packages/starknet-snap/src/estimateFee.ts
+++ b/packages/starknet-snap/src/estimateFee.ts
@@ -13,7 +13,7 @@ import {
   isAccountDeployed,
   isUpgradeRequired,
 } from './utils/starknetUtils';
-import { ACCOUNT_CLASS_HASH } from './utils/constants';
+import { ACCOUNT_CLASS_HASH, TRANSACTION_VERSION } from './utils/constants';
 import { logger } from './utils/logger';
 
 export async function estimateFee(params: ApiParams) {
@@ -25,6 +25,7 @@ export async function estimateFee(params: ApiParams) {
     const contractCallData = getCallDataArray(requestParamsObj.contractCallData);
     const senderAddress = requestParamsObj.senderAddress;
     const network = getNetworkFromChainId(state, requestParamsObj.chainId);
+    const transactionVersion = requestParamsObj.transactionVersion ?? TRANSACTION_VERSION;
 
     if (!contractAddress || !requestParamsObj.senderAddress || !contractFuncName) {
       throw new Error(
@@ -98,10 +99,22 @@ export async function estimateFee(params: ApiParams) {
     if (accountDeployed) {
       // This condition branch will be removed later when starknet.js
       // supports estimateFeeBulk in rpc mode
-      estimateFeeResp = await estimateFeeUtil(network, senderAddress, senderPrivateKey, txnInvocation);
+      estimateFeeResp = await estimateFeeUtil(
+        network,
+        senderAddress,
+        senderPrivateKey,
+        txnInvocation,
+        transactionVersion,
+      );
       logger.log(`estimateFee:\nestimateFeeUtil estimateFeeResp: ${toJson(estimateFeeResp)}`);
     } else {
-      const estimateBulkFeeResp = await estimateFeeBulk(network, senderAddress, senderPrivateKey, bulkTransactions);
+      const estimateBulkFeeResp = await estimateFeeBulk(
+        network,
+        senderAddress,
+        senderPrivateKey,
+        bulkTransactions,
+        transactionVersion,
+      );
       logger.log(`estimateFee:\nestimateFeeBulk estimateBulkFeeResp: ${toJson(estimateBulkFeeResp)}`);
       estimateFeeResp = addFeesFromAllTransactions(estimateBulkFeeResp);
     }

--- a/packages/starknet-snap/src/estimateFees.ts
+++ b/packages/starknet-snap/src/estimateFees.ts
@@ -3,6 +3,7 @@ import { getNetworkFromChainId } from './utils/snapUtils';
 import { getKeysFromAddress, estimateFeeBulk } from './utils/starknetUtils';
 import { ApiParams, EstimateFeesRequestParams } from './types/snapApi';
 import { logger } from './utils/logger';
+import { TRANSACTION_VERSION } from './utils/constants';
 
 export async function estimateFees(params: ApiParams) {
   try {
@@ -20,6 +21,7 @@ export async function estimateFees(params: ApiParams) {
       senderAddress,
       senderPrivateKey,
       requestParamsObj.invocations,
+      requestParamsObj.transactionVersion ?? TRANSACTION_VERSION,
       requestParamsObj.invocationDetails,
     );
 

--- a/packages/starknet-snap/src/executeTxn.ts
+++ b/packages/starknet-snap/src/executeTxn.ts
@@ -1,4 +1,4 @@
-import { Invocations, TransactionType } from 'starknet';
+import { Invocations, TransactionType, constants } from 'starknet';
 import { getNetworkFromChainId, getTxnSnapTxt, addDialogTxt, showUpgradeRequestModal } from './utils/snapUtils';
 import {
   getKeysFromAddress,
@@ -14,7 +14,7 @@ import { createAccount } from './createAccount';
 import { DialogType } from '@metamask/rpc-methods';
 import { heading, panel, divider } from '@metamask/snaps-sdk';
 import { logger } from './utils/logger';
-import { ACCOUNT_CLASS_HASH } from './utils/constants';
+import { ACCOUNT_CLASS_HASH, TRANSACTION_VERSION } from './utils/constants';
 
 export async function executeTxn(params: ApiParams) {
   try {
@@ -61,6 +61,7 @@ export async function executeTxn(params: ApiParams) {
       senderAddress,
       senderPrivateKey,
       bulkTransactions,
+      requestParams.transactionVersion ?? TRANSACTION_VERSION,
       requestParamsObj.invocationsDetails ? requestParamsObj.invocationsDetails : undefined,
     );
     const estimateFeeResp = addFeesFromAllTransactions(fees);
@@ -96,6 +97,7 @@ export async function executeTxn(params: ApiParams) {
         requestParamsObj.txnInvocation,
         requestParamsObj.abis,
         requestParamsObj.invocationsDetails,
+        requestParamsObj.transactionVersion === constants.TRANSACTION_VERSION.V3 ? 'STRK' : 'ETH',
       ),
     );
 

--- a/packages/starknet-snap/src/sendTransaction.ts
+++ b/packages/starknet-snap/src/sendTransaction.ts
@@ -71,6 +71,7 @@ export async function sendTransaction(params: ApiParams) {
       senderAddress,
       maxFee,
       network,
+      requestParamsObj.transactionVersion === constants.TRANSACTION_VERSION.V3 ? 'STRK' : 'ETH',
     );
     const response = await wallet.request({
       method: 'snap_dialog',

--- a/packages/starknet-snap/src/types/snapApi.ts
+++ b/packages/starknet-snap/src/types/snapApi.ts
@@ -12,6 +12,7 @@ import {
   DeployAccountSignerDetails,
   DeclareSignerDetails,
   typedData,
+  constants,
 } from 'starknet';
 
 export interface ApiParams {
@@ -51,6 +52,7 @@ export interface BaseRequestParams {
   chainId?: string;
   isDev?: boolean;
   debugLevel?: string;
+  transactionVersion?: constants.TRANSACTION_VERSION.V2 | constants.TRANSACTION_VERSION.V3;
 }
 
 export interface CreateAccountRequestParams extends BaseRequestParams {

--- a/packages/starknet-snap/src/upgradeAccContract.ts
+++ b/packages/starknet-snap/src/upgradeAccContract.ts
@@ -11,7 +11,7 @@ import {
 } from './utils/starknetUtils';
 import { getNetworkFromChainId, upsertTransaction, getSendTxnText } from './utils/snapUtils';
 import { ApiParams, UpgradeTransactionRequestParams } from './types/snapApi';
-import { ACCOUNT_CLASS_HASH, CAIRO_VERSION_LEGACY } from './utils/constants';
+import { ACCOUNT_CLASS_HASH, CAIRO_VERSION_LEGACY, TRANSACTION_VERSION } from './utils/constants';
 import { DialogType } from '@metamask/rpc-methods';
 import { heading, panel } from '@metamask/snaps-sdk';
 import { logger } from './utils/logger';
@@ -22,6 +22,7 @@ export async function upgradeAccContract(params: ApiParams) {
     const requestParamsObj = requestParams as UpgradeTransactionRequestParams;
     const contractAddress = requestParamsObj.contractAddress;
     const chainId = requestParamsObj.chainId;
+    const transactionVersion = requestParamsObj.transactionVersion ?? TRANSACTION_VERSION;
 
     if (!contractAddress) {
       throw new Error(`The given contract address need to be non-empty string, got: ${toJson(requestParamsObj)}`);
@@ -59,7 +60,14 @@ export async function upgradeAccContract(params: ApiParams) {
 
     let maxFee = requestParamsObj.maxFee ? num.toBigInt(requestParamsObj.maxFee) : constants.ZERO;
     if (maxFee === constants.ZERO) {
-      const estFeeResp = await estimateFee(network, contractAddress, privateKey, txnInvocation, CAIRO_VERSION_LEGACY);
+      const estFeeResp = await estimateFee(
+        network,
+        contractAddress,
+        privateKey,
+        txnInvocation,
+        transactionVersion,
+        CAIRO_VERSION_LEGACY,
+      );
       maxFee = num.toBigInt(estFeeResp.suggestedMaxFee.toString(10) ?? '0');
     }
 

--- a/packages/starknet-snap/src/utils/constants.ts
+++ b/packages/starknet-snap/src/utils/constants.ts
@@ -187,3 +187,5 @@ export const MIN_ACC_CONTRACT_VERSION = [0, 3, 0];
 export const CAIRO_VERSION = '1';
 
 export const CAIRO_VERSION_LEGACY = '0';
+
+export const TRANSACTION_VERSION = constants.TRANSACTION_VERSION.V3;

--- a/packages/starknet-snap/src/utils/snapUtils.ts
+++ b/packages/starknet-snap/src/utils/snapUtils.ts
@@ -206,6 +206,7 @@ export function getTxnSnapTxt(
   txnInvocation: Call | Call[],
   abis?: Abi[],
   invocationsDetails?: InvocationsDetails,
+  feeToken?: string,
 ) {
   const components = [];
   addDialogTxt(components, 'Network', network.name);
@@ -216,7 +217,7 @@ export function getTxnSnapTxt(
   }
 
   if (invocationsDetails?.maxFee) {
-    addDialogTxt(components, 'Max Fee(ETH)', convert(invocationsDetails.maxFee, 'wei', 'ether'));
+    addDialogTxt(components, `Max Fee(${feeToken ?? 'ETH'})`, convert(invocationsDetails.maxFee, 'wei', 'ether'));
   }
   if (invocationsDetails?.nonce) {
     addDialogTxt(components, 'Nonce', invocationsDetails.nonce.toString());
@@ -235,6 +236,7 @@ export function getSendTxnText(
   senderAddress: string,
   maxFee: num.BigNumberish,
   network: Network,
+  feeToken?: string,
 ): Array<Component> {
   // Retrieve the ERC-20 token from snap state for confirmation display purpose
   const token = getErc20Token(state, contractAddress, network.chainId);
@@ -242,7 +244,7 @@ export function getSendTxnText(
   addDialogTxt(components, 'Signer Address', senderAddress);
   addDialogTxt(components, 'Contract', contractAddress);
   addDialogTxt(components, 'Call Data', `[${contractCallData.join(', ')}]`);
-  addDialogTxt(components, 'Estimated Gas Fee(ETH)', convert(maxFee, 'wei', 'ether'));
+  addDialogTxt(components, `Estimated Gas Fee(${feeToken ?? 'ETH'})`, convert(maxFee, 'wei', 'ether'));
   addDialogTxt(components, 'Network', network.name);
 
   if (token && contractFuncName === 'transfer') {
@@ -281,6 +283,7 @@ export function getDeclareSnapTxt(
   network: Network,
   contractPayload: DeclareContractPayload,
   invocationsDetails?: InvocationsDetails,
+  feeToken?: string,
 ) {
   const components = [];
   addDialogTxt(components, 'Network', network.name);
@@ -303,7 +306,7 @@ export function getDeclareSnapTxt(
     addDialogTxt(components, 'Casm', JSON.stringify(contractPayload.casm, null, 2));
   }
   if (invocationsDetails?.maxFee !== undefined) {
-    addDialogTxt(components, 'Max Fee(ETH)', convert(invocationsDetails.maxFee, 'wei', 'ether'));
+    addDialogTxt(components, `Max Fee(${feeToken ?? 'ETH'})`, convert(invocationsDetails.maxFee, 'wei', 'ether'));
   }
   if (invocationsDetails?.nonce !== undefined) {
     addDialogTxt(components, 'Nonce', invocationsDetails.nonce.toString());

--- a/packages/starknet-snap/src/utils/starknetUtils.ts
+++ b/packages/starknet-snap/src/utils/starknetUtils.ts
@@ -46,6 +46,7 @@ import {
   ACCOUNT_CLASS_HASH,
   CAIRO_VERSION,
   CAIRO_VERSION_LEGACY,
+  TRANSACTION_VERSION,
 } from './constants';
 import { getAddressKey } from './keyPair';
 import {
@@ -80,9 +81,16 @@ export const getAccountInstance = (
   userAddress: string,
   privateKey: string | Uint8Array,
   cairoVersion?: CairoVersion,
+  transactionVersion?: constants.TRANSACTION_VERSION.V2 | constants.TRANSACTION_VERSION.V3,
 ): Account => {
   const provider = getProvider(network);
-  return new Account(provider, userAddress, privateKey, cairoVersion ?? CAIRO_VERSION);
+  return new Account(
+    provider,
+    userAddress,
+    privateKey,
+    cairoVersion ?? CAIRO_VERSION,
+    transactionVersion ?? TRANSACTION_VERSION,
+  );
 };
 
 export const callContract = async (
@@ -132,14 +140,18 @@ export const estimateFee = async (
   senderAddress: string,
   privateKey: string | Uint8Array,
   txnInvocation: Call | Call[],
+  transactionVersion?: constants.TRANSACTION_VERSION.V2 | constants.TRANSACTION_VERSION.V3,
   cairoVersion?: CairoVersion,
   invocationsDetails?: UniversalDetails,
 ): Promise<EstimateFee> => {
-  return getAccountInstance(network, senderAddress, privateKey, cairoVersion).estimateInvokeFee(txnInvocation, {
-    ...invocationsDetails,
-    skipValidate: false,
-    blockIdentifier: 'latest',
-  });
+  return getAccountInstance(network, senderAddress, privateKey, cairoVersion, transactionVersion).estimateInvokeFee(
+    txnInvocation,
+    {
+      ...invocationsDetails,
+      skipValidate: false,
+      blockIdentifier: 'latest',
+    },
+  );
 };
 
 export const estimateFeeBulk = async (
@@ -147,14 +159,18 @@ export const estimateFeeBulk = async (
   senderAddress: string,
   privateKey: string | Uint8Array,
   txnInvocation: Invocations,
+  transactionVersion?: constants.TRANSACTION_VERSION.V2 | constants.TRANSACTION_VERSION.V3,
   invocationsDetails?: UniversalDetails,
   cairoVersion?: CairoVersion,
 ): Promise<EstimateFee[]> => {
-  return getAccountInstance(network, senderAddress, privateKey, cairoVersion).estimateFeeBulk(txnInvocation, {
-    ...invocationsDetails,
-    skipValidate: false,
-    blockIdentifier: 'latest',
-  });
+  return getAccountInstance(network, senderAddress, privateKey, cairoVersion, transactionVersion).estimateFeeBulk(
+    txnInvocation,
+    {
+      ...invocationsDetails,
+      skipValidate: false,
+      blockIdentifier: 'latest',
+    },
+  );
 };
 
 export const executeTxn = async (
@@ -170,6 +186,7 @@ export const executeTxn = async (
     ...invocationsDetails,
     skipValidate: false,
     blockIdentifier: 'latest',
+    version: constants.TRANSACTION_VERSION.V3,
   });
 };
 

--- a/packages/wallet-ui/package.json
+++ b/packages/wallet-ui/package.json
@@ -27,7 +27,7 @@
     "react-redux": "^8.0.1",
     "redux-persist": "^6.0.0",
     "semver": "^7.5.2",
-    "starknet": "^4.22.0",
+    "starknet": "6.7.0",
     "styled-components": "^5.3.5",
     "toastr2": "^3.0.0-alpha.18",
     "web-vitals": "^2.1.4"

--- a/packages/wallet-ui/src/components/ui/molecule/AmountInput/AmountInput.stories.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/AmountInput/AmountInput.stories.tsx
@@ -11,7 +11,7 @@ export default {
 const asset = {
   address: '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7',
   amount: BigNumber.from('1000000000000000000'),
-  chainId: constants.StarknetChainId.TESTNET,
+  chainId: constants.StarknetChainId.SN_SEPOLIA,
   decimals: 18,
   name: 'Ether',
   symbol: 'ETH',

--- a/packages/wallet-ui/src/components/ui/molecule/AssetsList/AssetListItem/AssetListItem.stories.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/AssetsList/AssetListItem/AssetListItem.stories.tsx
@@ -12,7 +12,7 @@ export default {
 const asset: Erc20TokenBalance = {
   address: '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7',
   amount: BigNumber.from('1000000000000000000'),
-  chainId: constants.StarknetChainId.TESTNET,
+  chainId: constants.StarknetChainId.SN_SEPOLIA,
   decimals: 18,
   name: 'Ether',
   symbol: 'ETH',

--- a/packages/wallet-ui/src/components/ui/organism/Header/SendModal/SendModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/Header/SendModal/SendModal.view.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { AmountInput } from 'components/ui/molecule/AmountInput';
 import { SendSummaryModal } from '../SendSummaryModal';
 import {
@@ -17,6 +17,7 @@ import { ethers } from 'ethers';
 import { AddressInput } from 'components/ui/molecule/AddressInput';
 import { isValidAddress } from 'utils/utils';
 import { Bold, Normal } from '../../ConnectInfoModal/ConnectInfoModal.style';
+import { DropDown } from 'components/ui/molecule/DropDown';
 
 interface Props {
   closeModal?: () => void;
@@ -30,6 +31,7 @@ export const SendModalView = ({ closeModal }: Props) => {
     amount: '',
     address: '',
     chainId: networks.items.length > 0 ? networks.items[networks.activeNetwork].chainId : '',
+    feeToken: 'ETH', // Default fee token
   });
   const [errors, setErrors] = useState({ amount: '', address: '' });
 
@@ -62,8 +64,13 @@ export const SendModalView = ({ closeModal }: Props) => {
           }
         }
         break;
+      case 'feeToken':
+        setFields((prevFields) => ({
+          ...prevFields,
+          feeToken: fieldValue,
+        }));
+        break;
     }
-
     setFields((prevFields) => ({
       ...prevFields,
       [fieldName]: fieldValue,
@@ -105,6 +112,18 @@ export const SendModalView = ({ closeModal }: Props) => {
               decimalsMax={wallet.erc20TokenBalanceSelected.decimals}
               asset={wallet.erc20TokenBalanceSelected}
             />
+            <SeparatorSmall />
+            <div>
+              <label htmlFor="feeToken">Fee Token</label>
+              <DropDown
+                value={fields.feeToken}
+                options={[
+                  { label: 'ETH', value: 'ETH' },
+                  { label: 'STRK', value: 'STRK' },
+                ]}
+                onChange={(e) => handleChange('feeToken', e.value)}
+              />
+            </div>
           </Wrapper>
           <Buttons>
             <ButtonStyled onClick={closeModal} backgroundTransparent borderVisible>
@@ -123,6 +142,7 @@ export const SendModalView = ({ closeModal }: Props) => {
           address={fields.address}
           amount={fields.amount}
           chainId={fields.chainId}
+          selectedFeeToken={fields.feeToken} // Pass the selected fee token
         />
       )}
     </>

--- a/packages/wallet-ui/src/services/useStarkNetSnap.ts
+++ b/packages/wallet-ui/src/services/useStarkNetSnap.ts
@@ -22,6 +22,7 @@ import { ethers } from 'ethers';
 import { getAssetPriceUSD } from './coinGecko';
 import semver from 'semver/preload';
 import { setActiveNetwork } from 'slices/networkSlice';
+import { constants } from 'starknet';
 
 export const useStarkNetSnap = () => {
   const dispatch = useAppDispatch();
@@ -305,6 +306,7 @@ export const useStarkNetSnap = () => {
     contractCallData: string,
     senderAddress: string,
     chainId: string,
+    transactionVersion?: constants.TRANSACTION_VERSION.V2 | constants.TRANSACTION_VERSION.V3,
   ) {
     try {
       const response = await provider.request({
@@ -320,6 +322,7 @@ export const useStarkNetSnap = () => {
               contractCallData,
               senderAddress,
               chainId,
+              transactionVersion,
             },
           },
         },
@@ -338,6 +341,7 @@ export const useStarkNetSnap = () => {
     senderAddress: string,
     maxFee: string,
     chainId: string,
+    feeToken: string,
   ) {
     dispatch(enableLoadingWithMessage('Sending transaction...'));
     try {
@@ -355,6 +359,8 @@ export const useStarkNetSnap = () => {
               senderAddress,
               maxFee,
               chainId,
+              transactionVersion:
+                feeToken === 'ETH' ? constants.TRANSACTION_VERSION.V2 : constants.TRANSACTION_VERSION.V3,
             },
           },
         },

--- a/packages/wallet-ui/src/utils/constants.ts
+++ b/packages/wallet-ui/src/utils/constants.ts
@@ -4,7 +4,7 @@ import { constants } from 'starknet';
 export const SEPOLIA_CHAINID = '0x534e5f5345504f4c4941';
 
 export const TOKENS: any = {
-  [constants.StarknetChainId.MAINNET]: {
+  [constants.StarknetChainId.SN_MAIN]: {
     '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7': {
       coingeckoId: 'ethereum',
     },

--- a/packages/wallet-ui/src/utils/utils.ts
+++ b/packages/wallet-ui/src/utils/utils.ts
@@ -19,7 +19,7 @@ export const shortenAddress = (address: string, num = 3) => {
 export const openExplorerTab = (address: string, type = 'contract', chainId = SEPOLIA_CHAINID) => {
   let explorerUrl = STARKNET_SEPOLIA_TESTNET_EXPLORER;
   switch (chainId) {
-    case constants.StarknetChainId.MAINNET:
+    case constants.StarknetChainId.SN_MAIN:
       explorerUrl = STARKNET_MAINNET_EXPLORER;
       break;
     case SEPOLIA_CHAINID:


### PR DESCRIPTION
## Summary of changes : 

### Support for Transaction Versions:

- Addition of Transaction Version Parameter:
- Added transactionVersion to API request parameters and updated related type definitions in snapApi.
- Included transactionVersion in utility functions like getAccountInstance, estimateFee, estimateFeeBulk, and executeTxn.
- Conditional Handling Based on Transaction Version:
- Implemented logic to set fee token based on the transaction version (V2 for ETH, V3 for STRK).

### Enhanced Fee Token Management to support both V2 and V3 transaction :

- UI Components Adjustments:
- Added a dropdown for selecting the fee token (ETH or STRK) in the SendModal component.
- Adjusted the SendSummaryModal component to display and calculate fees based on the selected fee token.

### Code update details 

Modified functions like declareContract, estimateFee, estimateFees, executeTxn, and sendTransaction to incorporate and use the selected fee token.

###  Dependency Updates:

Upgraded starknet dependency from ^4.22.0 to 6.7.0 in wallet-ui package (required to get constants for TRANSACTION_VERSION)