### PR TITLE
refactor: add `TokenStateManager` 

### DIFF
--- a/packages/starknet-snap/src/state/token-state-manager.test.ts
+++ b/packages/starknet-snap/src/state/token-state-manager.test.ts
@@ -1,0 +1,311 @@
+import { constants } from 'starknet';
+
+import type { Erc20Token } from '../types/snapState';
+import {
+  ETHER_MAINNET,
+  ETHER_SEPOLIA_TESTNET,
+  STRK_MAINNET,
+  STRK_SEPOLIA_TESTNET,
+} from '../utils/constants';
+import { mockState } from './__tests__/helper';
+import { StateManagerError } from './state-manager';
+import { TokenStateManager, ChainIdFilter } from './token-state-manager';
+
+describe('TokenStateManager', () => {
+  describe('findToken', () => {
+    it('returns the token', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      await mockState({
+        tokens: [ETHER_MAINNET, ETHER_SEPOLIA_TESTNET],
+      });
+
+      const stateManager = new TokenStateManager();
+      const result = await stateManager.findToken({
+        chainId,
+        address: ETHER_SEPOLIA_TESTNET.address,
+      });
+
+      expect(result).toStrictEqual(ETHER_SEPOLIA_TESTNET);
+    });
+
+    it('finds the token by symbol', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      await mockState({
+        tokens: [ETHER_MAINNET, ETHER_SEPOLIA_TESTNET],
+      });
+
+      const stateManager = new TokenStateManager();
+      const result = await stateManager.findToken({
+        chainId,
+        address: ETHER_SEPOLIA_TESTNET.address,
+      });
+
+      expect(result).toStrictEqual(ETHER_SEPOLIA_TESTNET);
+    });
+
+    it('returns null if the token can not be found', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      await mockState({
+        tokens: [ETHER_MAINNET],
+      });
+
+      const stateManager = new TokenStateManager();
+      const result = await stateManager.findToken({
+        chainId,
+        address: ETHER_SEPOLIA_TESTNET.address,
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('addDefaultTokens', () => {
+    it("adds tokens if the given tokens don't exist", async () => {
+      const { state } = await mockState({
+        tokens: [],
+      });
+
+      const stateManager = new TokenStateManager();
+      await stateManager.addDefaultTokens([
+        ETHER_MAINNET,
+        ETHER_SEPOLIA_TESTNET,
+      ]);
+
+      expect(state.erc20Tokens).toStrictEqual([
+        ETHER_MAINNET,
+        ETHER_SEPOLIA_TESTNET,
+      ]);
+    });
+
+    it('updates the tokens if the given tokens found', async () => {
+      const { state } = await mockState({
+        tokens: [ETHER_MAINNET],
+      });
+
+      const stateManager = new TokenStateManager();
+      await stateManager.addDefaultTokens([
+        {
+          ...ETHER_MAINNET,
+          name: 'Updated Token',
+        },
+        ETHER_SEPOLIA_TESTNET,
+      ]);
+
+      expect(state.erc20Tokens[0]).toStrictEqual({
+        ...ETHER_MAINNET,
+        name: 'Updated Token',
+      });
+      expect(state.erc20Tokens[1]).toStrictEqual(ETHER_SEPOLIA_TESTNET);
+    });
+
+    it('throws a `StateManagerError` if an error was thrown', async () => {
+      const { getDataSpy } = await mockState({
+        tokens: [ETHER_MAINNET],
+      });
+      getDataSpy.mockRejectedValue(new Error('Error'));
+
+      const stateManager = new TokenStateManager();
+
+      await expect(
+        stateManager.addDefaultTokens([
+          {
+            ...ETHER_MAINNET,
+            name: 'Updated Token',
+          },
+          ETHER_SEPOLIA_TESTNET,
+        ]),
+      ).rejects.toThrow(StateManagerError);
+    });
+  });
+
+  describe('list', () => {
+    it('returns the list of token by chainId', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      await mockState({
+        tokens: [ETHER_MAINNET, ETHER_SEPOLIA_TESTNET],
+      });
+
+      const stateManager = new TokenStateManager();
+      const result = await stateManager.list([new ChainIdFilter([chainId])]);
+
+      expect(result).toStrictEqual([ETHER_SEPOLIA_TESTNET]);
+    });
+
+    it('returns empty array if a token with the given chainId cannot be found', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      await mockState({
+        tokens: [ETHER_MAINNET],
+      });
+
+      const stateManager = new TokenStateManager();
+      const result = await stateManager.list([new ChainIdFilter([chainId])]);
+
+      expect(result).toStrictEqual([]);
+    });
+  });
+
+  describe('updateToken', () => {
+    it('updates the token', async () => {
+      const { state } = await mockState({
+        tokens: [ETHER_MAINNET],
+      });
+
+      const stateManager = new TokenStateManager();
+      const updatedEntity = {
+        ...ETHER_MAINNET,
+        name: 'Updated Token',
+      };
+      await stateManager.updateToken(updatedEntity);
+
+      expect(state.erc20Tokens[0]).toStrictEqual(updatedEntity);
+    });
+
+    it('throws `Token does not exist` error if the update entity can not be found', async () => {
+      await mockState({
+        tokens: [ETHER_MAINNET],
+      });
+
+      const stateManager = new TokenStateManager();
+      const updatedEntity = {
+        ...ETHER_SEPOLIA_TESTNET,
+        name: 'Updated Token',
+      };
+
+      await expect(stateManager.updateToken(updatedEntity)).rejects.toThrow(
+        'Token does not exist',
+      );
+    });
+  });
+
+  describe('getEthToken', () => {
+    it.each([
+      {
+        chainId: constants.StarknetChainId.SN_MAIN,
+        token: ETHER_MAINNET,
+      },
+      {
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
+        token: ETHER_SEPOLIA_TESTNET,
+      },
+    ])(
+      'returns the ETH token if the chain id is $chainId',
+      async ({ chainId, token }: { chainId: string; token: Erc20Token }) => {
+        await mockState({
+          tokens: [token],
+        });
+
+        const stateManager = new TokenStateManager();
+        const result = await stateManager.getEthToken({
+          chainId,
+        });
+
+        expect(result).toStrictEqual(token);
+      },
+    );
+
+    it('returns null if the ETH token is null or undefined', async () => {
+      await mockState({
+        tokens: [ETHER_MAINNET],
+      });
+
+      const stateManager = new TokenStateManager();
+      const result = await stateManager.getEthToken({
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null if the chain id is not supported', async () => {
+      await mockState({
+        tokens: [ETHER_MAINNET],
+      });
+
+      const stateManager = new TokenStateManager();
+      const result = await stateManager.getEthToken({
+        chainId: 'invalid-chain-id',
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getStrkToken', () => {
+    it.each([
+      {
+        chainId: constants.StarknetChainId.SN_MAIN,
+        token: STRK_MAINNET,
+      },
+      {
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
+        token: STRK_SEPOLIA_TESTNET,
+      },
+    ])(
+      'return the STRK token if the chain id is $chainId',
+      async ({ chainId, token }: { chainId: string; token: Erc20Token }) => {
+        await mockState({
+          tokens: [token],
+        });
+
+        const stateManager = new TokenStateManager();
+        const result = await stateManager.getStrkToken({
+          chainId,
+        });
+
+        expect(result).toStrictEqual(token);
+      },
+    );
+
+    it('returns null if the STRK token is null or undefined', async () => {
+      await mockState({
+        tokens: [STRK_MAINNET],
+      });
+
+      const stateManager = new TokenStateManager();
+      const result = await stateManager.getStrkToken({
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null if the chain id is not supported', async () => {
+      await mockState({
+        tokens: [STRK_SEPOLIA_TESTNET],
+      });
+
+      const stateManager = new TokenStateManager();
+      const result = await stateManager.getStrkToken({
+        chainId: 'invalid-chain-id',
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('addToken', () => {
+    it('adds the token', async () => {
+      const { state } = await mockState({
+        tokens: [ETHER_MAINNET],
+      });
+
+      const stateManager = new TokenStateManager();
+      await stateManager.addToken(ETHER_SEPOLIA_TESTNET);
+
+      expect(state.erc20Tokens[1]).toStrictEqual(ETHER_SEPOLIA_TESTNET);
+    });
+
+    it('throws a `Token already exist` error if the token is exist', async () => {
+      const { setDataSpy } = await mockState({
+        tokens: [ETHER_MAINNET],
+      });
+      setDataSpy.mockRejectedValue(new Error('Error'));
+
+      const stateManager = new TokenStateManager();
+
+      await expect(stateManager.addToken(ETHER_MAINNET)).rejects.toThrow(
+        StateManagerError,
+      );
+    });
+  });
+});

--- a/packages/starknet-snap/src/state/token-state-manager.ts
+++ b/packages/starknet-snap/src/state/token-state-manager.ts
@@ -1,0 +1,245 @@
+import { constants } from 'starknet';
+import { assert, min, nonempty, number, string } from 'superstruct';
+
+import type { Erc20Token, SnapState } from '../types/snapState';
+import {
+  ETHER_MAINNET,
+  ETHER_SEPOLIA_TESTNET,
+  STRK_MAINNET,
+  STRK_SEPOLIA_TESTNET,
+} from '../utils/constants';
+import type { IFilter } from './filter';
+import {
+  AddressFilter as BaseAddressFilter,
+  ChainIdFilter as BaseChainIdFilter,
+} from './filter';
+import { StateManager, StateManagerError } from './state-manager';
+
+export type ITokenFilter = IFilter<Erc20Token>;
+
+export class AddressFilter
+  extends BaseAddressFilter<Erc20Token>
+  implements ITokenFilter {}
+
+export class ChainIdFilter
+  extends BaseChainIdFilter<Erc20Token>
+  implements ITokenFilter {}
+
+export class TokenStateManager extends StateManager<Erc20Token> {
+  protected getCollection(state: SnapState): Erc20Token[] {
+    return state.erc20Tokens;
+  }
+
+  protected updateEntity(dataInState: Erc20Token, data: Erc20Token): void {
+    assert(data.name, nonempty(string()));
+    assert(data.symbol, nonempty(string()));
+    assert(data.decimals, min(number(), 0));
+
+    dataInState.name = data.name;
+    dataInState.symbol = data.symbol;
+    dataInState.decimals = data.decimals;
+  }
+
+  #getCompositeKey(data: Erc20Token): string {
+    const key1 = BigInt(data.chainId);
+    const key2 = BigInt(data.address);
+    return `${key1}&${key2}`;
+  }
+
+  /**
+   * Add default Erc20Token tokens by the given chain id.
+   * If the Erc20Token object not exist, it will be added.
+   * If the Erc20Token object exist, it will be updated.
+   *
+   * @param tokens - An array of the Erc20Token object.
+   * @returns A Promise that resolves when the operation is complete.
+   */
+  async addDefaultTokens(tokens: Erc20Token[]): Promise<void> {
+    try {
+      await this.update(async (state: SnapState) => {
+        // Build a map of the token address to Erc20Token object from the current state.
+        const tokenMap = new Map<string, Erc20Token>();
+        for (const token of state.erc20Tokens) {
+          tokenMap.set(this.#getCompositeKey(token), token);
+        }
+
+        // Check if the Erc20Token object already exists in the state. True - update the Erc20Token object, False - insert the Erc20Token object.
+        for (const token of tokens) {
+          // Same comparison as aove.
+          const data = tokenMap.get(this.#getCompositeKey(token));
+          if (data === undefined) {
+            state.erc20Tokens.push(token);
+          } else {
+            this.updateEntity(data, token);
+          }
+        }
+      });
+    } catch (error) {
+      throw new StateManagerError(error.message);
+    }
+  }
+
+  /**
+   * Finds a Erc20Token based on the given chainId.
+   *
+   * @param param - The param object.
+   * @param param.address - The contract address of the Erc20Token to search for.
+   * @param param.chainId - The chainId of the Erc20Token to search for.
+   * @param [state] - The optional SnapState object.
+   * @returns A Promise that resolves with the Erc20Token object if found, or null if not found.
+   */
+  async findToken(
+    {
+      address,
+      chainId,
+    }: {
+      address: string;
+      chainId: string;
+    },
+    state?: SnapState,
+  ): Promise<Erc20Token | null> {
+    const filters: ITokenFilter[] = [
+      new AddressFilter([address]),
+      new ChainIdFilter([chainId]),
+    ];
+    return await this.find(filters, state);
+  }
+
+  /**
+   * Updates a Erc20Token object in the state with the given data.
+   *
+   * @param data - The updated Erc20Token object.
+   * @returns A Promise that resolves when the update is complete.
+   * @throws {StateManagerError} If there is an error updating the Erc20Token, such as:
+   * If the Erc20Token to be updated does not exist in the state.
+   */
+  async updateToken(data: Erc20Token): Promise<void> {
+    try {
+      await this.update(async (state: SnapState) => {
+        const dataInState = await this.findToken(
+          {
+            address: data.address,
+            chainId: data.chainId,
+          },
+          state,
+        );
+
+        if (!dataInState) {
+          throw new Error(`Token does not exist`);
+        }
+        this.updateEntity(dataInState, data);
+      });
+    } catch (error) {
+      throw new StateManagerError(error.message);
+    }
+  }
+
+  /**
+   * Adds a new Erc20Token object to the state with the given data.
+   *
+   * @param data - The Erc20Token object to add.
+   * @returns A Promise that resolves when the add is complete.
+   * @throws {StateManagerError} If there is an error adding the Erc20Token object, such as:
+   * If the Erc20Token object to be added already exists in the state.
+   */
+  async addToken(data: Erc20Token): Promise<void> {
+    try {
+      await this.update(async (state: SnapState) => {
+        const dataInState = await this.findToken(
+          {
+            address: data.address,
+            chainId: data.chainId,
+          },
+          state,
+        );
+
+        if (dataInState) {
+          throw new Error(`Token already exist`);
+        }
+        state.erc20Tokens.push(data);
+      });
+    } catch (error) {
+      throw new StateManagerError(error.message);
+    }
+  }
+
+  /**
+   * Finds the ETH Erc20Token object based on the given chainId.
+   *
+   * @param param - The param object.
+   * @param param.chainId - The chain id to search for.
+   * @param [state] - The optional SnapState object.
+   * @returns A Promise that resolves with the Erc20Token object if found, or null if not found.
+   */
+  async getEthToken(
+    {
+      chainId,
+    }: {
+      chainId: string;
+    },
+    state?: SnapState,
+  ): Promise<Erc20Token | null> {
+    const address = this.#getEthAddress(chainId);
+    if (!address) {
+      return null;
+    }
+    return await this.findToken(
+      {
+        address,
+        chainId,
+      },
+      state,
+    );
+  }
+
+  /**
+   * Finds the STRK Erc20Token object based on the given chainId.
+   *
+   * @param param - The param object.
+   * @param param.chainId - The chain id to search for.
+   * @param [state] - The optional SnapState object.
+   * @returns A Promise that resolves with the Erc20Token object if found, or null if not found.
+   */
+  async getStrkToken(
+    {
+      chainId,
+    }: {
+      chainId: string;
+    },
+    state?: SnapState,
+  ): Promise<Erc20Token | null> {
+    const address = this.#getStrkAddress(chainId);
+    if (!address) {
+      return null;
+    }
+    return await this.findToken(
+      {
+        address,
+        chainId,
+      },
+      state,
+    );
+  }
+
+  #getEthAddress(chainId: string): string {
+    switch (chainId) {
+      case constants.StarknetChainId.SN_MAIN:
+        return ETHER_MAINNET.address;
+      case constants.StarknetChainId.SN_SEPOLIA:
+        return ETHER_SEPOLIA_TESTNET.address;
+      default:
+        return '';
+    }
+  }
+
+  #getStrkAddress(chainId: string): string {
+    switch (chainId) {
+      case constants.StarknetChainId.SN_MAIN:
+        return STRK_MAINNET.address;
+      case constants.StarknetChainId.SN_SEPOLIA:
+        return STRK_SEPOLIA_TESTNET.address;
+      default:
+        return '';
+    }
+  }
+}


### PR DESCRIPTION
This PR is to add `TokenStateManager` to manage the token state as similar as this https://github.com/Consensys/starknet-snap/pull/323

this manager allow caller to:
- update, list, get the token
- get eth token by chain id
- get strj token by chain id
- add default tokens by given a list of tokens to check if it has to update / insert

