### PR TITLE
chore: add state management base class and shared lock

### DIFF
--- a/packages/starknet-snap/package.json
+++ b/packages/starknet-snap/package.json
@@ -45,7 +45,8 @@
     "ethers": "^5.5.1",
     "starknet": "6.11.0",
     "starknet_v4.22.0": "npm:starknet@4.22.0",
-    "superstruct": "^2.0.2"
+    "superstruct": "^2.0.2",
+    "uuid": "^10.0.0"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.23.3",

--- a/packages/starknet-snap/src/index.ts
+++ b/packages/starknet-snap/src/index.ts
@@ -13,7 +13,6 @@ import {
   copyable,
   SnapError,
 } from '@metamask/snaps-sdk';
-import { Mutex } from 'async-mutex';
 import { ethers } from 'ethers';
 
 import { addErc20Token } from './addErc20Token';
@@ -75,9 +74,9 @@ import {
   getKeysFromAddressIndex,
 } from './utils/starknetUtils';
 import { verifySignedMessage } from './verifySignedMessage';
+import { acquireLock } from './utils/lock';
 
 declare const snap;
-const saveMutex = new Mutex();
 
 export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   const requestParams = request?.params as unknown as ApiRequestParams;
@@ -94,6 +93,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       return 'pong';
     }
 
+    // TODO: this will causing racing condition, need to be fixed
     let state: SnapState = await snap.request({
       method: 'snap_manageState',
       params: {
@@ -116,6 +116,10 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
         },
       });
     }
+
+    // TODO: this can be remove, after state manager is implemented
+    const saveMutex = acquireLock()
+
     // pre-inserted the default networks and tokens
     await upsertNetwork(STARKNET_MAINNET_NETWORK, snap, saveMutex, state);
     await upsertNetwork(

--- a/packages/starknet-snap/src/index.ts
+++ b/packages/starknet-snap/src/index.ts
@@ -60,6 +60,7 @@ import {
   STARKNET_TESTNET_NETWORK,
 } from './utils/constants';
 import { getAddressKeyDeriver } from './utils/keyPair';
+import { acquireLock } from './utils/lock';
 import { logger, LogLevel } from './utils/logger';
 import { toJson } from './utils/serializer';
 import {
@@ -74,7 +75,6 @@ import {
   getKeysFromAddressIndex,
 } from './utils/starknetUtils';
 import { verifySignedMessage } from './verifySignedMessage';
-import { acquireLock } from './utils/lock';
 
 declare const snap;
 
@@ -118,7 +118,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     }
 
     // TODO: this can be remove, after state manager is implemented
-    const saveMutex = acquireLock()
+    const saveMutex = acquireLock();
 
     // pre-inserted the default networks and tokens
     await upsertNetwork(STARKNET_MAINNET_NETWORK, snap, saveMutex, state);

--- a/packages/starknet-snap/src/utils/lock.test.ts
+++ b/packages/starknet-snap/src/utils/lock.test.ts
@@ -1,0 +1,21 @@
+import { Mutex } from 'async-mutex';
+
+import { acquireLock } from './lock';
+
+jest.mock('async-mutex', () => {
+  return {
+    Mutex: jest.fn(),
+  };
+});
+
+describe('acquireLock', () => {
+  it('acquires lock', () => {
+    acquireLock();
+    expect(Mutex).toHaveBeenCalledTimes(0);
+  });
+
+  it('acquires new lock if parameter `create` is true', () => {
+    acquireLock(true);
+    expect(Mutex).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/starknet-snap/src/utils/lock.ts
+++ b/packages/starknet-snap/src/utils/lock.ts
@@ -1,0 +1,16 @@
+import { Mutex } from 'async-mutex';
+
+const saveMutex = new Mutex();
+
+/**
+ * Acquires or retrieves a lock.
+ *
+ * @param create - Whether to create a new lock or retrieve an existing one.
+ * @returns A Mutex object representing the lock.
+ */
+export function acquireLock(create = false) {
+  if (create) {
+    return new Mutex();
+  }
+  return saveMutex;
+}

--- a/packages/starknet-snap/src/utils/snap-state.test.ts
+++ b/packages/starknet-snap/src/utils/snap-state.test.ts
@@ -1,0 +1,599 @@
+import * as lockUtil from './lock';
+import * as snapUtil from './snap';
+import { SnapStateManager } from './snap-state';
+
+jest.mock('../utils/logger');
+
+type MockTransactionDetail = {
+  txHash: string;
+  cnt: number;
+};
+
+type MockTransactionDetails = {
+  [key in string]: MockTransactionDetail;
+};
+
+type MockTransactions = string[];
+
+type MockState = {
+  transaction: MockTransactions;
+  transactionDetails: MockTransactionDetails;
+};
+
+type MockExecuteTransactionInput = {
+  txHash: string;
+  id: string;
+  cnt: number;
+};
+
+describe('SnapStateManager', () => {
+  const createMockStateManager = <State, StateDataInput>(
+    createLock?: boolean,
+  ) => {
+    const updateDataSpy = jest.fn();
+    class MockSnapStateManager extends SnapStateManager<State> {
+      constructor() {
+        super(createLock);
+      }
+
+      async getData() {
+        return this.get();
+      }
+
+      async updateData(data: StateDataInput) {
+        await this.update(async (state) => updateDataSpy(state, data));
+      }
+    }
+
+    const instance = new MockSnapStateManager();
+
+    const executeTransactionFn = async (
+      data: StateDataInput,
+      delay: number,
+      isThrowError?: boolean,
+      isCommit?: boolean,
+    ) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      await instance.withTransaction(async (state) => {
+        await instance.updateData(data);
+        if (isCommit === true) {
+          await instance.commit();
+        }
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        if (isThrowError) {
+          throw new Error('executeTransactionFn error');
+        }
+      });
+    };
+
+    const executeFn = async (data, delay, isThrowError = false) => {
+      await instance.updateData(data);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      if (isThrowError) {
+        throw new Error('executeFn error');
+      }
+    };
+
+    return {
+      instance,
+      updateDataSpy,
+      executeTransactionFn,
+      executeFn,
+    };
+  };
+
+  const createMockState = (initState: MockState) => {
+    const setStateDataFn = async (data: MockState) => {
+      initState.transaction = [...data.transaction];
+      initState.transactionDetails = Object.entries(
+        data.transactionDetails,
+      ).reduce(
+        (acc, [key, value]: [key: string, value: MockTransactionDetail]) => {
+          acc[key] = {
+            ...value,
+          };
+          return acc;
+        },
+        {},
+      );
+    };
+
+    const updateDataFn = (
+      state: MockState,
+      data: MockExecuteTransactionInput,
+    ) => {
+      if (
+        Object.prototype.hasOwnProperty.call(
+          state.transactionDetails,
+          data.id,
+        ) === false
+      ) {
+        state.transaction.push(data.id);
+        state.transactionDetails[data.id] = {
+          txHash: data.txHash,
+          cnt: data.cnt,
+        };
+      } else {
+        state.transactionDetails[data.id] = {
+          txHash: data.txHash,
+          cnt: state.transactionDetails[data.id].cnt + data.cnt,
+        };
+      }
+    };
+
+    const getStateDataSpy = jest
+      .spyOn(snapUtil, 'getStateData')
+      .mockImplementation(async () => {
+        return {
+          transaction: [...initState.transaction],
+          transactionDetails: Object.entries(
+            initState.transactionDetails,
+          ).reduce(
+            (
+              acc,
+              [key, value]: [key: string, value: MockTransactionDetail],
+            ) => {
+              acc[key] = {
+                ...value,
+              };
+              return acc;
+            },
+            {},
+          ),
+        };
+      });
+
+    const setStateDataSpy = jest
+      .spyOn(snapUtil, 'setStateData')
+      .mockImplementation(setStateDataFn);
+
+    return {
+      setStateDataFn,
+      updateDataFn,
+      getStateDataSpy,
+      setStateDataSpy,
+    };
+  };
+
+  describe('constructor', () => {
+    it('sends `false` to Lock.Acquire if parameter `createLock` is `undefined`', async () => {
+      const spy = jest.spyOn(lockUtil, 'acquireLock');
+      createMockStateManager();
+
+      expect(spy).toHaveBeenCalledWith(false);
+    });
+
+    it('sends `true` to Lock.Acquire if parameter `createLock` is `true`', async () => {
+      const spy = jest.spyOn(lockUtil, 'acquireLock');
+      createMockStateManager(true);
+
+      expect(spy).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('get', () => {
+    it('returns result', async () => {
+      const { instance } = createMockStateManager(false);
+      const state = {
+        transaction: [
+          {
+            txHash: 'hash',
+            chainId: 'chainId',
+          },
+        ],
+      };
+      const readSpy = jest
+        .spyOn(snapUtil, 'getStateData')
+        .mockResolvedValue(state);
+      const result = await instance.getData();
+
+      expect(readSpy).toHaveBeenCalledTimes(1);
+      expect(result).toStrictEqual(state);
+    });
+  });
+
+  describe('update', () => {
+    it('updates state', async () => {
+      const { instance, updateDataSpy } = createMockStateManager(false);
+      const testcase = {
+        state: {
+          transaction: [
+            {
+              txHash: 'hash',
+              chainId: 'chainId',
+            },
+          ],
+        },
+        data: {
+          txHash: 'hash2',
+          chainId: 'chainId2',
+        },
+      };
+      const readSpy = jest
+        .spyOn(snapUtil, 'getStateData')
+        .mockResolvedValue(testcase.state);
+      const writeSpy = jest.spyOn(snapUtil, 'setStateData');
+      updateDataSpy.mockImplementation((state, data) => {
+        state.transaction.push(data);
+      });
+
+      await instance.updateData(testcase.data);
+
+      expect(readSpy).toHaveBeenCalledTimes(1);
+      expect(writeSpy).toHaveBeenCalledTimes(1);
+      expect(writeSpy).toHaveBeenCalledWith(testcase.state);
+      expect(testcase.state.transaction).toHaveLength(2);
+      expect(updateDataSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('withTransaction', () => {
+    it('executes callback code', async () => {
+      const initState = {
+        transaction: ['id'],
+        transactionDetails: {
+          id: {
+            txHash: 'hash',
+            cnt: 4,
+          },
+        },
+      };
+
+      const { getStateDataSpy, updateDataFn } = createMockState(initState);
+
+      const { updateDataSpy, executeTransactionFn } = createMockStateManager<
+        MockState,
+        MockExecuteTransactionInput
+      >();
+
+      updateDataSpy.mockImplementation(updateDataFn);
+
+      const promiseArr = [
+        executeTransactionFn(
+          {
+            txHash: 'hash-final',
+            id: 'id',
+            cnt: 2,
+          },
+          30,
+        ),
+        executeTransactionFn(
+          {
+            txHash: 'hash2',
+            id: 'id2',
+            cnt: 5,
+          },
+          0,
+        ),
+      ];
+
+      await Promise.all(promiseArr);
+      expect(initState.transaction).toStrictEqual(['id', 'id2']);
+
+      expect(initState.transactionDetails).toStrictEqual({
+        id: {
+          txHash: 'hash-final',
+          cnt: 6,
+        },
+        id2: {
+          txHash: 'hash2',
+          cnt: 5,
+        },
+      });
+      expect(getStateDataSpy).toHaveBeenCalledTimes(promiseArr.length * 2);
+      //  expect(setStateDataSpy).toHaveBeenCalledTimes(promiseArr.length);
+      expect(updateDataSpy).toHaveBeenCalledTimes(promiseArr.length);
+    });
+
+    it('does rollback if the transaction committed and an error was thrown', async () => {
+      const initState = {
+        transaction: ['id'],
+        transactionDetails: {
+          id: {
+            txHash: 'hash',
+            cnt: 4,
+          },
+        },
+      };
+      const { getStateDataSpy, updateDataFn } = createMockState(initState);
+      const { updateDataSpy, executeTransactionFn } = createMockStateManager<
+        MockState,
+        MockExecuteTransactionInput
+      >();
+      updateDataSpy.mockImplementation(updateDataFn);
+
+      const promiseArr = [
+        executeTransactionFn(
+          {
+            txHash: 'hash4',
+            id: 'id',
+            cnt: 1,
+          },
+          10,
+        ),
+        executeTransactionFn(
+          {
+            txHash: 'hash-final',
+            id: 'id',
+            cnt: 2,
+          },
+          30,
+          true,
+          true,
+        ),
+        executeTransactionFn(
+          {
+            txHash: 'hash2',
+            id: 'id2',
+            cnt: 5,
+          },
+          0,
+        ),
+      ];
+
+      await Promise.allSettled(promiseArr);
+
+      expect(initState.transaction).toStrictEqual(['id', 'id2']);
+      expect(initState.transactionDetails).toStrictEqual({
+        id: {
+          txHash: 'hash4',
+          cnt: 5,
+        },
+        id2: {
+          txHash: 'hash2',
+          cnt: 5,
+        },
+      });
+      expect(getStateDataSpy).toHaveBeenCalledTimes(promiseArr.length * 2);
+      expect(updateDataSpy).toHaveBeenCalledTimes(promiseArr.length);
+    });
+
+    it('does not trigger rollback if the transaction has not committed and an error was thrown', async () => {
+      const hasCommitted = false;
+      const initState: MockState = {
+        transaction: ['id'],
+        transactionDetails: {
+          id: {
+            txHash: 'hash',
+            cnt: 4,
+          },
+        },
+      };
+      const { setStateDataSpy, updateDataFn } = createMockState(initState);
+      const { updateDataSpy, executeTransactionFn } = createMockStateManager<
+        MockState,
+        MockExecuteTransactionInput
+      >();
+      updateDataSpy.mockImplementation(updateDataFn);
+
+      let expectedError;
+      try {
+        await executeTransactionFn(
+          {
+            txHash: 'hash-final',
+            id: 'id',
+            cnt: 2,
+          },
+          30,
+          true,
+          hasCommitted,
+        );
+      } catch (error) {
+        expectedError = error;
+      } finally {
+        expect(expectedError).toBeInstanceOf(Error);
+        expect(initState.transaction).toStrictEqual(['id']);
+        expect(setStateDataSpy).toHaveBeenCalledTimes(0);
+        expect(initState.transactionDetails).toStrictEqual({
+          id: {
+            txHash: 'hash',
+            cnt: 4,
+          },
+        });
+      }
+    });
+
+    it('does not rollback if the transaction committed and rollback failed', async () => {
+      const committed = true;
+      const initState: MockState = {
+        transaction: ['id'],
+        transactionDetails: {
+          id: {
+            txHash: 'hash',
+            cnt: 4,
+          },
+        },
+      };
+      const { setStateDataSpy, updateDataFn, setStateDataFn } =
+        createMockState(initState);
+      const { updateDataSpy, executeTransactionFn } = createMockStateManager<
+        MockState,
+        MockExecuteTransactionInput
+      >();
+      setStateDataSpy
+        .mockImplementationOnce(setStateDataFn)
+        .mockImplementationOnce(() => {
+          throw new Error('rollback error');
+        });
+      updateDataSpy.mockImplementation(updateDataFn);
+
+      const promiseArr = [
+        executeTransactionFn(
+          {
+            txHash: 'hash-final',
+            id: 'id',
+            cnt: 2,
+          },
+          30,
+          true,
+          committed,
+        ),
+        executeTransactionFn(
+          {
+            txHash: 'hash-final',
+            id: 'id',
+            cnt: 2,
+          },
+          30,
+          true,
+          false,
+        ),
+      ];
+      await Promise.allSettled(promiseArr);
+
+      expect(initState.transaction).toStrictEqual(['id']);
+      expect(initState.transactionDetails).toStrictEqual({
+        id: {
+          txHash: 'hash-final',
+          cnt: 6,
+        },
+      });
+    });
+
+    it('does not have racing condition', async () => {
+      const initState = {
+        transaction: [],
+        transactionDetails: {},
+      };
+      const { getStateDataSpy, updateDataFn } = createMockState(initState);
+      const { updateDataSpy, executeTransactionFn, executeFn } =
+        createMockStateManager<MockState, MockExecuteTransactionInput>();
+
+      updateDataSpy.mockImplementation(updateDataFn);
+
+      const promiseArr = [
+        executeTransactionFn(
+          {
+            txHash: 'hash',
+            id: 'id',
+            cnt: 2,
+          },
+          30,
+        ),
+        executeTransactionFn(
+          {
+            txHash: 'hash2',
+            id: 'id2',
+            cnt: 5,
+          },
+          20,
+        ),
+        executeFn(
+          {
+            txHash: 'hash32',
+            id: 'id3',
+            cnt: 8,
+          },
+          0,
+        ),
+        executeTransactionFn(
+          {
+            txHash: 'hash-updated',
+            id: 'id',
+            cnt: 1,
+          },
+          30,
+        ),
+        executeTransactionFn(
+          {
+            txHash: 'hash3',
+            id: 'id3',
+            cnt: 2,
+          },
+          10,
+        ),
+        executeTransactionFn(
+          {
+            txHash: 'hash-updated-final',
+            id: 'id',
+            cnt: 3,
+          },
+          2,
+        ),
+      ];
+
+      await Promise.all(promiseArr);
+
+      expect(initState.transaction).toStrictEqual(['id', 'id2', 'id3']);
+      expect(initState.transactionDetails).toStrictEqual({
+        id: {
+          txHash: 'hash-updated-final',
+          cnt: 6,
+        },
+        id2: {
+          txHash: 'hash2',
+          cnt: 5,
+        },
+        id3: {
+          txHash: 'hash3',
+          cnt: 10,
+        },
+      });
+      expect(getStateDataSpy).toHaveBeenCalledTimes(promiseArr.length * 2 - 1);
+      expect(updateDataSpy).toHaveBeenCalledTimes(promiseArr.length);
+    });
+
+    it('throws `Failed to begin transaction` error if the transaction can not init', async () => {
+      const initState = {
+        transaction: [],
+        transactionDetails: {},
+      };
+
+      const { getStateDataSpy } = createMockState(initState);
+
+      const { executeTransactionFn } = createMockStateManager<
+        MockState,
+        MockExecuteTransactionInput
+      >();
+
+      getStateDataSpy.mockResolvedValue(undefined);
+
+      await expect(
+        executeTransactionFn(
+          {
+            txHash: 'hash-final',
+            id: 'id',
+            cnt: 2,
+          },
+          30,
+        ),
+      ).rejects.toThrow('Failed to begin transaction');
+    });
+
+    it('throws an Error if another Error was thrown', async () => {
+      const initState = {
+        transaction: [],
+        transactionDetails: {},
+      };
+
+      const { setStateDataSpy, setStateDataFn, updateDataFn } =
+        createMockState(initState);
+
+      const { executeTransactionFn, updateDataSpy } = createMockStateManager<
+        MockState,
+        MockExecuteTransactionInput
+      >();
+
+      updateDataSpy.mockImplementation(updateDataFn);
+
+      // first mockImplementation mocks the set data actions
+      setStateDataSpy
+        .mockImplementationOnce(async () => {
+          throw new Error('setStateDataSpy');
+          // second mockImplementation mocks the rollback actions
+        })
+        .mockImplementationOnce(setStateDataFn);
+
+      await expect(
+        executeTransactionFn(
+          {
+            txHash: 'hash-final',
+            id: 'id',
+            cnt: 2,
+          },
+          30,
+        ),
+      ).rejects.toThrow(Error);
+    });
+  });
+});

--- a/packages/starknet-snap/src/utils/snap-state.ts
+++ b/packages/starknet-snap/src/utils/snap-state.ts
@@ -44,6 +44,7 @@ export abstract class SnapStateManager<State> {
       if (this.#transaction.current) {
         logger.info(
           `SnapStateManager.update [${
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
             this.#transaction.id
           }]: transaction is processing, use existing state`,
         );
@@ -133,6 +134,7 @@ export abstract class SnapStateManager<State> {
       ) {
         logger.info(
           `SnapStateManager.rollback [${
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
             this.#transaction.id
           }]: attempt to rollback state`,
         );
@@ -140,9 +142,9 @@ export abstract class SnapStateManager<State> {
         await this.set(this.#transaction.orgState);
       }
     } catch (error) {
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       logger.info(
         `SnapStateManager.rollback [${
+          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           this.#transaction.id
         }]: error : ${JSON.stringify(error)}`,
       );

--- a/packages/starknet-snap/src/utils/snap-state.ts
+++ b/packages/starknet-snap/src/utils/snap-state.ts
@@ -1,0 +1,160 @@
+import { type MutexInterface } from 'async-mutex';
+import { v4 as uuidv4 } from 'uuid';
+
+import { acquireLock } from './lock';
+import { logger } from './logger';
+import { getStateData, setStateData } from './snap';
+
+export type Transaction<State> = {
+  id?: string;
+  orgState?: State;
+  current?: State;
+  isRollingBack: boolean;
+  hasCommitted: boolean;
+};
+
+export abstract class SnapStateManager<State> {
+  protected readonly mtx: MutexInterface;
+
+  #transaction: Transaction<State>;
+
+  constructor(createLock = false) {
+    this.mtx = acquireLock(createLock);
+    this.#transaction = {
+      id: undefined,
+      orgState: undefined,
+      current: undefined,
+      isRollingBack: false,
+      hasCommitted: false,
+    };
+  }
+
+  protected async get(): Promise<State> {
+    return getStateData<State>();
+  }
+
+  protected async set(state: State): Promise<void> {
+    return setStateData<State>(state);
+  }
+
+  protected async update(
+    callback: (state: State) => Promise<void>,
+  ): Promise<void> {
+    if (this.mtx.isLocked()) {
+      if (this.#transaction.current) {
+        logger.info(
+          `SnapStateManager.update [${
+            this.#transaction.id
+          }]: transaction is processing, use existing state`,
+        );
+        await callback(this.#transaction.current);
+        return;
+      }
+      logger.info(
+        `SnapStateManager.update: transaction is not exist, create lock after prev lock is released`,
+      );
+    }
+    await this.mtx.runExclusive(async () => {
+      const state = await this.get();
+      await callback(state);
+      await this.set(state);
+    });
+  }
+
+  /**
+   * This method executes the callback code in a transaction-like format. It creates a lock to ensure the state is not intercepted during the transaction and initializes a transaction with the current state, original state, and transaction ID. If there is an error during the transaction, the state is rolled back to the original state. However, if the lock has no time limit, it might cause a deadlock if the transaction is not completed.
+   *
+   * @param callback - A Promise function that takes the state as an argument.
+   */
+  public async withTransaction(
+    callback: (state: State) => Promise<void>,
+  ): Promise<void> {
+    await this.mtx.runExclusive(async () => {
+      await this.#beginTransaction();
+
+      if (
+        !this.#transaction.current ||
+        !this.#transaction.orgState ||
+        !this.#transaction.id
+      ) {
+        throw new Error('Failed to begin transaction');
+      }
+
+      logger.info(
+        `SnapStateManager.withTransaction [${
+          this.#transaction.id
+        }]: begin transaction`,
+      );
+
+      try {
+        await callback(this.#transaction.current);
+        await this.set(this.#transaction.current);
+      } catch (error) {
+        logger.info(
+          `SnapStateManager.withTransaction [${
+            this.#transaction.id
+          }]: error : ${JSON.stringify(error.message)}`,
+        );
+
+        await this.#rollback();
+
+        throw error;
+      } finally {
+        this.#cleanUpTransaction();
+      }
+    });
+  }
+
+  async commit() {
+    if (!this.#transaction.current || !this.#transaction.orgState) {
+      throw new Error('Failed to commit transaction');
+    }
+    this.#transaction.hasCommitted = true;
+    await this.set(this.#transaction.current);
+  }
+
+  async #beginTransaction(): Promise<void> {
+    this.#transaction = {
+      id: uuidv4(),
+      orgState: await this.get(),
+      current: await this.get(), // make sure the current is not referenced to orgState
+      isRollingBack: false,
+      hasCommitted: false,
+    };
+  }
+
+  async #rollback(): Promise<void> {
+    try {
+      // we only need to rollback if the transaction is committed
+      if (
+        this.#transaction.hasCommitted &&
+        !this.#transaction.isRollingBack &&
+        this.#transaction.orgState
+      ) {
+        logger.info(
+          `SnapStateManager.rollback [${
+            this.#transaction.id
+          }]: attempt to rollback state`,
+        );
+        this.#transaction.isRollingBack = true;
+        await this.set(this.#transaction.orgState);
+      }
+    } catch (error) {
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      logger.info(
+        `SnapStateManager.rollback [${
+          this.#transaction.id
+        }]: error : ${JSON.stringify(error)}`,
+      );
+      throw new Error('Failed to rollback state');
+    }
+  }
+
+  #cleanUpTransaction(): void {
+    this.#transaction.orgState = undefined;
+    this.#transaction.current = undefined;
+    this.#transaction.id = undefined;
+    this.#transaction.isRollingBack = false;
+    this.#transaction.hasCommitted = false;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2216,7 +2216,7 @@ __metadata:
 
 "@consensys/starknet-snap@file:../starknet-snap::locator=wallet-ui%40workspace%3Apackages%2Fwallet-ui":
   version: 2.9.0
-  resolution: "@consensys/starknet-snap@file:../starknet-snap#../starknet-snap::hash=bdb700&locator=wallet-ui%40workspace%3Apackages%2Fwallet-ui"
+  resolution: "@consensys/starknet-snap@file:../starknet-snap#../starknet-snap::hash=4fe643&locator=wallet-ui%40workspace%3Apackages%2Fwallet-ui"
   dependencies:
     "@metamask/key-tree": 9.0.0
     "@metamask/snaps-sdk": ^4.0.0
@@ -2225,7 +2225,8 @@ __metadata:
     ethers: ^5.5.1
     starknet: 6.11.0
     starknet_v4.22.0: "npm:starknet@4.22.0"
-  checksum: f3c17dee4fca9fc6e7826279be325900be78e13207ee0fb6230d5d15091e6f9189f01972f17fff7f4ec15a6d86fb08c23fec5589c7ce1992fb0fefdfb2c085ce
+    superstruct: ^2.0.2
+  checksum: 56f4ffe23e87c7893827e7207b299e37bd5c46635082172413fdcf0c4d5803dbbe7ea770879ec32a825a125952b386ca29f41df69b50da2032616589722877a8
   languageName: node
   linkType: hard
 
@@ -2278,6 +2279,7 @@ __metadata:
     ts-jest: ^29.1.0
     ts-node: ^10.9.2
     typescript: ^4.7.4
+    uuid: ^10.0.0
   languageName: unknown
   linkType: soft
 
@@ -27192,6 +27194,15 @@ __metadata:
   version: 3.1.0
   resolution: "uuid-browser@npm:3.1.0"
   checksum: 951ec47593865c7cc746df671f7b0f0ff48fcab583fcdaeab6c517a5222af0f5e144a6fcea5fa9620a5b3be047e2f9412a80267ea5c45050e07d51774197d49e
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "uuid@npm:10.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 4b81611ade2885d2313ddd8dc865d93d8dccc13ddf901745edca8f86d99bc46d7a330d678e7532e7ebf93ce616679fb19b2e3568873ac0c14c999032acb25869
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR is to add state management base class `SnapStateManager`

it provides the functionally of `update, get, set, withTransaction, commit, rollback`

- `get` and `set` is the simple method to get the state and set the state.

- `update` is an method combine with get, then set, but also compatible with transaction mode.

- `withTransaction` is a method to init a transaction by getting the state, and do the callback, if anything happen, it will rollback to the state that we get previously, it can combine with`update` to use.

- `commit` is a method to force commit in a transaction before it auto commit.

- `rollback` is a internal method to rollback the state.

example use:
```typescript
export type SnapState = {
  walletIds: string[];
  wallets: Wallets;
};

class MyState extends SnapStateManager<SnapState> {
      constructor() {
        super(true);
      }

     async updateWallet(wallet) {
         await this.update(async (state: SnapState) => {
                 const { id, address } = wallet.account;
                 if (
                    this.isAccountExist(state, id) ||
                    this.getAccountByAddress(state, address)
                  ) {
                    throw new Error(`Account address ${address} already exists`);
                  }
              state.wallets[id] = wallet;
        })
     }
}


// Test rollback
async function testRollback() {
    const mgt = new MyState()
    await mgt.withTransaction(async () => {
        await mgt.addWallet({
          account: keyringAccount,
        });
        // if this line fail, it will not update the state
        await this.#emitEvent(KeyringEvent.AccountCreated, {
          account: keyringAccount,
          accountNameSuggestion: this.getKeyringAccountNameSuggestion(options),
        });
    });
}
```







