### PR TITLE
chore: ensure backward compatibility with remoteEntry.js of snap v2.9.0

### DIFF
--- a/packages/starknet-snap/src/index.ts
+++ b/packages/starknet-snap/src/index.ts
@@ -63,7 +63,7 @@ import type {
 } from './types/snapApi';
 import type { SnapState } from './types/snapState';
 import { upgradeAccContract } from './upgradeAccContract';
-import { getDappUrl, isSnapRpcError, mapDeprecatedParams } from './utils';
+import { getDappUrl, isSnapRpcError } from './utils';
 import {
   CAIRO_VERSION_LEGACY,
   ETHER_MAINNET,
@@ -152,21 +152,6 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       wallet: snap,
       saveMutex,
     };
-
-    // Define mappings to ensure backward compatibility with previous versions of the API.
-    // These mappings replace deprecated parameter names with the updated equivalents,
-    // allowing older integrations to function without changes, while the new version
-    // expects parameters such as `calls`, `details`, and `address`.
-    const paramMappings: Record<string, string> = {
-      signerAddress: 'address',
-      senderAddress: 'address',
-      txnInvocation: 'calls',
-      invocationsDetails: 'details',
-      transaction: 'details',
-    };
-
-    // Apply the mappings to apiParams.requestParams
-    mapDeprecatedParams(apiParams.requestParams, paramMappings);
 
     switch (request.method) {
       case 'starkNet_createAccount':

--- a/packages/starknet-snap/src/index.ts
+++ b/packages/starknet-snap/src/index.ts
@@ -63,7 +63,7 @@ import type {
 } from './types/snapApi';
 import type { SnapState } from './types/snapState';
 import { upgradeAccContract } from './upgradeAccContract';
-import { getDappUrl, isSnapRpcError } from './utils';
+import { getDappUrl, isSnapRpcError, mapDeprecatedParams } from './utils';
 import {
   CAIRO_VERSION_LEGACY,
   ETHER_MAINNET,
@@ -152,6 +152,21 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       wallet: snap,
       saveMutex,
     };
+
+    // Define mappings to ensure backward compatibility with previous versions of the API.
+    // These mappings replace deprecated parameter names with the updated equivalents,
+    // allowing older integrations to function without changes, while the new version
+    // expects parameters such as `calls`, `details`, and `address`.
+    const paramMappings: Record<string, string> = {
+      signerAddress: 'address',
+      senderAddress: 'address',
+      txnInvocation: 'calls',
+      invocationsDetails: 'details',
+      transaction: 'details',
+    };
+
+    // Apply the mappings to apiParams.requestParams
+    mapDeprecatedParams(apiParams.requestParams, paramMappings);
 
     switch (request.method) {
       case 'starkNet_createAccount':

--- a/packages/starknet-snap/src/rpcs/executeTxn.ts
+++ b/packages/starknet-snap/src/rpcs/executeTxn.ts
@@ -88,7 +88,7 @@ export class ExecuteTxnRpc extends AccountRpcController<
     };
 
     // Apply the mappings to params
-    mapDeprecatedParams(params as Record<string, Json>, paramMappings);
+    mapDeprecatedParams(params, paramMappings);
     await super.preExecute(params);
   }
 

--- a/packages/starknet-snap/src/rpcs/executeTxn.ts
+++ b/packages/starknet-snap/src/rpcs/executeTxn.ts
@@ -25,6 +25,7 @@ import {
   confirmDialog,
   UniversalDetailsStruct,
   CallsStruct,
+  mapDeprecatedParams,
 } from '../utils';
 import { logger } from '../utils/logger';
 import {
@@ -74,6 +75,21 @@ export class ExecuteTxnRpc extends AccountRpcController<
     this.txnStateManager = new TransactionStateManager();
     this.accStateManager = new AccountStateManager();
     this.tokenStateManager = new TokenStateManager();
+  }
+
+  protected async preExecute(params: ExecuteTxnParams): Promise<void> {
+    // Define mappings to ensure backward compatibility with previous versions of the API.
+    // These mappings replace deprecated parameter names with the updated equivalents,
+    // allowing older integrations to function without changes
+    const paramMappings: Record<string, string> = {
+      senderAddress: 'address',
+      txnInvocation: 'calls',
+      invocationsDetails: 'details',
+    };
+
+    // Apply the mappings to params
+    mapDeprecatedParams(params as Record<string, Json>, paramMappings);
+    await super.preExecute(params);
   }
 
   /**

--- a/packages/starknet-snap/src/rpcs/sign-declare-transaction.ts
+++ b/packages/starknet-snap/src/rpcs/sign-declare-transaction.ts
@@ -16,6 +16,7 @@ import {
   BaseRequestStruct,
   AccountRpcController,
   DeclareSignDetailsStruct,
+  mapDeprecatedParams,
 } from '../utils';
 import { signDeclareTransaction as signDeclareTransactionUtil } from '../utils/starknetUtils';
 
@@ -47,6 +48,22 @@ export class SignDeclareTransactionRpc extends AccountRpcController<
   protected requestStruct = SignDeclareTransactionRequestStruct;
 
   protected responseStruct = SignDeclareTransactionResponseStruct;
+
+  protected async preExecute(
+    params: SignDeclareTransactionParams,
+  ): Promise<void> {
+    // Define mappings to ensure backward compatibility with previous versions of the API.
+    // These mappings replace deprecated parameter names with the updated equivalents,
+    // allowing older integrations to function without changes
+    const paramMappings: Record<string, string> = {
+      signerAddress: 'address',
+      transaction: 'details',
+    };
+
+    // Apply the mappings to params
+    mapDeprecatedParams(params, paramMappings);
+    await super.preExecute(params);
+  }
 
   /**
    * Execute the sign declare transaction request handler.

--- a/packages/starknet-snap/src/rpcs/signMessage.ts
+++ b/packages/starknet-snap/src/rpcs/signMessage.ts
@@ -16,6 +16,7 @@ import {
   AuthorizableStruct,
   BaseRequestStruct,
   AccountRpcController,
+  mapDeprecatedParams,
 } from '../utils';
 import { signMessage as signMessageUtil } from '../utils/starknetUtils';
 
@@ -44,6 +45,19 @@ export class SignMessageRpc extends AccountRpcController<
   protected requestStruct = SignMessageRequestStruct;
 
   protected responseStruct = SignMessageResponseStruct;
+
+  protected async preExecute(params: SignMessageParams): Promise<void> {
+    // Define mappings to ensure backward compatibility with previous versions of the API.
+    // These mappings replace deprecated parameter names with the updated equivalents,
+    // allowing older integrations to function without changes
+    const paramMappings: Record<string, string> = {
+      signerAddress: 'address',
+    };
+
+    // Apply the mappings to params
+    mapDeprecatedParams(params, paramMappings);
+    await super.preExecute(params);
+  }
 
   /**
    * Execute the sign message request handler.

--- a/packages/starknet-snap/src/rpcs/signTransaction.ts
+++ b/packages/starknet-snap/src/rpcs/signTransaction.ts
@@ -17,6 +17,7 @@ import {
   AccountRpcController,
   CallDataStruct,
   toJson,
+  mapDeprecatedParams,
 } from '../utils';
 import { signTransactions } from '../utils/starknetUtils';
 
@@ -48,6 +49,19 @@ export class SignTransactionRpc extends AccountRpcController<
   protected requestStruct = SignTransactionRequestStruct;
 
   protected responseStruct = SignTransactionResponseStruct;
+
+  protected async preExecute(params: SignTransactionParams): Promise<void> {
+    // Define mappings to ensure backward compatibility with previous versions of the API.
+    // These mappings replace deprecated parameter names with the updated equivalents,
+    // allowing older integrations to function without changes
+    const paramMappings: Record<string, string> = {
+      signerAddress: 'address',
+    };
+
+    // Apply the mappings to params
+    mapDeprecatedParams(params, paramMappings);
+    await super.preExecute(params);
+  }
 
   /**
    * Execute the sign transaction request handler.

--- a/packages/starknet-snap/src/utils/formatterUtils.test.ts
+++ b/packages/starknet-snap/src/utils/formatterUtils.test.ts
@@ -52,7 +52,7 @@ describe('mapDeprecatedParams', () => {
     expect(requestParams).toStrictEqual(expected);
   });
 
-  it('should handle empty mappings correctly', () => {
+  it('does nothing if the mapping is empty', () => {
     const requestParams = {
       signerAddress: '0x123',
     };

--- a/packages/starknet-snap/src/utils/formatterUtils.test.ts
+++ b/packages/starknet-snap/src/utils/formatterUtils.test.ts
@@ -1,0 +1,67 @@
+import { mapDeprecatedParams } from './formatterUtils'; // replace 'yourModule' with the actual module path
+
+describe('mapDeprecatedParams', () => {
+  it('should map deprecated parameters to their new equivalents', () => {
+    const requestParams = {
+      signerAddress: '0x123',
+      txnInvocation: 'invoke',
+    };
+    const mappings = {
+      signerAddress: 'address',
+      txnInvocation: 'calls',
+    };
+
+    const expected = {
+      address: '0x123',
+      calls: 'invoke',
+    };
+
+    mapDeprecatedParams(requestParams, mappings);
+
+    expect(requestParams).toStrictEqual(expected);
+  });
+
+  it('should remove deprecated parameters after mapping', () => {
+    const requestParams = {
+      signerAddress: '0x123',
+      txnInvocation: 'invoke',
+    };
+    const mappings = {
+      signerAddress: 'address',
+      txnInvocation: 'calls',
+    };
+
+    mapDeprecatedParams(requestParams, mappings);
+
+    expect(requestParams).not.toHaveProperty('signerAddress');
+    expect(requestParams).not.toHaveProperty('txnInvocation');
+  });
+
+  it('should not map if deprecated parameter does not exist', () => {
+    const requestParams = {
+      otherParam: 'value',
+    };
+    const mappings = {
+      signerAddress: 'address',
+    };
+
+    const expected = { otherParam: 'value' };
+
+    mapDeprecatedParams(requestParams, mappings);
+
+    expect(requestParams).toStrictEqual(expected);
+  });
+
+  it('should handle empty mappings correctly', () => {
+    const requestParams = {
+      signerAddress: '0x123',
+    };
+    const mappings = {};
+
+    const expected = { signerAddress: '0x123' };
+
+    mapDeprecatedParams(requestParams, mappings);
+
+    expect(requestParams).toStrictEqual(expected);
+  });
+});

--- a/packages/starknet-snap/src/utils/formatterUtils.test.ts
+++ b/packages/starknet-snap/src/utils/formatterUtils.test.ts
@@ -1,4 +1,4 @@
-import { mapDeprecatedParams } from './formatterUtils'; // replace 'yourModule' with the actual module path
+import { mapDeprecatedParams } from './formatterUtils';
 
 describe('mapDeprecatedParams', () => {
   it('should map deprecated parameters to their new equivalents', () => {

--- a/packages/starknet-snap/src/utils/formatterUtils.test.ts
+++ b/packages/starknet-snap/src/utils/formatterUtils.test.ts
@@ -21,7 +21,7 @@ describe('mapDeprecatedParams', () => {
     expect(requestParams).toStrictEqual(expected);
   });
 
-  it('should remove deprecated parameters after mapping', () => {
+  it('removes the deprecated parameter after mapping', () => {
     const requestParams = {
       signerAddress: '0x123',
       txnInvocation: 'invoke',

--- a/packages/starknet-snap/src/utils/formatterUtils.test.ts
+++ b/packages/starknet-snap/src/utils/formatterUtils.test.ts
@@ -1,7 +1,7 @@
 import { mapDeprecatedParams } from './formatterUtils';
 
 describe('mapDeprecatedParams', () => {
-  it('should map deprecated parameters to their new equivalents', () => {
+  it('maps deprecated parameters to their new equivalents', () => {
     const requestParams = {
       signerAddress: '0x123',
       txnInvocation: 'invoke',

--- a/packages/starknet-snap/src/utils/formatterUtils.test.ts
+++ b/packages/starknet-snap/src/utils/formatterUtils.test.ts
@@ -37,7 +37,7 @@ describe('mapDeprecatedParams', () => {
     expect(requestParams).not.toHaveProperty('txnInvocation');
   });
 
-  it('should not map if deprecated parameter does not exist', () => {
+  it('does nothing if the deprecated parameter does not exist', () => {
     const requestParams = {
       otherParam: 'value',
     };

--- a/packages/starknet-snap/src/utils/formatterUtils.ts
+++ b/packages/starknet-snap/src/utils/formatterUtils.ts
@@ -1,3 +1,5 @@
+import type { Json } from '@metamask/snaps-sdk';
+
 export const hexToString = (hexStr) => {
   let str = '';
   for (let i = 0; i < hexStr.length; i += 2) {
@@ -26,12 +28,12 @@ export const hexToString = (hexStr) => {
  * mapDeprecatedParams(apiParams.requestParams, paramMappings);
  */
 export const mapDeprecatedParams = (
-  requestParams: any,
+  requestParams: Record<string, Json>,
   mappings: Record<string, string>,
 ) => {
   Object.keys(mappings).forEach((oldParam) => {
     const newParam = mappings[oldParam];
-    if (requestParams[oldParam]) {
+    if (Object.prototype.hasOwnProperty.call(requestParams, oldParam)) {
       requestParams[newParam] = requestParams[oldParam];
       delete requestParams[oldParam]; // Remove old param after mapping
     }

--- a/packages/starknet-snap/src/utils/formatterUtils.ts
+++ b/packages/starknet-snap/src/utils/formatterUtils.ts
@@ -7,3 +7,33 @@ export const hexToString = (hexStr) => {
   }
   return str;
 };
+
+/**
+ * Maps deprecated parameters to their new equivalents in the requestParams object
+ * and removes the deprecated parameters afterward.
+ *
+ * @param requestParams - The object containing the API request parameters.
+ * @param mappings - A record of key-value pairs where the key is the old parameter
+ * and the value is the new parameter.
+ * @example
+ * const paramMappings = {
+ *   signerAddress: 'address',
+ *   senderAddress: 'address',
+ *   txnInvocation: 'calls',
+ *   invocationsDetails: 'details',
+ *   transaction: 'details'
+ * };
+ * mapDeprecatedParams(apiParams.requestParams, paramMappings);
+ */
+export const mapDeprecatedParams = (
+  requestParams: any,
+  mappings: Record<string, string>,
+) => {
+  Object.keys(mappings).forEach((oldParam) => {
+    const newParam = mappings[oldParam];
+    if (requestParams[oldParam]) {
+      requestParams[newParam] = requestParams[oldParam];
+      delete requestParams[oldParam]; // Remove old param after mapping
+    }
+  });
+};

--- a/packages/starknet-snap/src/utils/formatterUtils.ts
+++ b/packages/starknet-snap/src/utils/formatterUtils.ts
@@ -1,5 +1,3 @@
-import type { Json } from '@metamask/snaps-sdk';
-
 export const hexToString = (hexStr) => {
   let str = '';
   for (let i = 0; i < hexStr.length; i += 2) {
@@ -28,11 +26,11 @@ export const hexToString = (hexStr) => {
  * mapDeprecatedParams(apiParams.requestParams, paramMappings);
  */
 export const mapDeprecatedParams = <Params>(
-  requestParams: Params
+  requestParams: Params,
   mappings: Record<string, string>,
 ) => {
   Object.keys(mappings).forEach((oldParam) => {
-    const newParam = mappings[oldParam]  as unknown as keyof Params;
+    const newParam = mappings[oldParam] as unknown as keyof Params;
     if (Object.prototype.hasOwnProperty.call(requestParams, oldParam)) {
       requestParams[newParam] = requestParams[oldParam];
       delete requestParams[oldParam]; // Remove old param after mapping

--- a/packages/starknet-snap/src/utils/formatterUtils.ts
+++ b/packages/starknet-snap/src/utils/formatterUtils.ts
@@ -27,12 +27,12 @@ export const hexToString = (hexStr) => {
  * };
  * mapDeprecatedParams(apiParams.requestParams, paramMappings);
  */
-export const mapDeprecatedParams = (
-  requestParams: Record<string, Json>,
+export const mapDeprecatedParams = <Params>(
+  requestParams: Params
   mappings: Record<string, string>,
 ) => {
   Object.keys(mappings).forEach((oldParam) => {
-    const newParam = mappings[oldParam];
+    const newParam = mappings[oldParam]  as unknown as keyof Params;
     if (Object.prototype.hasOwnProperty.call(requestParams, oldParam)) {
       requestParams[newParam] = requestParams[oldParam];
       delete requestParams[oldParam]; // Remove old param after mapping


### PR DESCRIPTION
### PR Description:

**Backward Compatibility for Request Parameters**

This PR ensures backward compatibility with version 2.9.0 for StarkNet-related methods (`starknet_sign*`, `starknet_execute`, and `starknet_declare`). 

- **`signerAddress` to `address` mapping**: In older versions, `starknet_sign*` methods used the `signerAddress` field. This update ensures that if `signerAddress` is passed in the request, it is mapped to the `address` field required by the new version.
  
- **`senderAddress` to `address` mapping**: Similarly, for `starknet_execute` and `starknet_declare`, which previously used `senderAddress`, the PR adds logic to map this to `address`.

By handling both `signerAddress` and `senderAddress`, this update allows for smooth transitions to the new parameter structure without breaking existing integrations.
