### PR TITLE
fix: improve error message in rpc input validation

### DIFF
--- a/packages/starknet-snap/src/utils/rpc.test.ts
+++ b/packages/starknet-snap/src/utils/rpc.test.ts
@@ -1,6 +1,6 @@
 import { InvalidParamsError, SnapError } from '@metamask/snaps-sdk';
 import { constants } from 'starknet';
-import { object, string } from 'superstruct';
+import { boolean, object, string, union } from 'superstruct';
 import type { Struct, Infer } from 'superstruct';
 
 import type { StarknetAccount } from '../__tests__/helper';
@@ -30,6 +30,15 @@ const validateParam = {
     '0x04882a372da3dfe1c53170ad75893832469bf87b62b13e84662565c4a88f25cd',
 };
 
+const treeStruct = union([
+  object({
+    field1: string(),
+  }),
+  object({
+    field3: boolean(),
+  }),
+]);
+
 describe('validateRequest', () => {
   it('does not throw error if the request is valid', () => {
     expect(() =>
@@ -45,6 +54,28 @@ describe('validateRequest', () => {
     expect(() =>
       validateRequest(requestParams, validateStruct as unknown as Struct),
     ).toThrow(InvalidParamsError);
+    expect(() =>
+      validateRequest(requestParams, validateStruct as unknown as Struct),
+    ).toThrow(
+      'At path: signerAddress -- Expected a string, but received: 1234',
+    );
+  });
+
+  it('throws `InvalidParamsError` and prints meaningful error message for tree struct', () => {
+    const requestParams = {
+      field1: true,
+    };
+
+    expect(() =>
+      validateRequest(requestParams, treeStruct as unknown as Struct),
+    ).toThrow(InvalidParamsError);
+    expect(() =>
+      validateRequest(requestParams, treeStruct as unknown as Struct),
+    ).toThrow(`At path: field1 --
+    Expected a string, but received: true
+    Expected a value of type \`never\`, but received: \`true\`
+
+At path: field3 -- Expected a value of type \`boolean\`, but received: \`undefined\``);
   });
 });
 

--- a/packages/starknet-snap/src/utils/rpc.ts
+++ b/packages/starknet-snap/src/utils/rpc.ts
@@ -25,7 +25,35 @@ export function validateRequest<Params>(requestParams: Params, struct: Struct) {
   try {
     assert(requestParams, struct);
   } catch (error) {
-    throw new InvalidParamsError(error.message) as unknown as Error;
+    const failures: any = error.failures();
+    const maxPathLength = Math.max(
+      ...failures.map((failure) => failure.path.length),
+    );
+    const filteredFailures = failures.filter(
+      (failure) => failure.path.length === maxPathLength,
+    );
+    const groupedFailures = filteredFailures.reduce((acc, failure) => {
+      const pathStr = failure.path.join('.');
+      if (!acc[pathStr]) {
+        acc[pathStr] = [];
+      }
+      acc[pathStr].push(failure.message);
+      return acc;
+    }, {} as Record<string, string[]>);
+
+    // Generate the output format
+    const output = Object.entries(groupedFailures)
+      .map(([path, messages]) => {
+        const messageBlock = (messages as [string])
+          .map((message: string) => `    ${message}`)
+          .join('\n');
+        return (messages as [string]).length > 1
+          ? `At path: ${path} --\n${messageBlock}`
+          : `At path: ${path} -- ${(messages as [string])[0]}`;
+      })
+      .join('\n\n');
+
+    throw new InvalidParamsError(output) as unknown as Error;
   }
 }
 


### PR DESCRIPTION
### PR Description: Improved Error Messages for Union Struct Validation

#### Before:
When testing a `union` struct with multiple levels, such as:

```typescript
const multiLevelStruct = union([
  object({
    field1: string(),
  }),
  object({
    field3: boolean(),
  }),
]);
```

If the input was incorrect, for example:

```json
{
  "field1": true
}
```

The error message provided was not clear and didn't offer much guidance:

```
"Expected the value to satisfy a union of `object | object`, but received: [object Object]"
```

This generic message made it difficult to diagnose the specific issue within the nested structure, particularly when working with complex schemas.

#### Now:
The error handling has been improved to provide much clearer and more informative messages. With the same incorrect input:

```json
{
  "field1": true
}
```

The new error message provides detailed information about where the validation failed:

```
At path: field1 --
    Expected a string, but received: true
    Expected a value of type `never`, but received: `true`

At path: field3 -- 
    Expected a value of type `boolean`, but received: `undefined`
```

#### Benefits:
- **Enhanced Clarity**: The error messages now pinpoint the exact field and expected type, making it easier to debug and correct invalid input.
- **Detailed Feedback**: By providing detailed feedback at each level of the validation, developers can quickly identify and resolve issues with their input data.
- **Better Support for Complex Schemas**: This improvement is especially valuable when dealing with nested or complex data structures, where understanding the root cause of validation failures is crucial.

This  PR improves  the developer experience and reduce time in debugging.
