### PR TITLE
fix: snap homepage screen error if the logger is not initialised 

### DIFF
--- a/packages/starknet-snap/src/index.ts
+++ b/packages/starknet-snap/src/index.ts
@@ -89,11 +89,10 @@ import {
 } from './utils/starknetUtils';
 
 declare const snap;
+logger.logLevel = parseInt(Config.logLevel, 10);
 
 export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   const requestParams = request?.params as unknown as ApiRequestParams;
-
-  logger.logLevel = parseInt(Config.logLevel, 10);
 
   logger.log(`${request.method}:\nrequestParams: ${toJson(requestParams)}`);
 


### PR DESCRIPTION
As in current implementation, logger is only initialised when a request send from dapp

When the home screen open without connect to a dapp, it will display an error due to logger is not initialised

This PR is to move the initialised part into `index.ts` to have single initialisation for all