### PR TITLE
refactor: add snap utils tool

### DIFF
--- a/packages/starknet-snap/src/utils/snap.test.ts
+++ b/packages/starknet-snap/src/utils/snap.test.ts
@@ -1,0 +1,101 @@
+import type { Component } from '@metamask/snaps-sdk';
+import { heading, panel, text, divider, row } from '@metamask/snaps-sdk';
+
+import * as snapUtil from './snap';
+
+jest.mock('@metamask/key-tree', () => ({
+  getBIP44AddressKeyDeriver: jest.fn(),
+}));
+
+describe('getBip44Deriver', () => {
+  it('gets bip44 deriver', async () => {
+    const spy = jest.spyOn(snapUtil.getProvider(), 'request');
+
+    await snapUtil.getBip44Deriver();
+
+    expect(spy).toHaveBeenCalledWith({
+      method: 'snap_getBip44Entropy',
+      params: {
+        coinType: 9004,
+      },
+    });
+  });
+});
+
+describe('confirmDialog', () => {
+  it('calls snap_dialog', async () => {
+    const spy = jest.spyOn(snapUtil.getProvider(), 'request');
+    const components: Component[] = [
+      heading('header'),
+      text('subHeader'),
+      divider(),
+      row('Label1', text('Value1')),
+      text('**Label2**:'),
+      row('SubLabel1', text('SubValue1')),
+    ];
+
+    await snapUtil.confirmDialog(components);
+
+    expect(spy).toHaveBeenCalledWith({
+      method: 'snap_dialog',
+      params: {
+        type: 'confirmation',
+        content: panel(components),
+      },
+    });
+  });
+});
+
+describe('getStateData', () => {
+  it('gets state data', async () => {
+    const spy = jest.spyOn(snapUtil.getProvider(), 'request');
+    const testcase = {
+      state: {
+        transaction: [
+          {
+            txHash: 'hash',
+            chainId: 'chainId',
+          },
+        ],
+      },
+    };
+
+    spy.mockResolvedValue(testcase.state);
+    const result = await snapUtil.getStateData();
+
+    expect(spy).toHaveBeenCalledWith({
+      method: 'snap_manageState',
+      params: {
+        operation: 'get',
+      },
+    });
+
+    expect(result).toStrictEqual(testcase.state);
+  });
+});
+
+describe('setStateData', () => {
+  it('sets state data', async () => {
+    const spy = jest.spyOn(snapUtil.getProvider(), 'request');
+    const testcase = {
+      state: {
+        transaction: [
+          {
+            txHash: 'hash',
+            chainId: 'chainId',
+          },
+        ],
+      },
+    };
+
+    await snapUtil.setStateData(testcase.state);
+
+    expect(spy).toHaveBeenCalledWith({
+      method: 'snap_manageState',
+      params: {
+        operation: 'update',
+        newState: testcase.state,
+      },
+    });
+  });
+});

--- a/packages/starknet-snap/src/utils/snap.ts
+++ b/packages/starknet-snap/src/utils/snap.ts
@@ -1,0 +1,77 @@
+import type { BIP44AddressKeyDeriver } from '@metamask/key-tree';
+import { getBIP44AddressKeyDeriver } from '@metamask/key-tree';
+import type { Component, DialogResult, Json } from '@metamask/snaps-sdk';
+import { panel, type SnapsProvider } from '@metamask/snaps-sdk';
+
+declare const snap: SnapsProvider;
+
+/**
+ * Retrieves the current SnapsProvider.
+ *
+ * @returns The current SnapsProvider.
+ */
+export function getProvider(): SnapsProvider {
+  return snap;
+}
+
+/**
+ * Retrieves a BIP44AddressKeyDeriver object.
+ *
+ * @returns A Promise that resolves to a BIP44AddressKeyDeriver object.
+ */
+export async function getBip44Deriver(): Promise<BIP44AddressKeyDeriver> {
+  const bip44Node = await snap.request({
+    method: 'snap_getBip44Entropy',
+    params: {
+      coinType: 9004,
+    },
+  });
+  return getBIP44AddressKeyDeriver(bip44Node);
+}
+
+/**
+ * Displays a confirmation dialog with the specified components.
+ *
+ * @param components - An array of components to display in the dialog.
+ * @returns A Promise that resolves to the result of the dialog.
+ */
+export async function confirmDialog(
+  components: Component[],
+): Promise<DialogResult> {
+  return snap.request({
+    method: 'snap_dialog',
+    params: {
+      type: 'confirmation',
+      content: panel(components),
+    },
+  });
+}
+
+/**
+ * Retrieves the current state data.
+ *
+ * @returns A Promise that resolves to the current state data.
+ */
+export async function getStateData<State>(): Promise<State> {
+  return (await snap.request({
+    method: 'snap_manageState',
+    params: {
+      operation: 'get',
+    },
+  })) as unknown as State;
+}
+
+/**
+ * Sets the current state data to the specified data.
+ *
+ * @param data - The new state data to set.
+ */
+export async function setStateData<State>(data: State) {
+  await snap.request({
+    method: 'snap_manageState',
+    params: {
+      operation: 'update',
+      newState: data as unknown as Record<string, Json>,
+    },
+  });
+}


### PR DESCRIPTION
This PR is to add a snap utils tool to group the snap necessary function (not apply to the code base yet)

it constains
- getBip44Deriver : A method to request snap_getBip44Entropy
- confirmDialog: A method to request confirm dialog
- getStateData: A method to retrieves the current state data
- setStateData: A method to sets the current state data to the specified data.