### PR TITLE
refactor: add error utils

### DIFF
--- a/packages/starknet-snap/src/utils/error.test.ts
+++ b/packages/starknet-snap/src/utils/error.test.ts
@@ -18,17 +18,7 @@ import {
   SnapError,
 } from '@metamask/snaps-sdk';
 
-import { CustomError, isSnapRpcError } from './error';
-
-describe('CustomError', () => {
-  it('creates a custom error', () => {
-    const customError = new CustomError('custom error message');
-    expect(customError).toBeInstanceOf(Error);
-    expect(customError).toBeInstanceOf(CustomError);
-    expect(customError.message).toBe('custom error message');
-    expect(customError.name).toBe('CustomError');
-  });
-});
+import { isSnapRpcError } from './error';
 
 describe('isSnapRpcError', () => {
   it('returns true for a Snap RPC error', () => {

--- a/packages/starknet-snap/src/utils/error.test.ts
+++ b/packages/starknet-snap/src/utils/error.test.ts
@@ -1,0 +1,65 @@
+import {
+  MethodNotFoundError,
+  UserRejectedRequestError,
+  MethodNotSupportedError,
+  ParseError,
+  ResourceNotFoundError,
+  ResourceUnavailableError,
+  TransactionRejected,
+  ChainDisconnectedError,
+  DisconnectedError,
+  UnauthorizedError,
+  UnsupportedMethodError,
+  InternalError,
+  InvalidInputError,
+  InvalidParamsError,
+  InvalidRequestError,
+  LimitExceededError,
+  SnapError,
+} from '@metamask/snaps-sdk';
+
+import { CustomError, isSnapRpcError } from './error';
+
+describe('CustomError', () => {
+  it('creates a custom error', () => {
+    const customError = new CustomError('custom error message');
+    expect(customError).toBeInstanceOf(Error);
+    expect(customError).toBeInstanceOf(CustomError);
+    expect(customError.message).toBe('custom error message');
+    expect(customError.name).toBe('CustomError');
+  });
+});
+
+describe('isSnapRpcError', () => {
+  it('returns true for a Snap RPC error', () => {
+    const snapErrors = [
+      SnapError,
+      MethodNotFoundError,
+      UserRejectedRequestError,
+      MethodNotSupportedError,
+      ParseError,
+      ResourceNotFoundError,
+      ResourceUnavailableError,
+      TransactionRejected,
+      ChainDisconnectedError,
+      DisconnectedError,
+      UnauthorizedError,
+      UnsupportedMethodError,
+      InternalError,
+      InvalidInputError,
+      InvalidParamsError,
+      InvalidRequestError,
+      LimitExceededError,
+    ];
+
+    for (const ErrorCtor of snapErrors) {
+      const error = new ErrorCtor('snap error message');
+      expect(isSnapRpcError(error)).toBe(true);
+    }
+  });
+
+  it('returns false for a non-Snap RPC error', () => {
+    const error = new Error('error message');
+    expect(isSnapRpcError(error)).toBe(false);
+  });
+});

--- a/packages/starknet-snap/src/utils/error.ts
+++ b/packages/starknet-snap/src/utils/error.ts
@@ -18,30 +18,6 @@ import {
   SnapError,
 } from '@metamask/snaps-sdk';
 
-export class CustomError extends Error {
-  name!: string;
-
-  constructor(message: string) {
-    super(message);
-
-    // set error name as constructor name, make it not enumerable to keep native Error behavior
-    // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target#new.target_in_constructors
-    // see https://github.com/adriengibrat/ts-custom-error/issues/30
-    Object.defineProperty(this, 'name', {
-      value: new.target.name,
-      enumerable: false,
-      configurable: true,
-    });
-
-    // fix the extended error prototype chain
-    // because typescript __extends implementation can't
-    // see https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
-    Object.setPrototypeOf(this, new.target.prototype);
-    // remove constructor from stack trace
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
-
 /**
  * Determines if the given error is a Snap RPC error.
  *

--- a/packages/starknet-snap/src/utils/error.ts
+++ b/packages/starknet-snap/src/utils/error.ts
@@ -1,0 +1,90 @@
+import {
+  MethodNotFoundError,
+  UserRejectedRequestError,
+  MethodNotSupportedError,
+  ParseError,
+  ResourceNotFoundError,
+  ResourceUnavailableError,
+  TransactionRejected,
+  ChainDisconnectedError,
+  DisconnectedError,
+  UnauthorizedError,
+  UnsupportedMethodError,
+  InternalError,
+  InvalidInputError,
+  InvalidParamsError,
+  InvalidRequestError,
+  LimitExceededError,
+  SnapError,
+} from '@metamask/snaps-sdk';
+
+export class CustomError extends Error {
+  name!: string;
+
+  constructor(message: string) {
+    super(message);
+
+    // set error name as constructor name, make it not enumerable to keep native Error behavior
+    // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target#new.target_in_constructors
+    // see https://github.com/adriengibrat/ts-custom-error/issues/30
+    Object.defineProperty(this, 'name', {
+      value: new.target.name,
+      enumerable: false,
+      configurable: true,
+    });
+
+    // fix the extended error prototype chain
+    // because typescript __extends implementation can't
+    // see https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, new.target.prototype);
+    // remove constructor from stack trace
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+/**
+ * Compacts an error to a specific error instance.
+ *
+ * @param error - The error instance to be compacted.
+ * @param ErrCtor - The error constructor for the desired error instance.
+ * @returns The compacted error instance.
+ */
+export function compactError<ErrorInstance extends Error>(
+  error: ErrorInstance,
+  ErrCtor: new (message?: string) => ErrorInstance,
+): ErrorInstance {
+  if (error instanceof ErrCtor) {
+    return error;
+  }
+  return new ErrCtor(error.message);
+}
+
+/**
+ * Determines if the given error is a Snap RPC error.
+ *
+ * @param error - The error instance to be checked.
+ * @returns A boolean indicating whether the error is a Snap RPC error.
+ */
+export function isSnapRpcError(error: Error): boolean {
+  const errors = [
+    SnapError,
+    MethodNotFoundError,
+    UserRejectedRequestError,
+    MethodNotSupportedError,
+    MethodNotFoundError,
+    ParseError,
+    ResourceNotFoundError,
+    ResourceUnavailableError,
+    TransactionRejected,
+    ChainDisconnectedError,
+    DisconnectedError,
+    UnauthorizedError,
+    UnsupportedMethodError,
+    InternalError,
+    InvalidInputError,
+    InvalidParamsError,
+    InvalidRequestError,
+    LimitExceededError,
+  ];
+  return errors.some((errType) => error instanceof errType);
+}

--- a/packages/starknet-snap/src/utils/error.ts
+++ b/packages/starknet-snap/src/utils/error.ts
@@ -43,23 +43,6 @@ export class CustomError extends Error {
 }
 
 /**
- * Compacts an error to a specific error instance.
- *
- * @param error - The error instance to be compacted.
- * @param ErrCtor - The error constructor for the desired error instance.
- * @returns The compacted error instance.
- */
-export function compactError<ErrorInstance extends Error>(
-  error: ErrorInstance,
-  ErrCtor: new (message?: string) => ErrorInstance,
-): ErrorInstance {
-  if (error instanceof ErrCtor) {
-    return error;
-  }
-  return new ErrCtor(error.message);
-}
-
-/**
  * Determines if the given error is a Snap RPC error.
  *
  * @param error - The error instance to be checked.
@@ -71,7 +54,6 @@ export function isSnapRpcError(error: Error): boolean {
     MethodNotFoundError,
     UserRejectedRequestError,
     MethodNotSupportedError,
-    MethodNotFoundError,
     ParseError,
     ResourceNotFoundError,
     ResourceUnavailableError,


### PR DESCRIPTION
This PR is to add an error utils to check if the error is an Snap Error

This PR can be combine to use with this  PR https://github.com/Consensys/starknet-snap/pull/305 
When validate request is throwing an Snap Error, and we should not hide the validation error by checking if the error is an snap error or not 

possible use case
```
try {
   validateRequest(params, struct)
} catch (error) {
   if (isSnapRpcError(error) {
       throw error
   }
   throw new SnapError('masked error message')
}
```

