### PR TITLE
refactor: add `TransactionStateManager`

### DIFF
--- a/packages/starknet-snap/src/state/transaction-state-manager.test.ts
+++ b/packages/starknet-snap/src/state/transaction-state-manager.test.ts
@@ -36,13 +36,13 @@ describe('TransactionStateManager', () => {
     };
   };
 
-  describe('findTransaction', () => {
+  describe('getTransaction', () => {
     it('returns the transaction', async () => {
       const chainId = constants.StarknetChainId.SN_SEPOLIA;
       const { txns } = await prepareMockData(chainId);
 
       const stateManager = new TransactionStateManager();
-      const result = await stateManager.findTransaction({
+      const result = await stateManager.getTransaction({
         txnHash: txns[0].txnHash,
       });
 
@@ -54,7 +54,7 @@ describe('TransactionStateManager', () => {
       const { txns } = await prepareMockData(chainId);
 
       const stateManager = new TransactionStateManager();
-      const result = await stateManager.findTransaction({
+      const result = await stateManager.getTransaction({
         txnHash: txns[1].txnHash,
         chainId: txns[1].chainId,
       });
@@ -68,7 +68,7 @@ describe('TransactionStateManager', () => {
 
       const stateManager = new TransactionStateManager();
 
-      const result = await stateManager.findTransaction({
+      const result = await stateManager.getTransaction({
         txnHash: txns[0].txnHash,
         chainId: constants.StarknetChainId.SN_MAIN,
       });

--- a/packages/starknet-snap/src/state/transaction-state-manager.test.ts
+++ b/packages/starknet-snap/src/state/transaction-state-manager.test.ts
@@ -1,0 +1,367 @@
+import {
+  TransactionType,
+  constants,
+  TransactionFinalityStatus,
+  TransactionExecutionStatus,
+} from 'starknet';
+
+import { generateTransactions } from '../../test/utils';
+import { PRELOADED_TOKENS } from '../utils/constants';
+import { mockAcccounts, mockState } from './__tests__/helper';
+import { StateManagerError } from './state-manager';
+import { TransactionStateManager } from './transaction-state-manager';
+
+describe('TransactionStateManager', () => {
+  const prepareMockData = async (chainId) => {
+    const accounts = await mockAcccounts(chainId, 1);
+    const txns = generateTransactions({
+      chainId,
+      address: accounts[0].address,
+      txnTypes: [
+        TransactionType.DECLARE,
+        TransactionType.DEPLOY_ACCOUNT,
+        TransactionType.INVOKE,
+      ],
+      cnt: 10,
+    });
+    const { state, setDataSpy, getDataSpy } = await mockState({
+      transactions: txns,
+    });
+    return {
+      state,
+      setDataSpy,
+      getDataSpy,
+      account: accounts[0],
+      txns,
+    };
+  };
+
+  describe('findTransaction', () => {
+    it('returns the transaction', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const { txns } = await prepareMockData(chainId);
+
+      const stateManager = new TransactionStateManager();
+      const result = await stateManager.findTransaction({
+        txnHash: txns[0].txnHash,
+      });
+
+      expect(result).toStrictEqual(txns[0]);
+    });
+
+    it('finds the transaction by chainId and txnHash', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const { txns } = await prepareMockData(chainId);
+
+      const stateManager = new TransactionStateManager();
+      const result = await stateManager.findTransaction({
+        txnHash: txns[1].txnHash,
+        chainId: txns[1].chainId,
+      });
+
+      expect(result).toStrictEqual(txns[1]);
+    });
+
+    it('returns null if the transaction can not be found', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const { txns } = await prepareMockData(chainId);
+
+      const stateManager = new TransactionStateManager();
+
+      const result = await stateManager.findTransaction({
+        txnHash: txns[0].txnHash,
+        chainId: constants.StarknetChainId.SN_MAIN,
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findTransactions', () => {
+    const prepareFindTransctions = async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const { txns } = await prepareMockData(chainId);
+      const stateManager = new TransactionStateManager();
+      return {
+        stateManager,
+        txns,
+      };
+    };
+
+    it('returns the list of transaction by chain id', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const { txns, stateManager } = await prepareFindTransctions();
+
+      const result = await stateManager.findTransactions({
+        chainId: [chainId],
+      });
+
+      expect(result).toStrictEqual(
+        txns.filter((txn) => txn.chainId === chainId),
+      );
+    });
+
+    it('returns the list of transaction by txn hash', async () => {
+      const { txns, stateManager } = await prepareFindTransctions();
+
+      const result = await stateManager.findTransactions({
+        txnHash: [txns[0].txnHash, txns[1].txnHash],
+      });
+
+      expect(result).toStrictEqual([txns[0], txns[1]]);
+    });
+
+    it('returns the list of transaction by txn type', async () => {
+      const { txns, stateManager } = await prepareFindTransctions();
+
+      const result = await stateManager.findTransactions({
+        txnType: [TransactionType.DEPLOY_ACCOUNT],
+      });
+
+      expect(result).toStrictEqual([
+        txns.find((txn) => txn.txnType === TransactionType.DEPLOY_ACCOUNT),
+      ]);
+    });
+
+    it('returns the list of transaction by sender address', async () => {
+      const { txns, stateManager } = await prepareFindTransctions();
+
+      const result = await stateManager.findTransactions({
+        senderAddress: [txns[0].senderAddress],
+      });
+
+      expect(result).toStrictEqual(txns);
+    });
+
+    it('returns the list of transaction by contract address', async () => {
+      const { txns, stateManager } = await prepareFindTransctions();
+      const tokenAddress1 = PRELOADED_TOKENS.map((token) => token.address)[0];
+      const tokenAddress2 = PRELOADED_TOKENS.map((token) => token.address)[2];
+
+      const result = await stateManager.findTransactions({
+        contractAddress: [tokenAddress1, tokenAddress2],
+      });
+
+      expect(result).toStrictEqual(
+        txns.filter(
+          (txn) =>
+            txn.contractAddress === tokenAddress1 ||
+            txn.contractAddress === tokenAddress2,
+        ),
+      );
+    });
+
+    it('returns the list of transaction by timestamp if the transaction timestamp is >= the search timestamp', async () => {
+      const { txns, stateManager } = await prepareFindTransctions();
+
+      const result = await stateManager.findTransactions({
+        // The timestamp from data source is in seconds, but we are comparing it in milliseconds
+        timestamp: txns[5].timestamp * 1000,
+      });
+
+      expect(result).toStrictEqual(
+        txns.filter((txn) => txn.timestamp >= txns[5].timestamp),
+      );
+    });
+
+    it('returns the list of transaction by finalityStatus', async () => {
+      const { txns, stateManager } = await prepareFindTransctions();
+      const finalityStatusCond = [
+        TransactionFinalityStatus.ACCEPTED_ON_L1,
+        TransactionFinalityStatus.ACCEPTED_ON_L2,
+      ];
+
+      const result = await stateManager.findTransactions({
+        finalityStatus: finalityStatusCond,
+      });
+
+      expect(result).toStrictEqual(
+        txns.filter((txn) => {
+          return finalityStatusCond.includes(
+            txn.finalityStatus as unknown as TransactionFinalityStatus,
+          );
+        }),
+      );
+    });
+
+    it('returns the list of transaction by executionStatus', async () => {
+      const { txns, stateManager } = await prepareFindTransctions();
+      const executionStatusCond = [TransactionExecutionStatus.REJECTED];
+
+      const result = await stateManager.findTransactions({
+        executionStatus: executionStatusCond,
+      });
+
+      expect(result).toStrictEqual(
+        txns.filter((txn) => {
+          return executionStatusCond.includes(
+            txn.executionStatus as unknown as TransactionExecutionStatus,
+          );
+        }),
+      );
+    });
+
+    it('returns the list of transaction by mutilple conditions', async () => {
+      const { txns, stateManager } = await prepareFindTransctions();
+      const finalityStatusCond = [
+        TransactionFinalityStatus.ACCEPTED_ON_L1,
+        TransactionFinalityStatus.ACCEPTED_ON_L2,
+      ];
+      const executionStatusCond = [
+        TransactionExecutionStatus.REVERTED,
+        TransactionExecutionStatus.SUCCEEDED,
+        TransactionExecutionStatus.REJECTED,
+      ];
+      const contractAddressCond = [
+        PRELOADED_TOKENS.map((token) => token.address)[0],
+      ];
+      const timestampCond = txns[5].timestamp * 1000;
+      const chainIdCond = [
+        txns[0].chainId as unknown as constants.StarknetChainId,
+      ];
+
+      const result = await stateManager.findTransactions({
+        chainId: chainIdCond,
+        finalityStatus: finalityStatusCond,
+        executionStatus: executionStatusCond,
+        timestamp: timestampCond,
+        contractAddress: contractAddressCond,
+        senderAddress: [txns[0].senderAddress],
+      });
+
+      expect(result).toStrictEqual(
+        txns.filter((txn) => {
+          return (
+            (finalityStatusCond.includes(
+              txn.finalityStatus as unknown as TransactionFinalityStatus,
+            ) ||
+              executionStatusCond.includes(
+                txn.executionStatus as unknown as TransactionExecutionStatus,
+              )) &&
+            txn.timestamp >= txns[5].timestamp &&
+            contractAddressCond.includes(txn.contractAddress) &&
+            chainIdCond.includes(
+              txn.chainId as unknown as constants.StarknetChainId,
+            ) &&
+            txn.senderAddress === txns[0].senderAddress
+          );
+        }),
+      );
+    });
+
+    it('returns empty array if none of the transaction found', async () => {
+      const { stateManager } = await prepareFindTransctions();
+
+      const result = await stateManager.findTransactions({
+        chainId: ['0x1' as unknown as constants.StarknetChainId],
+      });
+
+      expect(result).toStrictEqual([]);
+    });
+  });
+
+  describe('updateTransaction', () => {
+    it('updates the transaction', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const { txns, state } = await prepareMockData(chainId);
+
+      const stateManager = new TransactionStateManager();
+      const txn = txns[2];
+      const updatedEntity = {
+        ...txn,
+        executionStatus: TransactionExecutionStatus.REJECTED,
+        finalityStatus: TransactionFinalityStatus.ACCEPTED_ON_L1,
+        timestamp: Math.floor(Date.now() / 1000),
+      };
+      await stateManager.updateTransaction(updatedEntity);
+
+      expect(
+        state.transactions.find(
+          (transaction) => transaction.txnHash === txn.txnHash,
+        ),
+      ).toStrictEqual(updatedEntity);
+    });
+
+    it('throws `Transaction does not exist` error if the update entity can not be found', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const { txns } = await prepareMockData(chainId);
+
+      const stateManager = new TransactionStateManager();
+      const txn = txns[2];
+      const updatedEntity = {
+        ...txn,
+        timestamp: Math.floor(Date.now() / 1000),
+        txnHash: '0x123',
+      };
+
+      await expect(
+        stateManager.updateTransaction(updatedEntity),
+      ).rejects.toThrow('Transaction does not exist');
+    });
+  });
+
+  describe('removeTransactions', () => {
+    it('removes the transaction', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const { txns, state } = await prepareMockData(chainId);
+      const txnHashCond = [txns[2].txnHash, txns[1].txnHash];
+
+      const stateManager = new TransactionStateManager();
+
+      await stateManager.removeTransactions({
+        txnHash: txnHashCond,
+      });
+
+      expect(
+        state.transactions.filter((txn) => txnHashCond.includes(txn.txnHash)),
+      ).toStrictEqual([]);
+    });
+
+    it('throws a `StateManagerError` error if an error was thrown', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const { txns, setDataSpy } = await prepareMockData(chainId);
+      setDataSpy.mockRejectedValue(new Error('Error'));
+      const txnHashCond = [txns[2].txnHash, txns[1].txnHash];
+
+      const stateManager = new TransactionStateManager();
+
+      await expect(
+        stateManager.removeTransactions({
+          txnHash: txnHashCond,
+        }),
+      ).rejects.toThrow(StateManagerError);
+    });
+  });
+
+  describe('addTransaction', () => {
+    it('adds a transaction', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const {
+        txns: [txnToBeAdded, ...txns],
+        getDataSpy,
+        state,
+      } = await prepareMockData(chainId);
+      getDataSpy.mockResolvedValue({
+        transactions: txns,
+      });
+
+      const stateManager = new TransactionStateManager();
+
+      await stateManager.addTransaction(txnToBeAdded);
+
+      expect(
+        state.transactions.find((txn) => txn.txnHash === txnToBeAdded.txnHash),
+      ).toStrictEqual(txnToBeAdded);
+    });
+
+    it('throws a `Transaction already exist` error if the transaction is exist', async () => {
+      const chainId = constants.StarknetChainId.SN_SEPOLIA;
+      const { txns } = await prepareMockData(chainId);
+
+      const stateManager = new TransactionStateManager();
+
+      await expect(stateManager.addTransaction(txns[0])).rejects.toThrow(
+        'Transaction already exist',
+      );
+    });
+  });
+});

--- a/packages/starknet-snap/src/state/transaction-state-manager.ts
+++ b/packages/starknet-snap/src/state/transaction-state-manager.ts
@@ -1,0 +1,305 @@
+import type { constants, TransactionType } from 'starknet';
+import {
+  TransactionFinalityStatus,
+  TransactionExecutionStatus,
+} from 'starknet';
+import { assert, enums, number } from 'superstruct';
+
+import type { Transaction, SnapState } from '../types/snapState';
+import { TransactionStatusType } from '../types/snapState';
+import type { IFilter } from './filter';
+import {
+  BigIntFilter,
+  ChainIdFilter as BaseChainIdFilter,
+  StringFllter,
+  Filter,
+} from './filter';
+import { StateManager, StateManagerError } from './state-manager';
+
+export type ITxFilter = IFilter<Transaction>;
+
+export class ChainIdFilter
+  extends BaseChainIdFilter<Transaction>
+  implements ITxFilter {}
+
+export class ContractAddressFilter
+  extends BigIntFilter<Transaction>
+  implements ITxFilter
+{
+  dataKey = 'contractAddress';
+}
+export class SenderAddressFilter
+  extends BigIntFilter<Transaction>
+  implements ITxFilter
+{
+  dataKey = 'senderAddress';
+}
+
+export class TxHashFilter
+  extends BigIntFilter<Transaction>
+  implements ITxFilter
+{
+  dataKey = 'txnHash';
+}
+
+export class TxTimestampFilter
+  extends Filter<number, Transaction>
+  implements ITxFilter
+{
+  _apply(data: Transaction): boolean {
+    // The timestamp from the data source is in seconds, but we are comparing it in milliseconds
+    return this.search !== undefined && data.timestamp * 1000 >= this.search;
+  }
+}
+
+export class TxnTypeFilter
+  extends StringFllter<Transaction>
+  implements ITxFilter
+{
+  dataKey = 'txnType';
+}
+
+export class TxStatusFilter implements ITxFilter {
+  finalityStatus: Set<string>;
+
+  executionStatus: Set<string>;
+
+  constructor(finalityStatus: string[], executionStatus: string[]) {
+    this.finalityStatus = new Set(
+      finalityStatus.map((val) => val.toLowerCase()),
+    );
+    this.executionStatus = new Set(
+      executionStatus.map((val) => val.toLowerCase()),
+    );
+  }
+
+  apply(txn: Transaction): boolean {
+    let finalityStatusCond = false;
+    let executionStatusCond = false;
+
+    if (this.finalityStatus.size > 0) {
+      finalityStatusCond =
+        Object.prototype.hasOwnProperty.call(
+          txn,
+          TransactionStatusType.FINALITY,
+        ) &&
+        txn[TransactionStatusType.FINALITY] &&
+        this.finalityStatus.has(
+          txn[TransactionStatusType.FINALITY].toLowerCase(),
+        );
+    }
+
+    if (this.executionStatus.size > 0) {
+      executionStatusCond =
+        Object.prototype.hasOwnProperty.call(
+          txn,
+          TransactionStatusType.EXECUTION,
+        ) &&
+        txn[TransactionStatusType.EXECUTION] &&
+        this.executionStatus.has(
+          txn[TransactionStatusType.EXECUTION].toLowerCase(),
+        );
+    }
+    return finalityStatusCond || executionStatusCond;
+  }
+}
+
+export type SearchFilter = {
+  txnHash?: string[];
+  txnType?: TransactionType[];
+  chainId?: constants.StarknetChainId[];
+  senderAddress?: string[];
+  contractAddress?: string[];
+  executionStatus?: TransactionExecutionStatus[];
+  finalityStatus?: TransactionFinalityStatus[];
+  timestamp?: number;
+};
+
+export class TransactionStateManager extends StateManager<Transaction> {
+  protected getCollection(state: SnapState): Transaction[] {
+    return state.transactions;
+  }
+
+  protected updateEntity(dataInState: Transaction, data: Transaction): void {
+    assert(
+      data.executionStatus,
+      enums(Object.values(TransactionExecutionStatus)),
+    );
+    assert(
+      data.finalityStatus,
+      enums(Object.values(TransactionFinalityStatus)),
+    );
+    assert(data.timestamp, number());
+
+    dataInState.executionStatus = data.executionStatus;
+    dataInState.finalityStatus = data.finalityStatus;
+    dataInState.timestamp = data.timestamp;
+    dataInState.failureReason = data.failureReason;
+  }
+
+  #getCompositeKey(data: Transaction): string {
+    const key1 = BigInt(data.chainId);
+    const key2 = BigInt(data.txnHash);
+    return `${key1}&${key2}`;
+  }
+
+  async findTransactions(
+    {
+      txnHash,
+      txnType,
+      chainId,
+      senderAddress,
+      contractAddress,
+      executionStatus,
+      finalityStatus,
+      timestamp,
+    }: SearchFilter,
+    state?: SnapState,
+  ): Promise<Transaction[]> {
+    const filters: ITxFilter[] = [];
+    if (txnHash !== undefined && txnHash.length > 0) {
+      filters.push(new TxHashFilter(txnHash));
+    }
+
+    if (chainId !== undefined && chainId.length > 0) {
+      filters.push(new ChainIdFilter(chainId));
+    }
+
+    if (timestamp !== undefined) {
+      filters.push(new TxTimestampFilter(timestamp));
+    }
+
+    if (senderAddress !== undefined && senderAddress.length > 0) {
+      filters.push(new SenderAddressFilter(senderAddress));
+    }
+
+    if (contractAddress !== undefined && contractAddress.length > 0) {
+      filters.push(new ContractAddressFilter(contractAddress));
+    }
+
+    if (txnType !== undefined && txnType.length > 0) {
+      filters.push(new TxnTypeFilter(txnType));
+    }
+
+    if (finalityStatus !== undefined || executionStatus !== undefined) {
+      filters.push(
+        new TxStatusFilter(finalityStatus ?? [], executionStatus ?? []),
+      );
+    }
+
+    return this.list(
+      filters,
+      // sort by timestamp in descending order
+      (entityA: Transaction, entityB: Transaction) =>
+        entityB.timestamp - entityA.timestamp,
+      state,
+    );
+  }
+
+   /**
+   * Finds a transaction object based on the given chain id and txn hash.
+   *
+   * @param param - The param object.
+   * @param param.txnHash - The txn hash of the transaction object to search for.
+   * @param [param.chainId] - The optional chain id of the transaction object to search for.
+   * @param [state] - The optional SnapState object.
+   * @returns A Promise that resolves with the transaction object if found, or null if not found.
+   */
+  async findTransaction(
+    {
+      txnHash,
+      chainId,
+    }: {
+      txnHash: string;
+      chainId?: string;
+    },
+    state?: SnapState,
+  ): Promise<Transaction | null> {
+    const filters: ITxFilter[] = [new TxHashFilter([txnHash])];
+    if (chainId !== undefined) {
+      filters.push(new ChainIdFilter([chainId]));
+    }
+    return this.find(filters, state);
+  }
+
+  /**
+   * Updates a transaction object in the state with the given data.
+   *
+   * @param data - The updated transaction object.
+   * @returns A Promise that resolves when the update is complete.
+   * @throws {StateManagerError} If there is an error updating the transaction object, such as:
+   * If the transaction object to be updated does not exist in the state.
+   */
+  async updateTransaction(data: Transaction): Promise<void> {
+    try {
+      await this.update(async (state: SnapState) => {
+        const dataInState = await this.findTransaction(
+          {
+            txnHash: data.txnHash,
+            chainId: data.chainId,
+          },
+          state,
+        );
+        if (!dataInState) {
+          throw new Error(`Transaction does not exist`);
+        }
+        this.updateEntity(dataInState, data);
+      });
+    } catch (error) {
+      throw new StateManagerError(error.message);
+    }
+  }
+
+  /**
+   * Adds a new transaction object to the state with the given data.
+   *
+   * @param data - The transaction object to add.
+   * @returns A Promise that resolves when the add is complete.
+   * @throws {StateManagerError} If there is an error adding the transaction object, such as:
+   * If the transaction object to be added already exists in the state.
+   */
+  async addTransaction(data: Transaction): Promise<void> {
+    try {
+      await this.update(async (state: SnapState) => {
+        const dataInState = await this.findTransaction(
+          {
+            txnHash: data.txnHash,
+            chainId: data.chainId,
+          },
+          state,
+        );
+
+        if (dataInState) {
+          throw new Error(`Transaction already exist`);
+        }
+        state.transactions.push(data);
+      });
+    } catch (error) {
+      throw new StateManagerError(error.message);
+    }
+  }
+
+  /**
+   * Removes the transaction objects in the state with the given search conditions.
+   *
+   * @param searchFilter - The searchFilter object.
+   * @returns A Promise that resolves when the remove is complete.
+   */
+  async removeTransactions(searchFilter: SearchFilter): Promise<void> {
+    try {
+      await this.update(async (state: SnapState) => {
+        const dataInState = await this.findTransactions(searchFilter, state);
+
+        const dataSet = new Set<string>(
+          dataInState.map((txn) => this.#getCompositeKey(txn)),
+        );
+
+        state.transactions = state.transactions.filter((txn) => {
+          return !dataSet.has(this.#getCompositeKey(txn));
+        });
+      });
+    } catch (error) {
+      throw new StateManagerError(error.message);
+    }
+  }
+}

--- a/packages/starknet-snap/src/state/transaction-state-manager.ts
+++ b/packages/starknet-snap/src/state/transaction-state-manager.ts
@@ -196,7 +196,7 @@ export class TransactionStateManager extends StateManager<Transaction> {
     );
   }
 
-   /**
+  /**
    * Finds a transaction object based on the given chain id and txn hash.
    *
    * @param param - The param object.

--- a/packages/starknet-snap/src/state/transaction-state-manager.ts
+++ b/packages/starknet-snap/src/state/transaction-state-manager.ts
@@ -48,6 +48,8 @@ export class TxTimestampFilter
 {
   _apply(data: Transaction): boolean {
     // The timestamp from the data source is in seconds, but we are comparing it in milliseconds
+    // e.g if the search is 1630000000, it means we return the txns where the timestamp is greater than or equal to 1630000000 * 1000
+    // example use case: search for txns for the last 7 days, the search will be Date.now() - 7 * 24 * 60 * 60 * 1000
     return this.search !== undefined && data.timestamp * 1000 >= this.search;
   }
 }
@@ -59,6 +61,9 @@ export class TxnTypeFilter
   dataKey = 'txnType';
 }
 
+// Filter for transaction status
+// Search for transactions based on the finality status and execution status
+// It compare the finality status and execution status in OR condition, due to our use case is to find the transactions that fit to the given finality status or the given execution status
 export class TxStatusFilter implements ITxFilter {
   finalityStatus: Set<string>;
 
@@ -205,7 +210,7 @@ export class TransactionStateManager extends StateManager<Transaction> {
    * @param [state] - The optional SnapState object.
    * @returns A Promise that resolves with the transaction object if found, or null if not found.
    */
-  async findTransaction(
+  async getTransaction(
     {
       txnHash,
       chainId,
@@ -233,7 +238,7 @@ export class TransactionStateManager extends StateManager<Transaction> {
   async updateTransaction(data: Transaction): Promise<void> {
     try {
       await this.update(async (state: SnapState) => {
-        const dataInState = await this.findTransaction(
+        const dataInState = await this.getTransaction(
           {
             txnHash: data.txnHash,
             chainId: data.chainId,
@@ -261,7 +266,7 @@ export class TransactionStateManager extends StateManager<Transaction> {
   async addTransaction(data: Transaction): Promise<void> {
     try {
       await this.update(async (state: SnapState) => {
-        const dataInState = await this.findTransaction(
+        const dataInState = await this.getTransaction(
           {
             txnHash: data.txnHash,
             chainId: data.chainId,

--- a/packages/starknet-snap/src/types/snapState.ts
+++ b/packages/starknet-snap/src/types/snapState.ts
@@ -81,6 +81,7 @@ export enum TransactionStatusType { // for retrieving txn from StarkNet feeder g
 
 export type Transaction = {
   txnHash: string; // in hex
+  // TODO: Change the type of txnType to `TransactionType` in the SnapState, when this state manager apply to getTransactions, there is no migration neeeded, as the state is override for every fetch for getTransactions
   txnType: VoyagerTransactionType | string;
   chainId: string; // in hex
   senderAddress: string; // in hex

--- a/packages/starknet-snap/src/types/snapState.ts
+++ b/packages/starknet-snap/src/types/snapState.ts
@@ -84,6 +84,7 @@ export type Transaction = {
   // TODO: Change the type of txnType to `TransactionType` in the SnapState, when this state manager apply to getTransactions, there is no migration neeeded, as the state is override for every fetch for getTransactions
   txnType: VoyagerTransactionType | string;
   chainId: string; // in hex
+  // TODO: rename it to address to sync with the same naming convention in the AccContract
   senderAddress: string; // in hex
   contractAddress: string; // in hex
   contractFuncName: string;

--- a/packages/starknet-snap/test/utils.ts
+++ b/packages/starknet-snap/test/utils.ts
@@ -137,7 +137,7 @@ export async function generateAccounts(
  * @param params.finalityStatuses - Array of transaction finality status.
  * @param params.executionStatuses - Array of transaction execution status.
  * @param params.cnt - Number of transaction to generate.
- * @returns An array of StarknetAccount object.
+ * @returns An array of transaction object.
  */
 export function generateTransactions({
   chainId,


### PR DESCRIPTION
This PR is to add TransactionStateManager to manage the txn state as similar as this https://github.com/Consensys/starknet-snap/pull/323

this manager allow caller to:

- update, add , get the txn
- list the txns by different search conditions, by `[Txn Type, Execution Status, Finality Status, Timestamp, Contract Address, Send Address, Chain Id, Txn Hash ]`
- remove the txns by the same search conditions as above
