### PR TITLE
chore: maintain the naming convention for get single entity in all state manager

### DIFF
--- a/packages/starknet-snap/src/__tests__/helper.ts
+++ b/packages/starknet-snap/src/__tests__/helper.ts
@@ -1,7 +1,11 @@
+import {
+  BIP44CoinTypeNode,
+  getBIP44AddressKeyDeriver,
+} from '@metamask/key-tree';
 import { generateMnemonic } from 'bip39';
+import type { constants } from 'starknet';
 import {
   ec,
-  constants,
   CallData,
   hash,
   type Calldata,
@@ -10,18 +14,15 @@ import {
   TransactionExecutionStatus,
   TransactionType,
 } from 'starknet';
-import {
-  BIP44CoinTypeNode,
-  getBIP44AddressKeyDeriver,
-} from '@metamask/key-tree';
-import { AccContract, Transaction } from '../src/types/snapState';
+
+import type { AccContract, Transaction } from '../types/snapState';
 import {
   ACCOUNT_CLASS_HASH,
   ACCOUNT_CLASS_HASH_LEGACY,
   PRELOADED_TOKENS,
   PROXY_CONTRACT_HASH,
-} from '../src/utils/constants';
-import { grindKey } from '../src/utils/keyPair';
+} from '../utils/constants';
+import { grindKey } from '../utils/keyPair';
 
 /* eslint-disable */
 export type StarknetAccount = AccContract & {

--- a/packages/starknet-snap/src/__tests__/helper.ts
+++ b/packages/starknet-snap/src/__tests__/helper.ts
@@ -3,6 +3,7 @@ import {
   getBIP44AddressKeyDeriver,
 } from '@metamask/key-tree';
 import { generateMnemonic } from 'bip39';
+import { getRandomValues } from 'crypto';
 import type { constants } from 'starknet';
 import {
   ec,
@@ -30,6 +31,23 @@ export type StarknetAccount = AccContract & {
 };
 
 /* eslint-disable */
+
+/**
+ * Using pseudorandom number generators (PRNGs) to generate a security-sensitive random value that recommended by sonarcloud.
+ * It has led in the past to the following vulnerabilities:
+ * - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-6386
+ * - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2006-3419
+ * - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2008-4102
+ *
+ * @returns An random number.
+ */
+export function generateRandomValue() {
+  // max value of 32 bit signed integer
+  const maxU32 = 2 ** 32;
+  const u32Arr = new Uint32Array(1);
+  // by dividing the random value by maxU32, we get a decimal number between 0 and 1, which is the same as Math.random()
+  return getRandomValues(u32Arr)[0] / maxU32;
+}
 
 /**
  * Method to generate Bip44 Entropy.
@@ -213,15 +231,23 @@ export function generateTransactions({
 
   for (let i = 1; i <= createCnt; i++) {
     const randomContractAddress =
-      contractAddresses[Math.floor(Math.random() * contractAddresses.length)];
+      contractAddresses[
+        Math.floor(generateRandomValue() * contractAddresses.length)
+      ];
     const randomTxnType =
-      filteredTxnTypes[Math.floor(Math.random() * filteredTxnTypes.length)];
+      filteredTxnTypes[
+        Math.floor(generateRandomValue() * filteredTxnTypes.length)
+      ];
     let randomFinalityStatus =
-      finalityStatuses[Math.floor(Math.random() * finalityStatuses.length)];
+      finalityStatuses[
+        Math.floor(generateRandomValue() * finalityStatuses.length)
+      ];
     let randomExecutionStatus =
-      executionStatuses[Math.floor(Math.random() * executionStatuses.length)];
+      executionStatuses[
+        Math.floor(generateRandomValue() * executionStatuses.length)
+      ];
     let randomContractFuncName = ['transfer', 'upgrade'][
-      Math.floor(Math.random() * 2)
+      Math.floor(generateRandomValue() * 2)
     ];
     accumulatedTimestamp += i * 100;
     accumulatedTxnHash += BigInt(i * 100);

--- a/packages/starknet-snap/src/index.test.ts
+++ b/packages/starknet-snap/src/index.test.ts
@@ -2,7 +2,7 @@ import { constants } from 'starknet';
 
 import { onRpcRequest, onHomePage } from '.';
 import { manageStateSpy } from '../test/snap-provider.mock';
-import { generateAccounts, type StarknetAccount } from '../test/utils';
+import { generateAccounts, type StarknetAccount } from './__tests__/helper';
 import * as createAccountApi from './createAccount';
 import type { SnapState } from './types/snapState';
 import {

--- a/packages/starknet-snap/src/rpcs/__tests__/helper.ts
+++ b/packages/starknet-snap/src/rpcs/__tests__/helper.ts
@@ -1,7 +1,7 @@
 import type { constants } from 'starknet';
 
-import type { StarknetAccount } from '../../../test/utils';
-import { generateAccounts } from '../../../test/utils';
+import type { StarknetAccount } from '../../__tests__/helper';
+import { generateAccounts } from '../../__tests__/helper';
 import type { SnapState } from '../../types/snapState';
 import * as snapHelper from '../../utils/snap';
 import * as snapUtils from '../../utils/snapUtils';

--- a/packages/starknet-snap/src/state/__tests__/helper.ts
+++ b/packages/starknet-snap/src/state/__tests__/helper.ts
@@ -1,6 +1,6 @@
 import type { constants } from 'starknet';
 
-import { generateAccounts, type StarknetAccount } from '../../../test/utils';
+import { generateAccounts, type StarknetAccount } from '../../__tests__/helper';
 import type { Erc20Token, Network, Transaction } from '../../types/snapState';
 import * as snapHelper from '../../utils/snap';
 

--- a/packages/starknet-snap/src/state/account-state-manager.test.ts
+++ b/packages/starknet-snap/src/state/account-state-manager.test.ts
@@ -8,7 +8,7 @@ import {
 } from './account-state-manager';
 
 describe('AccountStateManager', () => {
-  describe('findAccount', () => {
+  describe('getAccount', () => {
     it('returns the account', async () => {
       const chainId = constants.StarknetChainId.SN_SEPOLIA;
       const accountsInTestnet = await mockAcccounts(chainId);
@@ -20,7 +20,7 @@ describe('AccountStateManager', () => {
       });
 
       const stateManager = new AccountStateManager();
-      const result = await stateManager.findAccount({
+      const result = await stateManager.getAccount({
         address: accountsInTestnet[0].address,
         chainId,
       });
@@ -36,7 +36,7 @@ describe('AccountStateManager', () => {
       });
 
       const stateManager = new AccountStateManager();
-      const result = await stateManager.findAccount({
+      const result = await stateManager.getAccount({
         address: accountNotExist.address,
         chainId,
       });
@@ -52,7 +52,7 @@ describe('AccountStateManager', () => {
       });
 
       const stateManager = new AccountStateManager();
-      const result = await stateManager.findAccount({
+      const result = await stateManager.getAccount({
         address: accounts[0].address,
         chainId: constants.StarknetChainId.SN_MAIN,
       });

--- a/packages/starknet-snap/src/state/account-state-manager.ts
+++ b/packages/starknet-snap/src/state/account-state-manager.ts
@@ -41,7 +41,7 @@ export class AccountStateManager extends StateManager<AccContract> {
    * @param [state] - The optional SnapState object.
    * @returns A Promise that resolves with the matching AccContract object if found, or null if not found.
    */
-  async findAccount(
+  async getAccount(
     {
       address,
       chainId,
@@ -68,7 +68,7 @@ export class AccountStateManager extends StateManager<AccContract> {
   async updateAccount(data: AccContract): Promise<void> {
     try {
       await this.update(async (state: SnapState) => {
-        const accountInState = await this.findAccount(
+        const accountInState = await this.getAccount(
           {
             address: data.address,
             chainId: data.chainId,
@@ -98,7 +98,7 @@ export class AccountStateManager extends StateManager<AccContract> {
   async addAccount(data: AccContract): Promise<void> {
     try {
       await this.update(async (state: SnapState) => {
-        const accountInState = await this.findAccount(
+        const accountInState = await this.getAccount(
           {
             address: data.address,
             chainId: data.chainId,

--- a/packages/starknet-snap/src/state/network-state-manager.test.ts
+++ b/packages/starknet-snap/src/state/network-state-manager.test.ts
@@ -10,7 +10,7 @@ import { NetworkStateManager, ChainIdFilter } from './network-state-manager';
 import { StateManagerError } from './state-manager';
 
 describe('NetworkStateManager', () => {
-  describe('findNetwork', () => {
+  describe('getNetwork', () => {
     it('returns the network', async () => {
       const chainId = constants.StarknetChainId.SN_SEPOLIA;
       await mockState({
@@ -18,7 +18,7 @@ describe('NetworkStateManager', () => {
       });
 
       const stateManager = new NetworkStateManager();
-      const result = await stateManager.findNetwork({
+      const result = await stateManager.getNetwork({
         chainId,
       });
 
@@ -32,7 +32,7 @@ describe('NetworkStateManager', () => {
       });
 
       const stateManager = new NetworkStateManager();
-      const result = await stateManager.findNetwork({
+      const result = await stateManager.getNetwork({
         chainId,
       });
 

--- a/packages/starknet-snap/src/state/network-state-manager.ts
+++ b/packages/starknet-snap/src/state/network-state-manager.ts
@@ -65,7 +65,7 @@ export class NetworkStateManager extends StateManager<Network> {
    * @param [state] - The optional SnapState object.
    * @returns A Promise that resolves with the Network object if found, or null if not found.
    */
-  async findNetwork(
+  async getNetwork(
     {
       chainId,
     }: {
@@ -88,7 +88,7 @@ export class NetworkStateManager extends StateManager<Network> {
   async updateNetwork(data: Network): Promise<void> {
     try {
       await this.update(async (state: SnapState) => {
-        const dataInState = await this.findNetwork(
+        const dataInState = await this.getNetwork(
           {
             chainId: data.chainId,
           },

--- a/packages/starknet-snap/src/state/token-state-manager.test.ts
+++ b/packages/starknet-snap/src/state/token-state-manager.test.ts
@@ -12,7 +12,7 @@ import { StateManagerError } from './state-manager';
 import { TokenStateManager, ChainIdFilter } from './token-state-manager';
 
 describe('TokenStateManager', () => {
-  describe('findToken', () => {
+  describe('getToken', () => {
     it('returns the token', async () => {
       const chainId = constants.StarknetChainId.SN_SEPOLIA;
       await mockState({
@@ -20,7 +20,7 @@ describe('TokenStateManager', () => {
       });
 
       const stateManager = new TokenStateManager();
-      const result = await stateManager.findToken({
+      const result = await stateManager.getToken({
         chainId,
         address: ETHER_SEPOLIA_TESTNET.address,
       });
@@ -35,7 +35,7 @@ describe('TokenStateManager', () => {
       });
 
       const stateManager = new TokenStateManager();
-      const result = await stateManager.findToken({
+      const result = await stateManager.getToken({
         chainId,
         address: ETHER_SEPOLIA_TESTNET.address,
       });
@@ -50,7 +50,7 @@ describe('TokenStateManager', () => {
       });
 
       const stateManager = new TokenStateManager();
-      const result = await stateManager.findToken({
+      const result = await stateManager.getToken({
         chainId,
         address: ETHER_SEPOLIA_TESTNET.address,
       });

--- a/packages/starknet-snap/src/state/token-state-manager.ts
+++ b/packages/starknet-snap/src/state/token-state-manager.ts
@@ -88,7 +88,7 @@ export class TokenStateManager extends StateManager<Erc20Token> {
    * @param [state] - The optional SnapState object.
    * @returns A Promise that resolves with the Erc20Token object if found, or null if not found.
    */
-  async findToken(
+  async getToken(
     {
       address,
       chainId,
@@ -116,7 +116,7 @@ export class TokenStateManager extends StateManager<Erc20Token> {
   async updateToken(data: Erc20Token): Promise<void> {
     try {
       await this.update(async (state: SnapState) => {
-        const dataInState = await this.findToken(
+        const dataInState = await this.getToken(
           {
             address: data.address,
             chainId: data.chainId,
@@ -145,7 +145,7 @@ export class TokenStateManager extends StateManager<Erc20Token> {
   async addToken(data: Erc20Token): Promise<void> {
     try {
       await this.update(async (state: SnapState) => {
-        const dataInState = await this.findToken(
+        const dataInState = await this.getToken(
           {
             address: data.address,
             chainId: data.chainId,
@@ -183,7 +183,7 @@ export class TokenStateManager extends StateManager<Erc20Token> {
     if (!address) {
       return null;
     }
-    return await this.findToken(
+    return await this.getToken(
       {
         address,
         chainId,
@@ -212,7 +212,7 @@ export class TokenStateManager extends StateManager<Erc20Token> {
     if (!address) {
       return null;
     }
-    return await this.findToken(
+    return await this.getToken(
       {
         address,
         chainId,

--- a/packages/starknet-snap/src/state/transaction-state-manager.test.ts
+++ b/packages/starknet-snap/src/state/transaction-state-manager.test.ts
@@ -5,7 +5,7 @@ import {
   TransactionExecutionStatus,
 } from 'starknet';
 
-import { generateTransactions } from '../../test/utils';
+import { generateTransactions } from '../__tests__/helper';
 import { PRELOADED_TOKENS } from '../utils/constants';
 import { mockAcccounts, mockState } from './__tests__/helper';
 import { StateManagerError } from './state-manager';

--- a/packages/starknet-snap/src/utils/rpc.test.ts
+++ b/packages/starknet-snap/src/utils/rpc.test.ts
@@ -3,8 +3,8 @@ import { constants } from 'starknet';
 import { object, string } from 'superstruct';
 import type { Struct, Infer } from 'superstruct';
 
-import type { StarknetAccount } from '../../test/utils';
-import { generateAccounts } from '../../test/utils';
+import type { StarknetAccount } from '../__tests__/helper';
+import { generateAccounts } from '../__tests__/helper';
 import type { SnapState } from '../types/snapState';
 import { STARKNET_SEPOLIA_TESTNET_NETWORK } from './constants';
 import {

--- a/packages/starknet-snap/src/utils/snapUtils.test.ts
+++ b/packages/starknet-snap/src/utils/snapUtils.test.ts
@@ -1,6 +1,6 @@
 import { constants } from 'starknet';
 
-import { generateAccounts } from '../../test/utils';
+import { generateAccounts } from '../__tests__/helper';
 import { STARKNET_SEPOLIA_TESTNET_NETWORK } from './constants';
 import { DeployRequiredError, UpgradeRequiredError } from './exceptions';
 import * as snapHelper from './snap';

--- a/packages/starknet-snap/test/snap-provider.mock.ts
+++ b/packages/starknet-snap/test/snap-provider.mock.ts
@@ -1,6 +1,6 @@
 import { BIP44CoinTypeNode } from '@metamask/key-tree';
 import { generateMnemonic } from 'bip39';
-import { generateBip44Entropy } from './utils';
+import { generateBip44Entropy } from '../src/__tests__/helper';
 
 export type SnapProvider = {
   registerRpcMessageHandler: (fn) => unknown;


### PR DESCRIPTION
This PR is to fix the comments on

> maybe we call this getTransaction, as it is very different from findTransactions above. Having similar name could be confusing.
> yup, so lets change all in other state manager too in other PR

_Originally posted by @khanti42 in https://github.com/Consensys/starknet-snap/pull/328#discussion_r1724820935_

and

move the test helper from
`./test/utils.ts`
to
`./src/__tests__/helper.ts`

and

add new **testing util method** `generateRandomValue` to generate a security-sensitive random value that recommended by sonarcloud.