### PR TITLE
fix: eip 6963 detection on wallet-ui

### DIFF
--- a/packages/wallet-ui/src/hooks/useHasMetamask.ts
+++ b/packages/wallet-ui/src/hooks/useHasMetamask.ts
@@ -87,10 +87,8 @@ export const useHasMetamask = () => {
         // Use the new detection method
 
         if (provider && (await isSupportSnap(provider))) {
-          window.ethereum = provider;
           dispatch(setProvider(provider));
           setHasMetamask(provider != null);
-          return window.ethereum;
         } else {
           dispatch(setProvider(null));
           setHasMetamask(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3176,7 +3176,7 @@ __metadata:
 
 "@consensys/starknet-snap@file:../starknet-snap::locator=wallet-ui%40workspace%3Apackages%2Fwallet-ui":
   version: 2.8.0
-  resolution: "@consensys/starknet-snap@file:../starknet-snap#../starknet-snap::hash=511eed&locator=wallet-ui%40workspace%3Apackages%2Fwallet-ui"
+  resolution: "@consensys/starknet-snap@file:../starknet-snap#../starknet-snap::hash=7bbefb&locator=wallet-ui%40workspace%3Apackages%2Fwallet-ui"
   dependencies:
     "@metamask/key-tree": 9.0.0
     "@metamask/snaps-sdk": ^4.0.0
@@ -3185,7 +3185,7 @@ __metadata:
     ethers: ^5.5.1
     starknet: 6.7.0
     starknet_v4.22.0: "npm:starknet@4.22.0"
-  checksum: 12c71045fd6bd5d137d51a9fb9a92b3aae206b7b1b1a036bd8fe4ddbf953d94967be56ecb170c4e871a30fa065ba64571dca714180522b89b5a9bf4cc6476b41
+  checksum: 1b61bb3753a444b81cd7a45acdc1e016c8e44e5a8b5528ce0d6832ec93e1b6a371985696a7f2a27f95df27f8b5b4afb4a74f4ab2eee84fb377e77da7b99e4694
   languageName: node
   linkType: hard
 
@@ -4828,13 +4828,6 @@ __metadata:
     eth-ens-namehash: ^2.0.8
     fast-deep-equal: ^3.1.3
   checksum: ce77d9006c34109d78787d91036b605c2e401f51bae58a60cfd955905ebd63ebe5a007b93861a1fcc51bb7e57b69ec2a6dd6142656c1ee2d87d74e397752dffa
-  languageName: node
-  linkType: hard
-
-"@metamask/detect-provider@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@metamask/detect-provider@npm:1.2.0"
-  checksum: 2c152534a8dd15bc1430bb5159cdf58993549a644cff344a1ff43f4ede8f041aad72b909e822747f6545de3ed293a740ecffc86a859daf7a925c4096efd61eb3
   languageName: node
   linkType: hard
 
@@ -27244,7 +27237,6 @@ __metadata:
     "@fortawesome/free-solid-svg-icons": ^6.1.1
     "@fortawesome/react-fontawesome": ^0.1.18
     "@headlessui/react": ^1.6.4
-    "@metamask/detect-provider": ^1.2.0
     "@metamask/jazzicon": "github:metamask/jazzicon#d923914fda6a8795f74c2e66134f73cd72070667"
     "@mui/icons-material": ^5.6.2
     "@mui/material": ^5.6.2


### PR DESCRIPTION
This PR includes updates to the MetaMask detection logic and the removal of legacy MetaMask Flask support:

1. **Updates to `useHasMetamask.ts`:**
   - Added import for `EIP6963ProviderDetail` and `eip6963RequestProvider` from `@metamask/providers`.
   - Updated the `useEffect` hook to use the new detection method (`eip6963RequestProvider`) for checking if MetaMask is installed.
   - Modified `detectMetamask` to return a `Promise<EIP6963ProviderDetail | null>` using the new detection method.
   - Added a fallback to the legacy detection method (`detectMetamaskLegacy`) to ensure compatibility.
   - Replaced the previous `detectMetamask` function with `detectMetamaskLegacy` to handle the legacy detection process.
   - Cleaned up the `getProvider` function by removing commented lines and refining provider detection logic.

2. **Removal of `useHasMetamaskFlask.ts`:**
   - Deleted the file `useHasMetamaskFlask.ts`, which contained logic for detecting MetaMask Flask. This removal indicates that Flask-specific logic is no longer necessary due to updates in MetaMask's support for Snaps.
