### PR TITLE
refactor: add `NetworkStateManager`

### DIFF
--- a/packages/starknet-snap/src/state/__tests__/helper.ts
+++ b/packages/starknet-snap/src/state/__tests__/helper.ts
@@ -1,0 +1,45 @@
+import type { constants } from 'starknet';
+
+import { generateAccounts, type StarknetAccount } from '../../../test/utils';
+import type { Erc20Token, Network, Transaction } from '../../types/snapState';
+import * as snapHelper from '../../utils/snap';
+
+jest.mock('../../utils/snap');
+jest.mock('../../utils/logger');
+
+export const mockAcccounts = async (
+  chainId: constants.StarknetChainId,
+  cnt = 10,
+) => {
+  return generateAccounts(chainId, cnt);
+};
+
+export const mockState = async ({
+  accounts,
+  tokens,
+  networks,
+  transactions,
+  currentNetwork,
+}: {
+  accounts?: StarknetAccount[];
+  tokens?: Erc20Token[];
+  networks?: Network[];
+  transactions?: Transaction[];
+  currentNetwork?: Network;
+}) => {
+  const getDataSpy = jest.spyOn(snapHelper, 'getStateData');
+  const setDataSpy = jest.spyOn(snapHelper, 'setStateData');
+  const state = {
+    accContracts: accounts,
+    erc20Tokens: tokens ?? [],
+    networks: networks ?? [],
+    transactions: transactions ?? [],
+    currentNetwork,
+  };
+  getDataSpy.mockResolvedValue(state);
+  return {
+    getDataSpy,
+    setDataSpy,
+    state,
+  };
+};

--- a/packages/starknet-snap/src/state/account-state-manager.test.ts
+++ b/packages/starknet-snap/src/state/account-state-manager.test.ts
@@ -165,7 +165,7 @@ describe('AccountStateManager', () => {
       const stateManager = new AccountStateManager();
       await stateManager.addAccount(accountNotExist);
 
-      expect(state.accContracts?.length).toStrictEqual(5);
+      expect(state.accContracts?.length).toBe(5);
       expect(
         state.accContracts?.[state.accContracts?.length - 1],
       ).toStrictEqual(accountNotExist);

--- a/packages/starknet-snap/src/state/filter.ts
+++ b/packages/starknet-snap/src/state/filter.ts
@@ -5,8 +5,6 @@ export type IFilter<Data> = {
 export abstract class Filter<SearchDataType, Data> implements IFilter<Data> {
   search?: SearchDataType;
 
-  optional = false;
-
   constructor(search: SearchDataType) {
     this.search = search;
   }
@@ -21,25 +19,29 @@ export abstract class Filter<SearchDataType, Data> implements IFilter<Data> {
 export abstract class MultiFilter<SearchDataType, SearchSetDataType, Data>
   implements IFilter<Data>
 {
-  search?: SearchDataType[];
-
-  optional = false;
-
-  searchSet: Set<SearchSetDataType>;
+  search: Set<SearchSetDataType> | Map<SearchSetDataType, Data>;
 
   dataKey: string;
 
-  constructor(search: SearchDataType[]) {
-    this.search = search;
-    this._prepareSearch();
+  constructor(
+    search:
+      | SearchDataType[]
+      | Set<SearchSetDataType>
+      | Map<SearchSetDataType, Data>,
+  ) {
+    if (Array.isArray(search)) {
+      this._prepareSearch(search);
+    } else {
+      this.search = search;
+    }
   }
 
-  protected abstract _prepareSearch();
+  protected abstract _prepareSearch(search: SearchDataType[]): void;
 
   protected abstract _apply(data: Data): boolean;
 
   apply(data: Data): boolean {
-    if (this.search === undefined && this.optional) {
+    if (this.search === undefined) {
       return true;
     }
     return this._apply(data);
@@ -51,14 +53,14 @@ export abstract class BigIntFilter<DataType> extends MultiFilter<
   bigint,
   DataType
 > {
-  protected _prepareSearch(): void {
-    this.searchSet = new Set(this.search?.map((val) => BigInt(val)));
+  protected _prepareSearch(search: string[]): void {
+    this.search = new Set(search?.map((val) => BigInt(val)));
   }
 
   protected _apply(data: DataType): boolean {
     return (
       Object.prototype.hasOwnProperty.call(data, this.dataKey) &&
-      this.searchSet.has(BigInt(data[this.dataKey]))
+      this.search.has(BigInt(data[this.dataKey]))
     );
   }
 }
@@ -68,14 +70,14 @@ export abstract class NumberFilter<DataType> extends MultiFilter<
   number,
   DataType
 > {
-  protected _prepareSearch(): void {
-    this.searchSet = new Set(this.search);
+  protected _prepareSearch(search: number[]): void {
+    this.search = new Set(search);
   }
 
   protected _apply(data: DataType): boolean {
     return (
       Object.prototype.hasOwnProperty.call(data, this.dataKey) &&
-      this.searchSet.has(data[this.dataKey])
+      this.search.has(data[this.dataKey])
     );
   }
 }
@@ -85,14 +87,14 @@ export abstract class StringFllter<DataType> extends MultiFilter<
   string,
   DataType
 > {
-  protected _prepareSearch(): void {
-    this.searchSet = new Set(this.search?.map((val) => val.toLowerCase()));
+  protected _prepareSearch(search: string[]): void {
+    this.search = new Set(search?.map((val) => val.toLowerCase()));
   }
 
   protected _apply(data: DataType): boolean {
     return (
       Object.prototype.hasOwnProperty.call(data, this.dataKey) &&
-      this.searchSet.has(data[this.dataKey].toLowerCase())
+      this.search.has(data[this.dataKey].toLowerCase())
     );
   }
 }

--- a/packages/starknet-snap/src/state/network-state-manager.test.ts
+++ b/packages/starknet-snap/src/state/network-state-manager.test.ts
@@ -11,7 +11,7 @@ import { StateManagerError } from './state-manager';
 
 describe('NetworkStateManager', () => {
   describe('findNetwork', () => {
-    it('returns the token', async () => {
+    it('returns the network', async () => {
       const chainId = constants.StarknetChainId.SN_SEPOLIA;
       await mockState({
         networks: [STARKNET_MAINNET_NETWORK, STARKNET_SEPOLIA_TESTNET_NETWORK],
@@ -25,7 +25,7 @@ describe('NetworkStateManager', () => {
       expect(result).toStrictEqual(STARKNET_SEPOLIA_TESTNET_NETWORK);
     });
 
-    it('returns null if the token can not be found', async () => {
+    it('returns null if the network can not be found', async () => {
       const chainId = constants.StarknetChainId.SN_SEPOLIA;
       await mockState({
         networks: [STARKNET_MAINNET_NETWORK],
@@ -112,7 +112,7 @@ describe('NetworkStateManager', () => {
       expect(result).toStrictEqual([STARKNET_SEPOLIA_TESTNET_NETWORK]);
     });
 
-    it('returns empty array if the account address can not be found', async () => {
+    it('returns empty array if a network with the given chainId cannot be found', async () => {
       const chainId = constants.StarknetChainId.SN_SEPOLIA;
       await mockState({
         networks: [STARKNET_MAINNET_NETWORK],

--- a/packages/starknet-snap/src/state/network-state-manager.test.ts
+++ b/packages/starknet-snap/src/state/network-state-manager.test.ts
@@ -1,0 +1,243 @@
+import { constants } from 'starknet';
+
+import type { Network } from '../types/snapState';
+import {
+  STARKNET_MAINNET_NETWORK,
+  STARKNET_SEPOLIA_TESTNET_NETWORK,
+} from '../utils/constants';
+import { mockState } from './__tests__/helper';
+import { NetworkStateManager, ChainIdFilter } from './network-state-manager';
+import { StateManagerError } from './state-manager';
+
+describe('NetworkStateManager', () => {
+  describe('findNetwork', () => {
+    it('returns the token', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      await mockState({
+        networks: [STARKNET_MAINNET_NETWORK, STARKNET_SEPOLIA_TESTNET_NETWORK],
+      });
+
+      const stateManager = new NetworkStateManager();
+      const result = await stateManager.findNetwork({
+        chainId,
+      });
+
+      expect(result).toStrictEqual(STARKNET_SEPOLIA_TESTNET_NETWORK);
+    });
+
+    it('returns null if the token can not be found', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      await mockState({
+        networks: [STARKNET_MAINNET_NETWORK],
+      });
+
+      const stateManager = new NetworkStateManager();
+      const result = await stateManager.findNetwork({
+        chainId,
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('addDefaultNetworks', () => {
+    it("adds the networks if the given networks don't exist", async () => {
+      const { state } = await mockState({
+        networks: [],
+      });
+
+      const stateManager = new NetworkStateManager();
+      await stateManager.addDefaultNetworks([
+        STARKNET_MAINNET_NETWORK,
+        STARKNET_SEPOLIA_TESTNET_NETWORK,
+      ]);
+
+      expect(state.networks).toStrictEqual([
+        STARKNET_MAINNET_NETWORK,
+        STARKNET_SEPOLIA_TESTNET_NETWORK,
+      ]);
+    });
+
+    it('updates the networks if the given networks found', async () => {
+      const { state } = await mockState({
+        networks: [STARKNET_MAINNET_NETWORK],
+      });
+
+      const stateManager = new NetworkStateManager();
+      await stateManager.addDefaultNetworks([
+        {
+          ...STARKNET_MAINNET_NETWORK,
+          name: 'Updated Network',
+        },
+        STARKNET_SEPOLIA_TESTNET_NETWORK,
+      ]);
+
+      expect(state.networks[0]).toStrictEqual({
+        ...STARKNET_MAINNET_NETWORK,
+        name: 'Updated Network',
+      });
+      expect(state.networks[1]).toStrictEqual(STARKNET_SEPOLIA_TESTNET_NETWORK);
+    });
+
+    it('throws a `StateManagerError` if an error was thrown', async () => {
+      const { getDataSpy } = await mockState({
+        networks: [STARKNET_MAINNET_NETWORK],
+      });
+      getDataSpy.mockRejectedValue(new Error('Error'));
+
+      const stateManager = new NetworkStateManager();
+
+      await expect(
+        stateManager.addDefaultNetworks([
+          {
+            ...STARKNET_MAINNET_NETWORK,
+            name: 'Updated Network',
+          },
+          STARKNET_SEPOLIA_TESTNET_NETWORK,
+        ]),
+      ).rejects.toThrow(StateManagerError);
+    });
+  });
+
+  describe('list', () => {
+    it('returns the list of network by chainId', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      await mockState({
+        networks: [STARKNET_MAINNET_NETWORK, STARKNET_SEPOLIA_TESTNET_NETWORK],
+      });
+
+      const stateManager = new NetworkStateManager();
+      const result = await stateManager.list([new ChainIdFilter([chainId])]);
+
+      expect(result).toStrictEqual([STARKNET_SEPOLIA_TESTNET_NETWORK]);
+    });
+
+    it('returns empty array if the account address can not be found', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      await mockState({
+        networks: [STARKNET_MAINNET_NETWORK],
+      });
+
+      const stateManager = new NetworkStateManager();
+      const result = await stateManager.list([new ChainIdFilter([chainId])]);
+
+      expect(result).toStrictEqual([]);
+    });
+  });
+
+  describe('updateNetwork', () => {
+    it('updates the network', async () => {
+      const { state } = await mockState({
+        networks: [STARKNET_MAINNET_NETWORK],
+      });
+
+      const stateManager = new NetworkStateManager();
+      const updatedEntity = {
+        ...STARKNET_MAINNET_NETWORK,
+        name: 'Updated Network',
+        nodeUrl: 'http://localhost:8080',
+      };
+      await stateManager.updateNetwork(updatedEntity);
+
+      expect(state.networks[0]).toStrictEqual(updatedEntity);
+    });
+
+    it('throws `Network does not exist` error if the update entity can not be found', async () => {
+      await mockState({
+        networks: [STARKNET_MAINNET_NETWORK],
+      });
+
+      const stateManager = new NetworkStateManager();
+      const updatedEntity = {
+        ...STARKNET_SEPOLIA_TESTNET_NETWORK,
+        name: 'Updated Network',
+        nodeUrl: 'http://localhost:8080',
+      };
+
+      await expect(stateManager.updateNetwork(updatedEntity)).rejects.toThrow(
+        'Network does not exist',
+      );
+    });
+  });
+
+  describe('getCurrentNetwork', () => {
+    it('get the current network', async () => {
+      await mockState({
+        networks: [STARKNET_MAINNET_NETWORK, STARKNET_SEPOLIA_TESTNET_NETWORK],
+        currentNetwork: STARKNET_MAINNET_NETWORK,
+      });
+
+      const stateManager = new NetworkStateManager();
+      const result = await stateManager.getCurrentNetwork();
+
+      expect(result).toStrictEqual(STARKNET_MAINNET_NETWORK);
+    });
+
+    it('returns null if the current network is null or undefined', async () => {
+      await mockState({
+        networks: [STARKNET_MAINNET_NETWORK, STARKNET_SEPOLIA_TESTNET_NETWORK],
+      });
+
+      const stateManager = new NetworkStateManager();
+      const result = await stateManager.getCurrentNetwork();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('setCurrentNetwork', () => {
+    it.each([
+      {
+        status: 'undefined',
+        currentNetwork: undefined,
+        updateTo: STARKNET_SEPOLIA_TESTNET_NETWORK,
+      },
+      {
+        status: 'same',
+        currentNetwork: STARKNET_MAINNET_NETWORK,
+        updateTo: STARKNET_MAINNET_NETWORK,
+      },
+      {
+        status: 'different',
+        currentNetwork: STARKNET_MAINNET_NETWORK,
+        updateTo: STARKNET_SEPOLIA_TESTNET_NETWORK,
+      },
+    ])(
+      'set the current network when the current network is $status',
+      async ({
+        currentNetwork,
+        updateTo,
+      }: {
+        status: string;
+        currentNetwork: Network;
+        updateTo: Network;
+      }) => {
+        const { state } = await mockState({
+          networks: [
+            STARKNET_MAINNET_NETWORK,
+            STARKNET_SEPOLIA_TESTNET_NETWORK,
+          ],
+          currentNetwork,
+        });
+
+        const stateManager = new NetworkStateManager();
+        await stateManager.setCurrentNetwork(updateTo);
+
+        expect(state.currentNetwork).toStrictEqual(updateTo);
+      },
+    );
+
+    it('throws a `StateManagerError` if an error was thrown', async () => {
+      const { setDataSpy } = await mockState({
+        networks: [STARKNET_MAINNET_NETWORK],
+      });
+      setDataSpy.mockRejectedValue(new Error('Error'));
+
+      const stateManager = new NetworkStateManager();
+
+      await expect(
+        stateManager.setCurrentNetwork(STARKNET_SEPOLIA_TESTNET_NETWORK),
+      ).rejects.toThrow(StateManagerError);
+    });
+  });
+});

--- a/packages/starknet-snap/src/state/network-state-manager.ts
+++ b/packages/starknet-snap/src/state/network-state-manager.ts
@@ -23,6 +23,14 @@ export class NetworkStateManager extends StateManager<Network> {
     dataInState.nodeUrl = data.nodeUrl;
   }
 
+  /**
+   * Add default network by the given chainId.
+   * If the network object not exist, it will be added.
+   * If the network object exist, it will be updated.
+   *
+   * @param networks - An array of the networks object.
+   * @returns A Promise that resolves when the operation is complete.
+   */
   async addDefaultNetworks(networks: Network[]): Promise<void> {
     try {
       await this.update(async (state: SnapState) => {

--- a/packages/starknet-snap/src/state/network-state-manager.ts
+++ b/packages/starknet-snap/src/state/network-state-manager.ts
@@ -1,0 +1,126 @@
+import { assert, string } from 'superstruct';
+
+import type { Network, SnapState } from '../types/snapState';
+import type { IFilter } from './filter';
+import { ChainIdFilter as BaseChainIdFilter } from './filter';
+import { StateManager, StateManagerError } from './state-manager';
+
+export type INetworkFilter = IFilter<Network>;
+
+export class ChainIdFilter
+  extends BaseChainIdFilter<Network>
+  implements INetworkFilter {}
+
+export class NetworkStateManager extends StateManager<Network> {
+  protected getCollection(state: SnapState): Network[] {
+    return state.networks;
+  }
+
+  protected updateEntity(dataInState: Network, data: Network): void {
+    assert(dataInState.name, string());
+
+    dataInState.name = data.name;
+    dataInState.nodeUrl = data.nodeUrl;
+  }
+
+  async addDefaultNetworks(networks: Network[]): Promise<void> {
+    try {
+      await this.update(async (state: SnapState) => {
+        // Build a map of chainId to Network object from the current state.
+        const chainMap = new Map<bigint, Network>();
+        for (const network of state.networks) {
+          const key = BigInt(network.chainId);
+          chainMap.set(key, network);
+        }
+
+        // Check if the network already exists in the state. True - update the network object, False - insert the network object.
+        for (const network of networks) {
+          // Same comparison as chainIdFilter.
+          const data = chainMap.get(BigInt(network.chainId));
+          if (data === undefined) {
+            state.networks.push(network);
+          } else {
+            this.updateEntity(data, network);
+          }
+        }
+      });
+    } catch (error) {
+      throw new StateManagerError(error.message);
+    }
+  }
+
+  /**
+   * Finds a network based on the given chainId.
+   *
+   * @param param - The param object.
+   * @param param.chainId - The chainId to search for.
+   * @param [state] - The optional SnapState object.
+   * @returns A Promise that resolves with the Network object if found, or null if not found.
+   */
+  async findNetwork(
+    {
+      chainId,
+    }: {
+      chainId: string;
+    },
+    state?: SnapState,
+  ): Promise<Network | null> {
+    const filters: INetworkFilter[] = [new ChainIdFilter([chainId])];
+    return this.find(filters, state);
+  }
+
+  /**
+   * Updates a network in the state with the given data.
+   *
+   * @param data - The updated Network object.
+   * @returns A Promise that resolves when the update is complete.
+   * @throws {StateManagerError} If there is an error updating the network, such as:
+   * If the network to be updated does not exist in the state.
+   */
+  async updateNetwork(data: Network): Promise<void> {
+    try {
+      await this.update(async (state: SnapState) => {
+        const dataInState = await this.findNetwork(
+          {
+            chainId: data.chainId,
+          },
+          state,
+        );
+
+        if (!dataInState) {
+          throw new Error(`Network does not exist`);
+        }
+        this.updateEntity(dataInState, data);
+      });
+    } catch (error) {
+      throw new StateManagerError(error.message);
+    }
+  }
+
+  /**
+   * Gets the current network from the state.
+   *
+   * @param [state] - The optional SnapState object.
+   * @returns A Promise that resolves with the current Network object if found, or null if not found.
+   */
+  async getCurrentNetwork(state?: SnapState): Promise<Network | null> {
+    return (state ?? (await this.get())).currentNetwork ?? null;
+  }
+
+  /**
+   * Sets the current network in the state with the given data.
+   *
+   * @param data - The Network object to set as the current network.
+   * @returns A Promise that resolves when the update is complete.
+   * @throws {StateManagerError} If there is an error setting the current network.
+   */
+  async setCurrentNetwork(data: Network): Promise<void> {
+    try {
+      await this.update(async (state: SnapState) => {
+        state.currentNetwork = data;
+      });
+    } catch (error) {
+      throw new StateManagerError(error.message);
+    }
+  }
+}

--- a/packages/starknet-snap/src/state/state-manager.ts
+++ b/packages/starknet-snap/src/state/state-manager.ts
@@ -37,10 +37,18 @@ export abstract class StateManager<Entity> extends SnapStateManager<SnapState> {
     });
   }
 
-  abstract getCollection(state: SnapState): Entity[] | undefined;
+  protected abstract getCollection(state: SnapState): Entity[] | undefined;
 
-  abstract updateEntity(dataInState: Entity, data: Entity): void;
+  protected abstract updateEntity(dataInState: Entity, data: Entity): void;
 
+  /**
+   *
+   * Finds an entity in the state that matches the given filters.
+   *
+   * @param filters - An array of filters to apply to the entities.
+   * @param [state] - The optional SnapState object.
+   * @returns A Promise that resolves with the matching Entity object if found, or null if not found.
+   */
   async find(
     filters: IFilter<Entity>[],
     state?: SnapState,
@@ -53,6 +61,15 @@ export abstract class StateManager<Entity> extends SnapStateManager<SnapState> {
     );
   }
 
+  /**
+   *
+   * Lists all entities in the state that match the given filters, optionally sorted.
+   *
+   * @param filters - An array of filters to apply to the entities.
+   * @param [sort] - An optional sorting function.
+   * @param [state] - The optional SnapState object.
+   * @returns A Promise that resolves with an array of matching Entity objects.
+   */
   async list(
     filters: IFilter<Entity>[],
     sort?: (entityA: Entity, entityB: Entity) => number,


### PR DESCRIPTION
This PR is to add `NetworkStateManager` as similar as this https://github.com/Consensys/starknet-snap/pull/323

this manager allow caller to:
- update, list, get the network
- set, get the current network
- add default networks by given a list of network to check if it has to update / insert

this PR also adding a test helper  in './state/__tests__/helper.ts' to reduce the duplication of the test code across all state manager

