### PR TITLE
refactor: add mock for snap helper

### DIFF
--- a/packages/starknet-snap/src/utils/__mocks__/snap.ts
+++ b/packages/starknet-snap/src/utils/__mocks__/snap.ts
@@ -1,0 +1,9 @@
+export const getProvider = jest.fn();
+
+export const getBip44Deriver = jest.fn();
+
+export const confirmDialog = jest.fn();
+
+export const getStateData = jest.fn();
+
+export const setStateData = jest.fn();


### PR DESCRIPTION
This PR is to add mocking for snap helper `./utils/snap.ts` for future unit test purpose 