### PR TITLE
fix(get-starknet): address not update when network change

### DIFF
--- a/packages/get-starknet/src/wallet.ts
+++ b/packages/get-starknet/src/wallet.ts
@@ -101,11 +101,6 @@ export class MetaMaskSnapWallet implements IStarknetWindowObject {
   }
 
   async #getWalletAddress(chainId: string) {
-    // address always same regardless network, only single address provided
-    if (this.selectedAddress) {
-      return this.selectedAddress;
-    }
-
     const accountResponse = await this.snap.recoverDefaultAccount(chainId);
 
     if (!accountResponse?.address) {


### PR DESCRIPTION
this PR is to fix the address not update when network change

it is due to an user may have 2 different address when using different network due to different cairo contract version / contract upgrade