### PR TITLE
refactor(StateManager): change `StateManager` to return value in `withTransaction`

### DIFF
--- a/packages/starknet-snap/src/utils/snap-state.ts
+++ b/packages/starknet-snap/src/utils/snap-state.ts
@@ -67,10 +67,10 @@ export abstract class SnapStateManager<State> {
    *
    * @param callback - A Promise function that takes the state as an argument.
    */
-  public async withTransaction(
-    callback: (state: State) => Promise<void>,
-  ): Promise<void> {
-    await this.mtx.runExclusive(async () => {
+  public async withTransaction<Response>(
+    callback: (state: State) => Promise<Response>,
+  ): Promise<Response> {
+    return await this.mtx.runExclusive(async () => {
       await this.#beginTransaction();
 
       if (
@@ -88,8 +88,9 @@ export abstract class SnapStateManager<State> {
       );
 
       try {
-        await callback(this.#transaction.current);
+        const result = await callback(this.#transaction.current);
         await this.set(this.#transaction.current);
+        return result;
       } catch (error) {
         logger.info(
           `SnapStateManager.withTransaction [${


### PR DESCRIPTION
This PR is to change `StateManager` to return value in `withTransaction`

in any case if the withTransaction execute a callback and if there is a returned value in callback

the value should be returned to caller