### PR TITLE
fix: get balance should check on pending block

### DIFF
--- a/packages/starknet-snap/src/getErc20TokenBalance.ts
+++ b/packages/starknet-snap/src/getErc20TokenBalance.ts
@@ -35,7 +35,13 @@ export async function getErc20TokenBalance(params: ApiParams) {
 
     logger.log(`getErc20Balance:\nerc20Address: ${erc20Address}\nuserAddress: ${userAddress}`);
 
-    const resp = await callContract(network, erc20Address, 'balanceOf', [num.toBigInt(userAddress).toString(10)]);
+    const resp = await callContract(
+      network,
+      erc20Address,
+      'balanceOf',
+      [num.toBigInt(userAddress).toString(10)],
+      'pending',
+    );
 
     logger.log(`getErc20Balance:\nresp: ${toJson(resp)}`);
 

--- a/packages/starknet-snap/src/utils/starknetUtils.ts
+++ b/packages/starknet-snap/src/utils/starknetUtils.ts
@@ -36,6 +36,7 @@ import {
   ProviderInterface,
   GetTransactionReceiptResponse,
   BigNumberish,
+  BlockIdentifier,
 } from 'starknet';
 import { Network, SnapState, Transaction, TransactionType } from '../types/snapState';
 import {
@@ -94,15 +95,19 @@ export const callContract = async (
   contractAddress: string,
   contractFuncName: string,
   contractCallData: RawCalldata = [],
+  blockIdentifier?: BlockIdentifier,
 ): Promise<CallContractResponse> => {
   const provider = getProvider(network);
+  if (!blockIdentifier) {
+    blockIdentifier = 'latest';
+  }
   return provider.callContract(
     {
       contractAddress,
       entrypoint: contractFuncName,
       calldata: contractCallData,
     },
-    'latest',
+    blockIdentifier,
   );
 };
 


### PR DESCRIPTION
In order for the balance to be in sync we need to read it from pending block instead of latest.