### PR TITLE
feat: detect metamask version to force upgrade

### DIFF
--- a/packages/get-starknet/.eslintrc.js
+++ b/packages/get-starknet/.eslintrc.js
@@ -36,6 +36,13 @@ module.exports = {
         'import/no-nodejs-modules': 'off',
       },
     },
+
+    {
+      files: ['src/wallet.ts'],
+      rules: {
+        'no-restricted-globals': ['off', 'document', 'window'] // Disable rule for document and window
+      },
+    },
   ],
 
   ignorePatterns: ['!.eslintrc.js', 'dist/', '**/test', '.nyc_output/', 'coverage/'],

--- a/packages/get-starknet/package.json
+++ b/packages/get-starknet/package.json
@@ -17,7 +17,7 @@
     "build": "webpack --config webpack.config.build.js",
     "prettier": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint 'src/*.{js,ts,tsx}' --max-warnings 0 -f json -o eslint-report.json",
-    "lint:fix": "eslint '**/*.{js,ts,tsx}' --fix",
+    "lint:fix": "eslint 'src/*.{js,ts,tsx}' --fix",
     "test:unit": ""
   },
   "keywords": [],


### PR DESCRIPTION
## PR Summary: Handle MetaMask Snap Upgrade Prompt

This PR introduces changes related to the `get-starknet` package, focusing on handling scenarios where the MetaMask Snap requires a minimum MetaMask version and enhancing the overall user experience with a popup notification system.

This is required because the jsx support ( #350 ) is only available starting from version 12.

### 1. ESLint Configuration Updates
- A new ESLint rule is added for `wallet.ts`:
  - Disables restrictions on global objects `document` and `window` to allow browser-related features.

### 2. Package Script Update
- The `lint:fix` script is updated:
  - Now targets only the `src` folder (`src/*.{js,ts,tsx}`) instead of the entire project.

### 3. MetaMaskSnap Class Enhancement
- **`isUpgradeRequired` Method**:
  - Compares the current MetaMask version against a required minimum version (`'13.0.0'`).
  - If the current version is outdated, an upgrade is required.
  
- **`#getVersionNumber` Method**:
  - Retrieves the MetaMask version using `web3_clientVersion` and extracts the version number (e.g., `xx.yy.zz`).

### 4. MetaMaskSnapWallet Class Updates
- **New `isPopupVisible` Property**:
  - Tracks whether the upgrade notification popup is currently displayed.

- **Enhanced `enable` Method**:
  - Checks if a MetaMask upgrade is needed before installing the snap.
  - If an upgrade is required, the popup is shown using `document`.

### 5. Popup Notification System
- **`#showPopup` Method**:
  - Dynamically creates and displays a popup prompting the user to update MetaMask.
  - Features include:
    - A message encouraging the user to update to the latest MetaMask version.
    - An "Update MetaMask" button with the MetaMask logo, which opens the MetaMask website in a new tab.
    - A close button to dismiss the popup.
    - Prevents multiple popups from appearing at the same time using `isPopupVisible`.

### Summary
This PR addresses situations where MetaMask Snap users need to update their extension, providing a user-friendly experience with a pop-up notification when an upgrade is required. It also adjusts the linting rules to allow browser-specific objects like `document` and `window`.
