### PR TITLE
fix: add cache key for different env in CICD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,7 +125,7 @@ jobs:
             ./packages/starknet-snap/dist
             ./packages/starknet-snap/snap.manifest.json
             ./node_modules/.yarn-state.yml
-          key: ${{ steps.prepare_parameters.outputs.CACHE_KEY }}
+          key: ${{ needs.prepare_parameters.outputs.CACHE_KEY }}
 
   publish-npm-dry-run:
     runs-on: ubuntu-latest
@@ -152,7 +152,7 @@ jobs:
             ./packages/starknet-snap/dist
             ./packages/starknet-snap/snap.manifest.json
             ./node_modules/.yarn-state.yml
-          key: ${{ steps.prepare_parameters.outputs.CACHE_KEY }}
+          key: ${{ needs.prepare_parameters.outputs.CACHE_KEY }}
       - name: Dry Run Publish
         run: |
           npm pack ./packages/starknet-snap --tag "$TAG" --access public
@@ -184,7 +184,7 @@ jobs:
             ./packages/starknet-snap/dist
             ./packages/starknet-snap/snap.manifest.json
             ./node_modules/.yarn-state.yml
-          key: ${{ steps.prepare_parameters.outputs.CACHE_KEY }}
+          key: ${{ needs.prepare_parameters.outputs.CACHE_KEY }}
       - name: Run Publish
         run: |
           npm publish ./packages/starknet-snap --tag "$TAG" --access public
@@ -218,7 +218,7 @@ jobs:
             ./packages/starknet-snap/dist
             ./packages/starknet-snap/snap.manifest.json
             ./node_modules/.yarn-state.yml
-          key: ${{ steps.prepare_parameters.outputs.CACHE_KEY }}
+          key: ${{ needs.prepare_parameters.outputs.CACHE_KEY }}
       - name: Deploy to AWS
         run: | 
           echo "Deployed Dapp to : $AWS_S3_URL"
@@ -252,7 +252,7 @@ jobs:
             ./packages/starknet-snap/dist
             ./packages/starknet-snap/snap.manifest.json
             ./node_modules/.yarn-state.yml
-          key: ${{ steps.prepare_parameters.outputs.CACHE_KEY }}
+          key: ${{ needs.prepare_parameters.outputs.CACHE_KEY }}
       - name: Deploy to AWS
         run: | 
           echo "Deployed get Starknet to : $AWS_S3_GET_STARKNET_URL"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,7 @@ jobs:
       AWS_CLOUDFRONT_DISTRIBUTIONS_ID: ${{ steps.prepare_parameters.outputs.AWS_CLOUDFRONT_DISTRIBUTIONS_ID }}
       AWS_S3_URL: ${{ steps.prepare_parameters.outputs.AWS_S3_URL }}
       GET_STARKNET_PUBLIC_PATH: ${{ steps.prepare_parameters.outputs.GET_STARKNET_PUBLIC_PATH }}
+      CACHE_KEY: ${{ github.sha }}-${{ steps.prepare_parameters.outputs.ENV }}
 
   install-build:
     needs: 
@@ -124,7 +125,7 @@ jobs:
             ./packages/starknet-snap/dist
             ./packages/starknet-snap/snap.manifest.json
             ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
+          key: ${{ steps.prepare_parameters.outputs.CACHE_KEY }}
 
   publish-npm-dry-run:
     runs-on: ubuntu-latest
@@ -151,7 +152,7 @@ jobs:
             ./packages/starknet-snap/dist
             ./packages/starknet-snap/snap.manifest.json
             ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
+          key: ${{ steps.prepare_parameters.outputs.CACHE_KEY }}
       - name: Dry Run Publish
         run: |
           npm pack ./packages/starknet-snap --tag "$TAG" --access public
@@ -183,7 +184,7 @@ jobs:
             ./packages/starknet-snap/dist
             ./packages/starknet-snap/snap.manifest.json
             ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
+          key: ${{ steps.prepare_parameters.outputs.CACHE_KEY }}
       - name: Run Publish
         run: |
           npm publish ./packages/starknet-snap --tag "$TAG" --access public
@@ -217,7 +218,7 @@ jobs:
             ./packages/starknet-snap/dist
             ./packages/starknet-snap/snap.manifest.json
             ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
+          key: ${{ steps.prepare_parameters.outputs.CACHE_KEY }}
       - name: Deploy to AWS
         run: | 
           echo "Deployed Dapp to : $AWS_S3_URL"
@@ -251,7 +252,7 @@ jobs:
             ./packages/starknet-snap/dist
             ./packages/starknet-snap/snap.manifest.json
             ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
+          key: ${{ steps.prepare_parameters.outputs.CACHE_KEY }}
       - name: Deploy to AWS
         run: | 
           echo "Deployed get Starknet to : $AWS_S3_GET_STARKNET_URL"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,7 +125,7 @@ jobs:
             ./packages/starknet-snap/dist
             ./packages/starknet-snap/snap.manifest.json
             ./node_modules/.yarn-state.yml
-          key: ${{ needs.prepare_parameters.outputs.CACHE_KEY }}
+          key: ${{ needs.prepare-deployment.outputs.CACHE_KEY }}
 
   publish-npm-dry-run:
     runs-on: ubuntu-latest
@@ -152,7 +152,7 @@ jobs:
             ./packages/starknet-snap/dist
             ./packages/starknet-snap/snap.manifest.json
             ./node_modules/.yarn-state.yml
-          key: ${{ needs.prepare_parameters.outputs.CACHE_KEY }}
+          key: ${{ needs.prepare-deployment.outputs.CACHE_KEY }}
       - name: Dry Run Publish
         run: |
           npm pack ./packages/starknet-snap --tag "$TAG" --access public
@@ -184,7 +184,7 @@ jobs:
             ./packages/starknet-snap/dist
             ./packages/starknet-snap/snap.manifest.json
             ./node_modules/.yarn-state.yml
-          key: ${{ needs.prepare_parameters.outputs.CACHE_KEY }}
+          key: ${{ needs.prepare-deployment.outputs.CACHE_KEY }}
       - name: Run Publish
         run: |
           npm publish ./packages/starknet-snap --tag "$TAG" --access public
@@ -218,7 +218,7 @@ jobs:
             ./packages/starknet-snap/dist
             ./packages/starknet-snap/snap.manifest.json
             ./node_modules/.yarn-state.yml
-          key: ${{ needs.prepare_parameters.outputs.CACHE_KEY }}
+          key: ${{ needs.prepare-deployment.outputs.CACHE_KEY }}
       - name: Deploy to AWS
         run: | 
           echo "Deployed Dapp to : $AWS_S3_URL"
@@ -252,7 +252,7 @@ jobs:
             ./packages/starknet-snap/dist
             ./packages/starknet-snap/snap.manifest.json
             ./node_modules/.yarn-state.yml
-          key: ${{ needs.prepare_parameters.outputs.CACHE_KEY }}
+          key: ${{ needs.prepare-deployment.outputs.CACHE_KEY }}
       - name: Deploy to AWS
         run: | 
           echo "Deployed get Starknet to : $AWS_S3_GET_STARKNET_URL"


### PR DESCRIPTION
This PR is to fix a bug in the CICD pipeline when processiong “Deployments" workflow

if the same commit point deploy twice in different env, the latter deploy code will reuse the build from prev build from a cache, and lead to incorrect deployment

solution:
adding the cache with key `commit sha + '-' + env`

jira: https://consensyssoftware.atlassian.net/jira/software/projects/SF/boards/472?selectedIssue=SF-651