### PR TITLE
refactor: add `verifyIfAccountNeedUpgradeOrDeploy` method to group the account deploy or upgrade required validation logic

### DIFF
--- a/packages/starknet-snap/src/declareContract.ts
+++ b/packages/starknet-snap/src/declareContract.ts
@@ -9,12 +9,11 @@ import { toJson } from './utils/serializer';
 import {
   getNetworkFromChainId,
   getDeclareSnapTxt,
-  showAccountRequireUpgradeOrDeployModal,
+  verifyIfAccountNeedUpgradeOrDeploy,
 } from './utils/snapUtils';
 import {
   getKeysFromAddress,
   declareContract as declareContractUtil,
-  validateAccountRequireUpgradeOrDeploy,
 } from './utils/starknetUtils';
 
 /**
@@ -38,16 +37,7 @@ export async function declareContract(params: ApiParamsWithKeyDeriver) {
       senderAddress,
     );
 
-    try {
-      await validateAccountRequireUpgradeOrDeploy(
-        network,
-        senderAddress,
-        publicKey,
-      );
-    } catch (validateError) {
-      await showAccountRequireUpgradeOrDeployModal(wallet, validateError);
-      throw validateError;
-    }
+    await verifyIfAccountNeedUpgradeOrDeploy(network, senderAddress, publicKey);
 
     const snapComponents = getDeclareSnapTxt(
       senderAddress,

--- a/packages/starknet-snap/src/estimateFee.ts
+++ b/packages/starknet-snap/src/estimateFee.ts
@@ -8,9 +8,11 @@ import type {
 import { ACCOUNT_CLASS_HASH } from './utils/constants';
 import { logger } from './utils/logger';
 import { toJson } from './utils/serializer';
-import { getNetworkFromChainId } from './utils/snapUtils';
 import {
-  validateAccountRequireUpgradeOrDeploy,
+  getNetworkFromChainId,
+  verifyIfAccountNeedUpgradeOrDeploy,
+} from './utils/snapUtils';
+import {
   validateAndParseAddress,
   getKeysFromAddress,
   getCallDataArray,
@@ -64,10 +66,11 @@ export async function estimateFee(params: ApiParamsWithKeyDeriver) {
     const { privateKey: senderPrivateKey, publicKey } =
       await getKeysFromAddress(keyDeriver, network, state, senderAddress);
 
-    await validateAccountRequireUpgradeOrDeploy(
+    await verifyIfAccountNeedUpgradeOrDeploy(
       network,
       senderAddress,
       publicKey,
+      false,
     );
 
     const txnInvocation = {

--- a/packages/starknet-snap/src/executeTxn.ts
+++ b/packages/starknet-snap/src/executeTxn.ts
@@ -14,7 +14,7 @@ import {
   getNetworkFromChainId,
   getTxnSnapTxt,
   addDialogTxt,
-  showAccountRequireUpgradeOrDeployModal,
+  verifyIfAccountNeedUpgradeOrDeploy,
 } from './utils/snapUtils';
 import {
   getKeysFromAddress,
@@ -23,7 +23,6 @@ import {
   estimateFeeBulk,
   getAccContractAddressAndCallData,
   addFeesFromAllTransactions,
-  validateAccountRequireUpgradeOrDeploy,
 } from './utils/starknetUtils';
 
 /**
@@ -42,16 +41,7 @@ export async function executeTxn(params: ApiParamsWithKeyDeriver) {
       addressIndex,
     } = await getKeysFromAddress(keyDeriver, network, state, senderAddress);
 
-    try {
-      await validateAccountRequireUpgradeOrDeploy(
-        network,
-        senderAddress,
-        publicKey,
-      );
-    } catch (validateError) {
-      await showAccountRequireUpgradeOrDeployModal(wallet, validateError);
-      throw validateError;
-    }
+    await verifyIfAccountNeedUpgradeOrDeploy(network, senderAddress, publicKey);
 
     const txnInvocationArray = Array.isArray(requestParamsObj.txnInvocation)
       ? requestParamsObj.txnInvocation

--- a/packages/starknet-snap/src/extractPrivateKey.ts
+++ b/packages/starknet-snap/src/extractPrivateKey.ts
@@ -6,13 +6,14 @@ import type {
 } from './types/snapApi';
 import { logger } from './utils/logger';
 import { toJson } from './utils/serializer';
-import { getNetworkFromChainId } from './utils/snapUtils';
+import {
+  getNetworkFromChainId,
+  verifyIfAccountNeedUpgradeOrDeploy,
+} from './utils/snapUtils';
 import {
   validateAndParseAddress,
   getKeysFromAddress,
-  validateAccountRequireUpgradeOrDeploy,
 } from './utils/starknetUtils';
-
 /**
  *
  * @param params
@@ -43,10 +44,12 @@ export async function extractPrivateKey(params: ApiParamsWithKeyDeriver) {
       state,
       userAddress,
     );
-    await validateAccountRequireUpgradeOrDeploy(
+
+    await verifyIfAccountNeedUpgradeOrDeploy(
       network,
       userAddress,
       publicKey,
+      false,
     );
 
     const response = await wallet.request({

--- a/packages/starknet-snap/src/extractPublicKey.ts
+++ b/packages/starknet-snap/src/extractPublicKey.ts
@@ -6,10 +6,13 @@ import type {
 } from './types/snapApi';
 import { logger } from './utils/logger';
 import { toJson } from './utils/serializer';
-import { getAccount, getNetworkFromChainId } from './utils/snapUtils';
+import {
+  getAccount,
+  getNetworkFromChainId,
+  verifyIfAccountNeedUpgradeOrDeploy,
+} from './utils/snapUtils';
 import {
   validateAndParseAddress,
-  validateAccountRequireUpgradeOrDeploy,
   getKeysFromAddress,
 } from './utils/starknetUtils';
 
@@ -48,10 +51,12 @@ export async function extractPublicKey(params: ApiParamsWithKeyDeriver) {
       state,
       userAddress,
     );
-    await validateAccountRequireUpgradeOrDeploy(
+
+    await verifyIfAccountNeedUpgradeOrDeploy(
       network,
       userAddress,
       publicKey,
+      false,
     );
 
     let userPublicKey;

--- a/packages/starknet-snap/src/signDeclareTransaction.ts
+++ b/packages/starknet-snap/src/signDeclareTransaction.ts
@@ -10,12 +10,11 @@ import { toJson } from './utils/serializer';
 import {
   getNetworkFromChainId,
   getSignTxnTxt,
-  showAccountRequireUpgradeOrDeployModal,
+  verifyIfAccountNeedUpgradeOrDeploy,
 } from './utils/snapUtils';
 import {
   getKeysFromAddress,
   signDeclareTransaction as signDeclareTransactionUtil,
-  validateAccountRequireUpgradeOrDeploy,
 } from './utils/starknetUtils';
 
 /**
@@ -38,16 +37,7 @@ export async function signDeclareTransaction(
       signerAddress,
     );
 
-    try {
-      await validateAccountRequireUpgradeOrDeploy(
-        network,
-        signerAddress,
-        publicKey,
-      );
-    } catch (validateError) {
-      await showAccountRequireUpgradeOrDeployModal(wallet, validateError);
-      throw validateError;
-    }
+    await verifyIfAccountNeedUpgradeOrDeploy(network, signerAddress, publicKey);
 
     logger.log(
       `signDeclareTransaction params: ${toJson(

--- a/packages/starknet-snap/src/signDeployAccountTransaction.ts
+++ b/packages/starknet-snap/src/signDeployAccountTransaction.ts
@@ -10,12 +10,11 @@ import { toJson } from './utils/serializer';
 import {
   getNetworkFromChainId,
   getSignTxnTxt,
-  showAccountRequireUpgradeOrDeployModal,
+  verifyIfAccountNeedUpgradeOrDeploy,
 } from './utils/snapUtils';
 import {
   getKeysFromAddress,
   signDeployAccountTransaction as signDeployAccountTransactionUtil,
-  validateAccountRequireUpgradeOrDeploy,
 } from './utils/starknetUtils';
 
 /**
@@ -38,16 +37,7 @@ export async function signDeployAccountTransaction(
       signerAddress,
     );
 
-    try {
-      await validateAccountRequireUpgradeOrDeploy(
-        network,
-        signerAddress,
-        publicKey,
-      );
-    } catch (validateError) {
-      await showAccountRequireUpgradeOrDeployModal(wallet, validateError);
-      throw validateError;
-    }
+    await verifyIfAccountNeedUpgradeOrDeploy(network, signerAddress, publicKey);
 
     logger.log(
       `signDeployAccountTransaction params: ${toJson(

--- a/packages/starknet-snap/src/signMessage.ts
+++ b/packages/starknet-snap/src/signMessage.ts
@@ -9,13 +9,12 @@ import { toJson } from './utils/serializer';
 import {
   getNetworkFromChainId,
   addDialogTxt,
-  showAccountRequireUpgradeOrDeployModal,
+  verifyIfAccountNeedUpgradeOrDeploy,
 } from './utils/snapUtils';
 import {
   signMessage as signMessageUtil,
   getKeysFromAddress,
   validateAndParseAddress,
-  validateAccountRequireUpgradeOrDeploy,
 } from './utils/starknetUtils';
 
 /**
@@ -52,16 +51,7 @@ export async function signMessage(params: ApiParamsWithKeyDeriver) {
       );
     }
 
-    try {
-      await validateAccountRequireUpgradeOrDeploy(
-        network,
-        signerAddress,
-        publicKey,
-      );
-    } catch (validateError) {
-      await showAccountRequireUpgradeOrDeployModal(wallet, validateError);
-      throw validateError;
-    }
+    await verifyIfAccountNeedUpgradeOrDeploy(network, signerAddress, publicKey);
 
     const components = [];
     addDialogTxt(components, 'Message', toJson(typedDataMessage));

--- a/packages/starknet-snap/src/signTransaction.ts
+++ b/packages/starknet-snap/src/signTransaction.ts
@@ -10,13 +10,9 @@ import { toJson } from './utils/serializer';
 import {
   getNetworkFromChainId,
   getSignTxnTxt,
-  showAccountRequireUpgradeOrDeployModal,
+  verifyIfAccountNeedUpgradeOrDeploy,
 } from './utils/snapUtils';
-import {
-  getKeysFromAddress,
-  signTransactions,
-  validateAccountRequireUpgradeOrDeploy,
-} from './utils/starknetUtils';
+import { getKeysFromAddress, signTransactions } from './utils/starknetUtils';
 
 /**
  *
@@ -37,16 +33,7 @@ export async function signTransaction(
       signerAddress,
     );
 
-    try {
-      await validateAccountRequireUpgradeOrDeploy(
-        network,
-        signerAddress,
-        publicKey,
-      );
-    } catch (validateError) {
-      await showAccountRequireUpgradeOrDeployModal(wallet, validateError);
-      throw validateError;
-    }
+    await verifyIfAccountNeedUpgradeOrDeploy(network, signerAddress, publicKey);
 
     logger.log(
       `signTransaction params: ${toJson(requestParamsObj.transactions, 2)}}`,

--- a/packages/starknet-snap/src/utils/__mocks__/snap.ts
+++ b/packages/starknet-snap/src/utils/__mocks__/snap.ts
@@ -4,6 +4,8 @@ export const getBip44Deriver = jest.fn();
 
 export const confirmDialog = jest.fn();
 
+export const alertDialog = jest.fn();
+
 export const getStateData = jest.fn();
 
 export const setStateData = jest.fn();

--- a/packages/starknet-snap/src/utils/exceptions.ts
+++ b/packages/starknet-snap/src/utils/exceptions.ts
@@ -1,3 +1,17 @@
-export class UpgradeRequiredError extends Error {}
+import { SnapError } from '@metamask/snaps-sdk';
 
-export class DeployRequiredError extends Error {}
+// Extend SnapError to allow error message visible to client
+export class UpgradeRequiredError extends SnapError {
+  constructor(message?: string) {
+    super(message ?? 'Upgrade required');
+  }
+}
+
+export class DeployRequiredError extends SnapError {
+  constructor(message?: string) {
+    super(
+      message ??
+        'Cairo 0 contract address balance is not empty, deploy required',
+    );
+  }
+}

--- a/packages/starknet-snap/src/utils/snap.test.ts
+++ b/packages/starknet-snap/src/utils/snap.test.ts
@@ -46,6 +46,30 @@ describe('confirmDialog', () => {
   });
 });
 
+describe('alertDialog', () => {
+  it('calls snap_dialog', async () => {
+    const spy = jest.spyOn(snapUtil.getProvider(), 'request');
+    const components: Component[] = [
+      heading('header'),
+      text('subHeader'),
+      divider(),
+      row('Label1', text('Value1')),
+      text('**Label2**:'),
+      row('SubLabel1', text('SubValue1')),
+    ];
+
+    await snapUtil.alertDialog(components);
+
+    expect(spy).toHaveBeenCalledWith({
+      method: 'snap_dialog',
+      params: {
+        type: 'alert',
+        content: panel(components),
+      },
+    });
+  });
+});
+
 describe('getStateData', () => {
   it('gets state data', async () => {
     const spy = jest.spyOn(snapUtil.getProvider(), 'request');

--- a/packages/starknet-snap/src/utils/snap.ts
+++ b/packages/starknet-snap/src/utils/snap.ts
@@ -1,7 +1,7 @@
 import type { BIP44AddressKeyDeriver } from '@metamask/key-tree';
 import { getBIP44AddressKeyDeriver } from '@metamask/key-tree';
 import type { Component, DialogResult, Json } from '@metamask/snaps-sdk';
-import { panel, type SnapsProvider } from '@metamask/snaps-sdk';
+import { DialogType, panel, type SnapsProvider } from '@metamask/snaps-sdk';
 
 declare const snap: SnapsProvider;
 
@@ -41,7 +41,25 @@ export async function confirmDialog(
   return snap.request({
     method: 'snap_dialog',
     params: {
-      type: 'confirmation',
+      type: DialogType.Confirmation,
+      content: panel(components),
+    },
+  });
+}
+
+/**
+ * Displays a alert dialog with the specified components.
+ *
+ * @param components - An array of components to display in the dialog.
+ * @returns A Promise that resolves to the result of the dialog.
+ */
+export async function alertDialog(
+  components: Component[],
+): Promise<DialogResult> {
+  return snap.request({
+    method: 'snap_dialog',
+    params: {
+      type: DialogType.Alert,
       content: panel(components),
     },
   });

--- a/packages/starknet-snap/src/utils/snapUtils.test.ts
+++ b/packages/starknet-snap/src/utils/snapUtils.test.ts
@@ -1,0 +1,131 @@
+import { constants } from 'starknet';
+
+import { generateAccounts } from '../../test/utils';
+import { STARKNET_SEPOLIA_TESTNET_NETWORK } from './constants';
+import { DeployRequiredError, UpgradeRequiredError } from './exceptions';
+import * as snapHelper from './snap';
+import { verifyIfAccountNeedUpgradeOrDeploy } from './snapUtils';
+import * as starknetUtils from './starknetUtils';
+
+jest.mock('./snap');
+jest.mock('./logger');
+
+describe('verifyIfAccountNeedUpgradeOrDeploy', () => {
+  const network = STARKNET_SEPOLIA_TESTNET_NETWORK;
+
+  const mockAcccount = async () => {
+    const accounts = await generateAccounts(
+      constants.StarknetChainId.SN_SEPOLIA,
+      1,
+    );
+    return accounts[0];
+  };
+
+  const prepareMock = () => {
+    const verifyIfAccountNeedUpgradeOrDeploySpy = jest.spyOn(
+      starknetUtils,
+      'validateAccountRequireUpgradeOrDeploy',
+    );
+
+    const alertDialogSpy = jest.spyOn(snapHelper, 'alertDialog');
+
+    verifyIfAccountNeedUpgradeOrDeploySpy.mockReturnThis();
+    alertDialogSpy.mockReturnThis();
+
+    return {
+      verifyIfAccountNeedUpgradeOrDeploySpy,
+      alertDialogSpy,
+    };
+  };
+
+  it('does not throw error if the account does not required to upgrade or deploy', async () => {
+    const account = await mockAcccount();
+    const { alertDialogSpy } = prepareMock();
+
+    await verifyIfAccountNeedUpgradeOrDeploy(
+      network,
+      account.address,
+      account.publicKey,
+    );
+
+    expect(alertDialogSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      action: 'upgrade',
+      error: new UpgradeRequiredError(),
+    },
+    {
+      action: 'deploy',
+      error: new DeployRequiredError(),
+    },
+  ])(
+    'throws error but does not render alert dialog if the account required $action and `showAlert` is false',
+    async (testData: { error: Error }) => {
+      const account = await mockAcccount();
+      const { verifyIfAccountNeedUpgradeOrDeploySpy, alertDialogSpy } =
+        prepareMock();
+      verifyIfAccountNeedUpgradeOrDeploySpy.mockRejectedValue(testData.error);
+
+      await expect(
+        verifyIfAccountNeedUpgradeOrDeploy(
+          network,
+          account.address,
+          account.publicKey,
+          false,
+        ),
+      ).rejects.toThrow(testData.error);
+
+      expect(alertDialogSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it('throws error and does not render alert dialog if the error is not either UpgradeRequiredError or DeployRequiredError', async () => {
+    const account = await mockAcccount();
+    const { verifyIfAccountNeedUpgradeOrDeploySpy } = prepareMock();
+    verifyIfAccountNeedUpgradeOrDeploySpy.mockRejectedValue(
+      new Error('Internal Error'),
+    );
+
+    await expect(
+      verifyIfAccountNeedUpgradeOrDeploy(
+        network,
+        account.address,
+        account.publicKey,
+      ),
+    ).rejects.toThrow('Internal Error');
+
+    expect(snapHelper.alertDialog).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      action: 'upgrade',
+      error: new UpgradeRequiredError(),
+    },
+    {
+      action: 'deploy',
+      error: new DeployRequiredError(),
+    },
+  ])(
+    'throws error and renders alert dialog if the account required $action and `showAlert` is true',
+    async (testData: { error: Error }) => {
+      const account = await mockAcccount();
+      const { verifyIfAccountNeedUpgradeOrDeploySpy, alertDialogSpy } =
+        prepareMock();
+      verifyIfAccountNeedUpgradeOrDeploySpy.mockRejectedValue(testData.error);
+
+      await expect(
+        verifyIfAccountNeedUpgradeOrDeploy(
+          network,
+          account.address,
+          account.publicKey,
+          true,
+        ),
+      ).rejects.toThrow(testData.error);
+
+      expect(alertDialogSpy).toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/starknet-snap/src/utils/starknetUtils.ts
+++ b/packages/starknet-snap/src/utils/starknetUtils.ts
@@ -1154,10 +1154,8 @@ export const validateAccountRequireUpgradeOrDeploy = async (
   pubKey: string,
 ) => {
   if (await isUpgradeRequired(network, address)) {
-    throw new UpgradeRequiredError('Upgrade required');
+    throw new UpgradeRequiredError();
   } else if (await isDeployRequired(network, address, pubKey)) {
-    throw new DeployRequiredError(
-      `Cairo 0 contract address ${address} balance is not empty, deploy required`,
-    );
+    throw new DeployRequiredError();
   }
 };

--- a/packages/starknet-snap/src/verifySignedMessage.ts
+++ b/packages/starknet-snap/src/verifySignedMessage.ts
@@ -5,12 +5,14 @@ import type {
 } from './types/snapApi';
 import { logger } from './utils/logger';
 import { toJson } from './utils/serializer';
-import { getNetworkFromChainId } from './utils/snapUtils';
+import {
+  getNetworkFromChainId,
+  verifyIfAccountNeedUpgradeOrDeploy,
+} from './utils/snapUtils';
 import {
   verifyTypedDataMessageSignature,
   getFullPublicKeyPairFromPrivateKey,
   getKeysFromAddress,
-  validateAccountRequireUpgradeOrDeploy,
   validateAndParseAddress,
 } from './utils/starknetUtils';
 
@@ -53,10 +55,12 @@ export async function verifySignedMessage(params: ApiParamsWithKeyDeriver) {
 
     const { privateKey: signerPrivateKey, publicKey } =
       await getKeysFromAddress(keyDeriver, network, state, verifySignerAddress);
-    await validateAccountRequireUpgradeOrDeploy(
+
+    await verifyIfAccountNeedUpgradeOrDeploy(
       network,
       verifySignerAddress,
       publicKey,
+      false,
     );
 
     const fullPublicKey = getFullPublicKeyPairFromPrivateKey(signerPrivateKey);

--- a/packages/starknet-snap/test/src/declareContract.test.ts
+++ b/packages/starknet-snap/test/src/declareContract.test.ts
@@ -18,7 +18,6 @@ import {
 import { getAddressKeyDeriver } from '../../src/utils/keyPair';
 import { Mutex } from 'async-mutex';
 import {
-  ApiParams,
   ApiParamsWithKeyDeriver,
   DeclareContractRequestParams,
 } from '../../src/types/snapApi';
@@ -65,75 +64,11 @@ describe('Test function: declareContract', function () {
     sandbox.useFakeTimers(createAccountProxyTxn.timestamp);
     walletStub.rpcStubs.snap_dialog.resolves(true);
     walletStub.rpcStubs.snap_manageState.resolves(state);
-
-    sandbox
-      .stub(snapsUtil, 'showAccountRequireUpgradeOrDeployModal')
-      .callsFake(async (wallet, e) => {
-        if (e instanceof DeployRequiredError) {
-          await snapsUtil.showDeployRequestModal(wallet);
-        } else if (e instanceof UpgradeRequiredError) {
-          await snapsUtil.showUpgradeRequestModal(wallet);
-        }
-      });
   });
 
   afterEach(function () {
     walletStub.reset();
     sandbox.restore();
-  });
-
-  it('should 1) throw an error and 2) show upgrade modal if account upgrade required', async function () {
-    const validateAccountRequireUpgradeOrDeployStub = sandbox
-      .stub(utils, 'validateAccountRequireUpgradeOrDeploy')
-      .throws(new UpgradeRequiredError('Upgrade Required'));
-    const showUpgradeRequestModalStub = sandbox
-      .stub(snapsUtil, 'showUpgradeRequestModal')
-      .resolves();
-    let result;
-    try {
-      result = await declareContract(apiParams);
-    } catch (err) {
-      result = err;
-    } finally {
-      expect(
-        validateAccountRequireUpgradeOrDeployStub,
-      ).to.have.been.calledOnceWith(
-        STARKNET_SEPOLIA_TESTNET_NETWORK,
-        account1.address,
-        account1.publicKey,
-      );
-      expect(showUpgradeRequestModalStub).to.have.been.calledOnce;
-      expect(result).to.be.an('Error');
-    }
-  });
-
-  it('should 1) throw an error and 2) show deploy modal if account deployed required', async function () {
-    const validateAccountRequireUpgradeOrDeployStub = sandbox
-      .stub(utils, 'validateAccountRequireUpgradeOrDeploy')
-      .throws(
-        new DeployRequiredError(
-          `Cairo 0 contract address ${account1.address} balance is not empty, deploy required`,
-        ),
-      );
-    const showDeployRequestModalStub = sandbox
-      .stub(snapsUtil, 'showDeployRequestModal')
-      .resolves();
-    let result;
-    try {
-      result = await declareContract(apiParams);
-    } catch (err) {
-      result = err;
-    } finally {
-      expect(
-        validateAccountRequireUpgradeOrDeployStub,
-      ).to.have.been.calledOnceWith(
-        STARKNET_SEPOLIA_TESTNET_NETWORK,
-        account1.address,
-        account1.publicKey,
-      );
-      expect(showDeployRequestModalStub).to.have.been.calledOnce;
-      expect(result).to.be.an('Error');
-    }
   });
 
   it('should declareContract correctly', async function () {

--- a/packages/starknet-snap/test/src/executeTxn.test.ts
+++ b/packages/starknet-snap/test/src/executeTxn.test.ts
@@ -84,63 +84,12 @@ describe('Test function: executeTxn', function () {
     sandbox
       .stub(utils, 'waitForTransaction')
       .resolves({} as unknown as GetTransactionReceiptResponse);
-    sandbox
-      .stub(snapsUtil, 'showAccountRequireUpgradeOrDeployModal')
-      .callsFake(async (wallet, e) => {
-        if (e instanceof DeployRequiredError) {
-          await snapsUtil.showDeployRequestModal(wallet);
-        } else if (e instanceof UpgradeRequiredError) {
-          await snapsUtil.showUpgradeRequestModal(wallet);
-        }
-      });
   });
 
   afterEach(function () {
     walletStub.reset();
     sandbox.restore();
     apiParams.requestParams = requestObject;
-  });
-
-  it('should 1) throw an error and 2) show upgrade modal if account upgrade required', async function () {
-    const validateAccountRequireUpgradeOrDeployStub = sandbox
-      .stub(utils, 'validateAccountRequireUpgradeOrDeploy')
-      .throws(new UpgradeRequiredError('Upgrade Required'));
-    const showUpgradeRequestModalStub = sandbox
-      .stub(snapsUtil, 'showUpgradeRequestModal')
-      .resolves();
-    let result;
-    try {
-      result = await executeTxn(apiParams);
-    } catch (err) {
-      result = err;
-    } finally {
-      expect(validateAccountRequireUpgradeOrDeployStub).to.have.been.calledOnce;
-      expect(showUpgradeRequestModalStub).to.have.been.calledOnce;
-      expect(result).to.be.an('Error');
-    }
-  });
-
-  it('should 1) throw an error and 2) show deploy modal if account deployed required', async function () {
-    const validateAccountRequireUpgradeOrDeployStub = sandbox
-      .stub(utils, 'validateAccountRequireUpgradeOrDeploy')
-      .throws(
-        new DeployRequiredError(
-          `Cairo 0 contract address ${account1.address} balance is not empty, deploy required`,
-        ),
-      );
-    const showDeployRequestModalStub = sandbox
-      .stub(snapsUtil, 'showDeployRequestModal')
-      .resolves();
-    let result;
-    try {
-      result = await executeTxn(apiParams);
-    } catch (err) {
-      result = err;
-    } finally {
-      expect(validateAccountRequireUpgradeOrDeployStub).to.have.been.calledOnce;
-      expect(showDeployRequestModalStub).to.have.been.calledOnce;
-      expect(result).to.be.an('Error');
-    }
   });
 
   it('should executeTxn correctly and deploy an account', async function () {

--- a/packages/starknet-snap/test/src/signDeclareTransaction.test.ts
+++ b/packages/starknet-snap/test/src/signDeclareTransaction.test.ts
@@ -71,15 +71,6 @@ describe('Test function: signDeclareTransaction', function () {
     sandbox.useFakeTimers(createAccountProxyTxn.timestamp);
     walletStub.rpcStubs.snap_dialog.resolves(true);
     walletStub.rpcStubs.snap_manageState.resolves(state);
-    sandbox
-      .stub(snapsUtil, 'showAccountRequireUpgradeOrDeployModal')
-      .callsFake(async (wallet, e) => {
-        if (e instanceof DeployRequiredError) {
-          await snapsUtil.showDeployRequestModal(wallet);
-        } else if (e instanceof UpgradeRequiredError) {
-          await snapsUtil.showUpgradeRequestModal(wallet);
-        }
-      });
   });
 
   afterEach(function () {
@@ -94,61 +85,6 @@ describe('Test function: signDeclareTransaction', function () {
     const result = await signDeclareTransaction(apiParams);
     expect(walletStub.rpcStubs.snap_dialog).to.have.been.calledOnce;
     expect(result).to.be.eql(signature3);
-  });
-
-  it('should 1) throw an error and 2) show upgrade modal if account upgrade required', async function () {
-    const validateAccountRequireUpgradeOrDeployStub = sandbox
-      .stub(utils, 'validateAccountRequireUpgradeOrDeploy')
-      .throws(new UpgradeRequiredError('Upgrade Required'));
-    const showUpgradeRequestModalStub = sandbox
-      .stub(snapsUtil, 'showUpgradeRequestModal')
-      .resolves();
-    let result;
-    try {
-      result = await signDeclareTransaction(apiParams);
-    } catch (err) {
-      result = err;
-    } finally {
-      expect(
-        validateAccountRequireUpgradeOrDeployStub,
-      ).to.have.been.calledOnceWith(
-        STARKNET_SEPOLIA_TESTNET_NETWORK,
-        account1.address,
-        account1.publicKey,
-      );
-      expect(showUpgradeRequestModalStub).to.have.been.calledOnce;
-      expect(result).to.be.an('Error');
-      expect(result.message).to.equal('Upgrade Required');
-    }
-  });
-
-  it('should 1) throw an error and 2) show deploy modal if account deployed required', async function () {
-    const validateAccountRequireUpgradeOrDeployStub = sandbox
-      .stub(utils, 'validateAccountRequireUpgradeOrDeploy')
-      .throws(
-        new DeployRequiredError(
-          `Cairo 0 contract address ${account1.address} balance is not empty, deploy required`,
-        ),
-      );
-    const showDeployRequestModalStub = sandbox
-      .stub(snapsUtil, 'showDeployRequestModal')
-      .resolves();
-    let result;
-    try {
-      result = await signDeclareTransaction(apiParams);
-    } catch (err) {
-      result = err;
-    } finally {
-      expect(
-        validateAccountRequireUpgradeOrDeployStub,
-      ).to.have.been.calledOnceWith(
-        STARKNET_SEPOLIA_TESTNET_NETWORK,
-        account1.address,
-        account1.publicKey,
-      );
-      expect(showDeployRequestModalStub).to.have.been.calledOnce;
-      expect(result).to.be.an('Error');
-    }
   });
 
   it('should throw error if signDeclareTransaction fail', async function () {

--- a/packages/starknet-snap/test/src/signDeployAccountTransaction.test.ts
+++ b/packages/starknet-snap/test/src/signDeployAccountTransaction.test.ts
@@ -74,15 +74,6 @@ describe('Test function: signDeployAccountTransaction', function () {
     sandbox.useFakeTimers(createAccountProxyTxn.timestamp);
     walletStub.rpcStubs.snap_dialog.resolves(true);
     walletStub.rpcStubs.snap_manageState.resolves(state);
-    sandbox
-      .stub(snapsUtil, 'showAccountRequireUpgradeOrDeployModal')
-      .callsFake(async (wallet, e) => {
-        if (e instanceof DeployRequiredError) {
-          await snapsUtil.showDeployRequestModal(wallet);
-        } else if (e instanceof UpgradeRequiredError) {
-          await snapsUtil.showUpgradeRequestModal(wallet);
-        }
-      });
   });
 
   afterEach(function () {
@@ -97,61 +88,6 @@ describe('Test function: signDeployAccountTransaction', function () {
     const result = await signDeployAccountTransaction(apiParams);
     expect(walletStub.rpcStubs.snap_dialog).to.have.been.calledOnce;
     expect(result).to.be.eql(signature3);
-  });
-
-  it('should 1) throw an error and 2) show upgrade modal if account upgrade required', async function () {
-    const validateAccountRequireUpgradeOrDeployStub = sandbox
-      .stub(utils, 'validateAccountRequireUpgradeOrDeploy')
-      .throws(new UpgradeRequiredError('Upgrade Required'));
-    const showUpgradeRequestModalStub = sandbox
-      .stub(snapsUtil, 'showUpgradeRequestModal')
-      .resolves();
-    let result;
-    try {
-      result = await signDeployAccountTransaction(apiParams);
-    } catch (err) {
-      result = err;
-    } finally {
-      expect(
-        validateAccountRequireUpgradeOrDeployStub,
-      ).to.have.been.calledOnceWith(
-        STARKNET_SEPOLIA_TESTNET_NETWORK,
-        account1.address,
-        account1.publicKey,
-      );
-      expect(showUpgradeRequestModalStub).to.have.been.calledOnce;
-      expect(result).to.be.an('Error');
-      expect(result.message).to.equal('Upgrade Required');
-    }
-  });
-
-  it('should 1) throw an error and 2) show deploy modal if account deployed required', async function () {
-    const validateAccountRequireUpgradeOrDeployStub = sandbox
-      .stub(utils, 'validateAccountRequireUpgradeOrDeploy')
-      .throws(
-        new DeployRequiredError(
-          `Cairo 0 contract address ${account1.address} balance is not empty, deploy required`,
-        ),
-      );
-    const showDeployRequestModalStub = sandbox
-      .stub(snapsUtil, 'showDeployRequestModal')
-      .resolves();
-    let result;
-    try {
-      result = await signDeployAccountTransaction(apiParams);
-    } catch (err) {
-      result = err;
-    } finally {
-      expect(
-        validateAccountRequireUpgradeOrDeployStub,
-      ).to.have.been.calledOnceWith(
-        STARKNET_SEPOLIA_TESTNET_NETWORK,
-        account1.address,
-        account1.publicKey,
-      );
-      expect(showDeployRequestModalStub).to.have.been.calledOnce;
-      expect(result).to.be.an('Error');
-    }
   });
 
   it('should throw error if signDeployAccountTransaction fail', async function () {

--- a/packages/starknet-snap/test/src/signMessage.test.ts
+++ b/packages/starknet-snap/test/src/signMessage.test.ts
@@ -148,68 +148,6 @@ describe('Test function: signMessage', function () {
       });
     });
 
-    describe('when account require upgrade', function () {
-      let validateAccountRequireUpgradeOrDeployStub: sinon.SinonStub;
-      beforeEach(async function () {
-        validateAccountRequireUpgradeOrDeployStub = sandbox
-          .stub(utils, 'validateAccountRequireUpgradeOrDeploy')
-          .throws(new UpgradeRequiredError('Upgrade Required'));
-      });
-
-      it('should throw error if upgrade required', async function () {
-        let result;
-        try {
-          result = await signMessage(apiParams);
-        } catch (err) {
-          result = err;
-        } finally {
-          expect(
-            validateAccountRequireUpgradeOrDeployStub,
-          ).to.have.been.calledOnceWith(
-            STARKNET_SEPOLIA_TESTNET_NETWORK,
-            account1.address,
-            account1.publicKey,
-          );
-          expect(result).to.be.an('Error');
-          expect(result.message).to.equal('Upgrade Required');
-        }
-      });
-    });
-
-    describe('when account require deploy', function () {
-      let validateAccountRequireUpgradeOrDeployStub: sinon.SinonStub;
-      beforeEach(async function () {
-        validateAccountRequireUpgradeOrDeployStub = sandbox
-          .stub(utils, 'validateAccountRequireUpgradeOrDeploy')
-          .throws(
-            new DeployRequiredError(
-              `Cairo 0 contract address ${account1.address} balance is not empty, deploy required`,
-            ),
-          );
-      });
-
-      it('should throw error if deploy required', async function () {
-        let result;
-        try {
-          result = await signMessage(apiParams);
-        } catch (err) {
-          result = err;
-        } finally {
-          expect(
-            validateAccountRequireUpgradeOrDeployStub,
-          ).to.have.been.calledOnceWith(
-            STARKNET_SEPOLIA_TESTNET_NETWORK,
-            account1.address,
-            account1.publicKey,
-          );
-          expect(result).to.be.an('Error');
-          expect(result.message).to.equal(
-            `Cairo 0 contract address ${account1.address} balance is not empty, deploy required`,
-          );
-        }
-      });
-    });
-
     describe('when account is not require upgrade', function () {
       beforeEach(async function () {
         apiParams.requestParams = {

--- a/packages/starknet-snap/test/src/signTransaction.test.ts
+++ b/packages/starknet-snap/test/src/signTransaction.test.ts
@@ -82,15 +82,6 @@ describe('Test function: signTransaction', function () {
     sandbox.useFakeTimers(createAccountProxyTxn.timestamp);
     walletStub.rpcStubs.snap_dialog.resolves(true);
     walletStub.rpcStubs.snap_manageState.resolves(state);
-    sandbox
-      .stub(snapsUtil, 'showAccountRequireUpgradeOrDeployModal')
-      .callsFake(async (wallet, e) => {
-        if (e instanceof DeployRequiredError) {
-          await snapsUtil.showDeployRequestModal(wallet);
-        } else if (e instanceof UpgradeRequiredError) {
-          await snapsUtil.showUpgradeRequestModal(wallet);
-        }
-      });
   });
 
   afterEach(function () {
@@ -104,61 +95,6 @@ describe('Test function: signTransaction', function () {
     const result = await signTransaction(apiParams);
     expect(walletStub.rpcStubs.snap_dialog).to.have.been.calledOnce;
     expect(result).to.be.eql(signature3);
-  });
-
-  it('should 1) throw an error and 2) show upgrade modal if account upgrade required', async function () {
-    const validateAccountRequireUpgradeOrDeployStub = sandbox
-      .stub(utils, 'validateAccountRequireUpgradeOrDeploy')
-      .throws(new UpgradeRequiredError('Upgrade Required'));
-    const showUpgradeRequestModalStub = sandbox
-      .stub(snapsUtil, 'showUpgradeRequestModal')
-      .resolves();
-    let result;
-    try {
-      result = await signTransaction(apiParams);
-    } catch (err) {
-      result = err;
-    } finally {
-      expect(
-        validateAccountRequireUpgradeOrDeployStub,
-      ).to.have.been.calledOnceWith(
-        STARKNET_SEPOLIA_TESTNET_NETWORK,
-        account1.address,
-        account1.publicKey,
-      );
-      expect(showUpgradeRequestModalStub).to.have.been.calledOnce;
-      expect(result).to.be.an('Error');
-      expect(result.message).to.equal('Upgrade Required');
-    }
-  });
-
-  it('should 1) throw an error and 2) show deploy modal if account deployed required', async function () {
-    const validateAccountRequireUpgradeOrDeployStub = sandbox
-      .stub(utils, 'validateAccountRequireUpgradeOrDeploy')
-      .throws(
-        new DeployRequiredError(
-          `Cairo 0 contract address ${account1.address} balance is not empty, deploy required`,
-        ),
-      );
-    const showDeployRequestModalStub = sandbox
-      .stub(snapsUtil, 'showDeployRequestModal')
-      .resolves();
-    let result;
-    try {
-      result = await signTransaction(apiParams);
-    } catch (err) {
-      result = err;
-    } finally {
-      expect(
-        validateAccountRequireUpgradeOrDeployStub,
-      ).to.have.been.calledOnceWith(
-        STARKNET_SEPOLIA_TESTNET_NETWORK,
-        account1.address,
-        account1.publicKey,
-      );
-      expect(showDeployRequestModalStub).to.have.been.calledOnce;
-      expect(result).to.be.an('Error');
-    }
   });
 
   it('should throw error if signTransaction fail', async function () {

--- a/packages/starknet-snap/test/src/verifySignedMessage.test.ts
+++ b/packages/starknet-snap/test/src/verifySignedMessage.test.ts
@@ -119,33 +119,6 @@ describe('Test function: verifySignedMessage', function () {
       });
     });
 
-    describe('when account require upgrade', function () {
-      let validateAccountRequireUpgradeOrDeployStub: sinon.SinonStub;
-      beforeEach(async function () {
-        validateAccountRequireUpgradeOrDeployStub = sandbox
-          .stub(utils, 'validateAccountRequireUpgradeOrDeploy')
-          .throws(new UpgradeRequiredError('Upgrade Required'));
-      });
-
-      it('should throw error if upgrade required', async function () {
-        let result;
-        try {
-          result = await verifySignedMessage(apiParams);
-        } catch (err) {
-          result = err;
-        } finally {
-          expect(
-            validateAccountRequireUpgradeOrDeployStub,
-          ).to.have.been.calledOnceWith(
-            STARKNET_SEPOLIA_TESTNET_NETWORK,
-            account1.address,
-            account1.publicKey,
-          );
-          expect(result).to.be.an('Error');
-        }
-      });
-    });
-
     describe('when account is not require upgrade', function () {
       beforeEach(async function () {
         sandbox


### PR DESCRIPTION
This PR is to add new method `verifyIfAccountNeedUpgradeOrDeploy`  in snapUtils to group the logic of
- show update/deploy alert dialog (optional)
- check if the account needed to upgrade or deploy
- throw upgrade or deploy required error

it also update the `showDeployRequestModal ` and `showUpgradeRequestModal ` to use the alertDialog utils from `snap`

it also remove some of the test case that depends on the removed method `showAccountRequireUpgradeOrDeployModal`, 
as the test responsibility is on the util itself, rather than the rpc api
