### PR TITLE
refactor: add `AccountStateManager`

### DIFF
--- a/packages/starknet-snap/src/state/account-state-manager.test.ts
+++ b/packages/starknet-snap/src/state/account-state-manager.test.ts
@@ -1,0 +1,163 @@
+import { constants } from 'starknet';
+
+import { generateAccounts, type StarknetAccount } from '../../test/utils';
+import * as snapHelper from '../utils/snap';
+import {
+  AddressFilter,
+  ChainIdFilter,
+  AccountStateManager,
+} from './account-state-manager';
+
+jest.mock('../utils/snap');
+jest.mock('../utils/logger');
+
+const mockAcccounts = async (chainId: constants.StarknetChainId, cnt = 10) => {
+  return generateAccounts(chainId, cnt);
+};
+
+const mockState = async (accounts: StarknetAccount[]) => {
+  const getDataSpy = jest.spyOn(snapHelper, 'getStateData');
+  const state = {
+    accContracts: accounts,
+    erc20Tokens: [],
+    networks: [],
+    transactions: [],
+  };
+  getDataSpy.mockResolvedValue(state);
+  return {
+    getDataSpy,
+    state,
+  };
+};
+
+describe('AccountStateManager', () => {
+  describe('findAccount', () => {
+    it('returns the account', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const accountsInTestnet = await mockAcccounts(chainId);
+      const accountsInMainnet = await mockAcccounts(
+        constants.StarknetChainId.SN_MAIN,
+      );
+      await mockState([...accountsInTestnet, ...accountsInMainnet]);
+
+      const stateManager = new AccountStateManager();
+      const result = await stateManager.findAccount({
+        address: accountsInTestnet[0].address,
+        chainId,
+      });
+
+      expect(result).toStrictEqual(accountsInTestnet[0]);
+    });
+
+    it('returns null if the account address can not be found', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const [accountNotExist, ...accounts] = await mockAcccounts(chainId);
+      await mockState(accounts);
+
+      const stateManager = new AccountStateManager();
+      const result = await stateManager.findAccount({
+        address: accountNotExist.address,
+        chainId,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null if the account chainId is not match', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const accounts = await mockAcccounts(chainId);
+      await mockState(accounts);
+
+      const stateManager = new AccountStateManager();
+      const result = await stateManager.findAccount({
+        address: accounts[0].address,
+        chainId: constants.StarknetChainId.SN_MAIN,
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('list', () => {
+    it('returns the list of account', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const accountsInTestnet = await mockAcccounts(chainId);
+      const accountsInMainnet = await mockAcccounts(
+        constants.StarknetChainId.SN_MAIN,
+      );
+      await mockState([...accountsInTestnet, ...accountsInMainnet]);
+      const stateManager = new AccountStateManager();
+      const result = await stateManager.list([
+        new AddressFilter([
+          accountsInTestnet[0].address,
+          accountsInMainnet[0].address,
+        ]),
+      ]);
+
+      expect(result).toStrictEqual([
+        accountsInTestnet[0],
+        accountsInMainnet[0],
+      ]);
+    });
+
+    it('returns empty array if the account address can not be found', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const [accountNotExist, ...accounts] = await mockAcccounts(chainId);
+      await mockState(accounts);
+
+      const stateManager = new AccountStateManager();
+      const result = await stateManager.list([
+        new AddressFilter([accountNotExist.address]),
+        new ChainIdFilter([chainId]),
+      ]);
+
+      expect(result).toStrictEqual([]);
+    });
+  });
+
+  describe('updateAccount', () => {
+    it('updates the account', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const accounts = await mockAcccounts(chainId);
+      const { state } = await mockState(accounts);
+
+      const stateManager = new AccountStateManager();
+      const updatedAccount = { ...accounts[0], deployTxnHash: '0x1234' };
+      await stateManager.updateAccount(updatedAccount);
+
+      expect(state.accContracts[0]).toStrictEqual(updatedAccount);
+      expect(state.accContracts[0].upgradeRequired).toBeUndefined();
+      expect(state.accContracts[0].deployRequired).toBeUndefined();
+    });
+
+    it('updates upgradeRequired and deployRequired of the account', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const accounts = await mockAcccounts(chainId);
+      const { state } = await mockState(accounts);
+
+      const stateManager = new AccountStateManager();
+      const updatedAccount = {
+        ...accounts[0],
+        upgradeRequired: true,
+        deployRequired: false,
+      };
+      await stateManager.updateAccount(updatedAccount);
+
+      expect(state.accContracts[0]).toStrictEqual(updatedAccount);
+      expect(state.accContracts[0].upgradeRequired).toBe(true);
+      expect(state.accContracts[0].deployRequired).toBe(false);
+    });
+
+    it('throws `Account does not exist` error if the update account can not be found', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const [accountNotExist, ...accounts] = await mockAcccounts(chainId);
+      await mockState(accounts);
+
+      const stateManager = new AccountStateManager();
+      const account = { ...accountNotExist, deployTxnHash: '0x1234' };
+      await expect(stateManager.updateAccount(account)).rejects.toThrow(
+        'Account does not exist',
+      );
+    });
+  });
+});

--- a/packages/starknet-snap/src/state/account-state-manager.ts
+++ b/packages/starknet-snap/src/state/account-state-manager.ts
@@ -1,0 +1,93 @@
+import type { AccContract, SnapState } from '../types/snapState';
+import type { IFilter } from './filter';
+import {
+  AddressFilter as BaseAddressFilter,
+  ChainIdFilter as BaseChainIdFilter,
+} from './filter';
+import { StateManager, StateManagerError } from './state-manager';
+
+export type IAccountFilter = IFilter<AccContract>;
+
+export class AddressFilter
+  extends BaseAddressFilter<AccContract>
+  implements IAccountFilter {}
+
+export class ChainIdFilter
+  extends BaseChainIdFilter<AccContract>
+  implements IAccountFilter {}
+
+export class AccountStateManager extends StateManager<AccContract> {
+  getCollection(state: SnapState): AccContract[] {
+    return state.accContracts;
+  }
+
+  updateEntity(dataInState: AccContract, data: AccContract): void {
+    dataInState.deployTxnHash = data.deployTxnHash;
+
+    if (data.upgradeRequired !== undefined) {
+      dataInState.upgradeRequired = data.upgradeRequired;
+    }
+    if (data.deployRequired !== undefined) {
+      dataInState.deployRequired = data.deployRequired;
+    }
+  }
+
+  async findAccount(
+    {
+      address,
+      chainId,
+    }: {
+      address: string;
+      chainId: string;
+    },
+    state?: SnapState,
+  ): Promise<AccContract | null> {
+    return this.find(
+      [new AddressFilter([address]), new ChainIdFilter([chainId])],
+      state,
+    );
+  }
+
+  async updateAccount(data: AccContract): Promise<void> {
+    try {
+      await this.update(async (state: SnapState) => {
+        const accountInState = await this.findAccount(
+          {
+            address: data.address,
+            chainId: data.chainId,
+          },
+          state,
+        );
+
+        if (!accountInState) {
+          throw new Error(`Account does not exist`);
+        }
+
+        this.updateEntity(accountInState, data);
+      });
+    } catch (error) {
+      throw new StateManagerError(error.message);
+    }
+  }
+
+  async addAccount(acc: AccContract): Promise<void> {
+    try {
+      await this.update(async (state: SnapState) => {
+        const accountInState = await this.findAccount(
+          {
+            address: acc.address,
+            chainId: acc.chainId,
+          },
+          state,
+        );
+
+        if (accountInState) {
+          throw new Error(`Account already exist`);
+        }
+        state.accContracts.push(acc);
+      });
+    } catch (error) {
+      throw new StateManagerError(error.message);
+    }
+  }
+}

--- a/packages/starknet-snap/src/state/filter.ts
+++ b/packages/starknet-snap/src/state/filter.ts
@@ -1,0 +1,114 @@
+export type IFilter<Data> = {
+  apply(data: Data): boolean;
+};
+
+export abstract class Filter<SearchDataType, Data> implements IFilter<Data> {
+  search?: SearchDataType;
+
+  optional = false;
+
+  constructor(search: SearchDataType) {
+    this.search = search;
+  }
+
+  apply(data: Data): boolean {
+    return this._apply(data);
+  }
+
+  protected abstract _apply(data: Data): boolean;
+}
+
+export abstract class MultiFilter<SearchDataType, SearchSetDataType, Data>
+  implements IFilter<Data>
+{
+  search?: SearchDataType[];
+
+  optional = false;
+
+  searchSet: Set<SearchSetDataType>;
+
+  dataKey: string;
+
+  constructor(search: SearchDataType[]) {
+    this.search = search;
+    this._prepareSearch();
+  }
+
+  protected abstract _prepareSearch();
+
+  protected abstract _apply(data: Data): boolean;
+
+  apply(data: Data): boolean {
+    if (this.search === undefined && this.optional) {
+      return true;
+    }
+    return this._apply(data);
+  }
+}
+
+export abstract class BigIntFilter<DataType> extends MultiFilter<
+  string,
+  bigint,
+  DataType
+> {
+  protected _prepareSearch(): void {
+    this.searchSet = new Set(this.search?.map((val) => BigInt(val)));
+  }
+
+  protected _apply(data: DataType): boolean {
+    return (
+      Object.prototype.hasOwnProperty.call(data, this.dataKey) &&
+      this.searchSet.has(BigInt(data[this.dataKey]))
+    );
+  }
+}
+
+export abstract class NumberFilter<DataType> extends MultiFilter<
+  number,
+  number,
+  DataType
+> {
+  protected _prepareSearch(): void {
+    this.searchSet = new Set(this.search);
+  }
+
+  protected _apply(data: DataType): boolean {
+    return (
+      Object.prototype.hasOwnProperty.call(data, this.dataKey) &&
+      this.searchSet.has(data[this.dataKey])
+    );
+  }
+}
+
+export abstract class StringFllter<DataType> extends MultiFilter<
+  string,
+  string,
+  DataType
+> {
+  protected _prepareSearch(): void {
+    this.searchSet = new Set(this.search?.map((val) => val.toLowerCase()));
+  }
+
+  protected _apply(data: DataType): boolean {
+    return (
+      Object.prototype.hasOwnProperty.call(data, this.dataKey) &&
+      this.searchSet.has(data[this.dataKey].toLowerCase())
+    );
+  }
+}
+
+export class AddressFilter<
+  DataType extends {
+    address: string;
+  },
+> extends BigIntFilter<DataType> {
+  dataKey = 'address';
+}
+
+export class ChainIdFilter<
+  DataType extends {
+    chainId: string;
+  },
+> extends BigIntFilter<DataType> {
+  dataKey = 'chainId';
+}

--- a/packages/starknet-snap/src/state/state-manager.ts
+++ b/packages/starknet-snap/src/state/state-manager.ts
@@ -1,0 +1,86 @@
+import type { SnapState } from '../types/snapState';
+import { SnapStateManager } from '../utils';
+import type { IFilter } from './filter';
+
+export class StateManagerError extends Error {}
+
+export abstract class StateManager<Entity> extends SnapStateManager<SnapState> {
+  protected override async get(): Promise<SnapState> {
+    return super.get().then((state: SnapState) => {
+      if (!state) {
+        // eslint-disable-next-line no-param-reassign
+        state = {
+          accContracts: [],
+          erc20Tokens: [],
+          networks: [],
+          transactions: [],
+        };
+      }
+
+      if (!state.accContracts) {
+        state.accContracts = [];
+      }
+
+      if (!state.erc20Tokens) {
+        state.erc20Tokens = [];
+      }
+
+      if (!state.networks) {
+        state.networks = [];
+      }
+
+      if (!state.transactions) {
+        state.transactions = [];
+      }
+
+      return state;
+    });
+  }
+
+  abstract getCollection(state: SnapState): Entity[] | undefined;
+
+  abstract updateEntity(dataInState: Entity, data: Entity): void;
+
+  async find(
+    filters: IFilter<Entity>[],
+    state?: SnapState,
+  ): Promise<Entity | null> {
+    const snapState = state ?? (await this.get());
+    return (
+      this.getCollection(snapState)?.find((data) => {
+        return filters.every((filter) => filter.apply(data));
+      }) ?? null
+    );
+  }
+
+  async list(
+    filters: IFilter<Entity>[],
+    sort?: (entityA: Entity, entityB: Entity) => number,
+    state?: SnapState,
+  ): Promise<Entity[]> {
+    const snapState = state ?? (await this.get());
+    return (
+      this.getCollection(snapState)
+        ?.filter((data) => {
+          return filters.every((filter) => filter.apply(data));
+        })
+        .sort(sort) ?? []
+    );
+  }
+  // TODO: Remove this if no longer needed
+  // async upsert(data: Entity, condition: IFilter<Entity>[]): Promise<void> {
+  //   try {
+  //     await this.update(async (state: SnapState) => {
+  //       const dataInState = await this.find(condition, state);
+
+  //       if (dataInState !== null) {
+  //         this.updateEntity(dataInState, data);
+  //       } else {
+  //         this.getCollection(state)?.push(data);
+  //       }
+  //     });
+  //   } catch (error) {
+  //     throw new StateManagerError(error.message);
+  //   }
+  // }
+}

--- a/packages/starknet-snap/src/utils/index.ts
+++ b/packages/starknet-snap/src/utils/index.ts
@@ -5,4 +5,5 @@ export * from './serializer';
 export * from './superstruct';
 export * from './logger';
 export * from './formatterUtils';
+export * from './snap-state';
 // TODO: add other utils


### PR DESCRIPTION
This PR is to add `AccountStateManager` to manage the account data in state

This PR also create an Filter Class to allow us to have data filter in OOP

usage:
```typescript
class MyFilter
  extends Filter<string, AccAcontract> {
  protected _apply(data: AccAcontract): boolean {
    return (
       data.address === this.search
    );
  }
}

const mgr = new AccountStateManager()
const result = await mgr.list([
  new MyFilter("address")
])

```

