### PR TITLE
refactor(get-starknet): change `MetaMaskSnapWallet` lock handling

### DIFF
--- a/packages/get-starknet/src/__tests__/helper.ts
+++ b/packages/get-starknet/src/__tests__/helper.ts
@@ -1,6 +1,8 @@
 import { constants } from 'starknet';
 
-import type { Network } from '../type';
+import { MetaMaskSnap } from '../snap';
+import type { MetaMaskProvider, Network } from '../type';
+import { MetaMaskSnapWallet } from '../wallet';
 
 export const SepoliaNetwork: Network = {
   name: 'Sepolia Testnet',
@@ -11,7 +13,7 @@ export const SepoliaNetwork: Network = {
   accountClassHash: '', // from argent-x repo
 };
 
-export const MainnetaNetwork: Network = {
+export const MainnetNetwork: Network = {
   name: 'Mainnet',
   baseUrl: 'https://mainnet.starknet.io',
   chainId: constants.StarknetChainId.SN_MAIN,
@@ -21,15 +23,17 @@ export const MainnetaNetwork: Network = {
 };
 
 /**
+ * Generate an account object.
  *
- * @param options0
- * @param options0.addressSalt
- * @param options0.publicKey
- * @param options0.address
- * @param options0.addressIndex
- * @param options0.derivationPath
- * @param options0.deployTxnHash
- * @param options0.chainId
+ * @param params
+ * @param params.addressSalt - The salt of the address.
+ * @param params.publicKey - The public key of the account.
+ * @param params.address - The address of the account.
+ * @param params.addressIndex - The index of the address.
+ * @param params.derivationPath - The derivation path of the address.
+ * @param params.deployTxnHash - The transaction hash of the deploy transaction.
+ * @param params.chainId - The chain id of the account.
+ * @returns The account object.
  */
 export function generateAccount({
   addressSalt = 'addressSalt',
@@ -56,5 +60,51 @@ export function generateAccount({
     derivationPath,
     deployTxnHash,
     chainId,
+  };
+}
+
+export class MockProvider implements MetaMaskProvider {
+  request = jest.fn();
+}
+
+/**
+ * Create a wallet instance.
+ */
+export function createWallet() {
+  return new MetaMaskSnapWallet(new MockProvider());
+}
+
+/**
+ * Mock the wallet init method.
+ *
+ * @param params
+ * @param params.install - The return value of the installIfNot method.
+ * @param params.currentNetwork - The return value of the getCurrentNetwork method.
+ * @param params.address - The address of the account.
+ * @returns The spy objects.
+ */
+export function mockWalletInit({
+  install = true,
+  currentNetwork = SepoliaNetwork,
+  address = '0x04882a372da3dfe1c53170ad75893832469bf87b62b13e84662565c4a88f25cd',
+}: {
+  install?: boolean;
+  currentNetwork?: Network;
+  address?: string;
+}) {
+  const installSpy = jest.spyOn(MetaMaskSnap.prototype, 'installIfNot');
+  const getCurrentNetworkSpy = jest.spyOn(MetaMaskSnap.prototype, 'getCurrentNetwork');
+  const recoverDefaultAccountSpy = jest.spyOn(MetaMaskSnap.prototype, 'recoverDefaultAccount');
+  const initSpy = jest.spyOn(MetaMaskSnapWallet.prototype, 'init');
+
+  installSpy.mockResolvedValue(install);
+  getCurrentNetworkSpy.mockResolvedValue(currentNetwork);
+  recoverDefaultAccountSpy.mockResolvedValue(generateAccount({ address }));
+
+  return {
+    initSpy,
+    installSpy,
+    getCurrentNetworkSpy,
+    recoverDefaultAccountSpy,
   };
 }

--- a/packages/get-starknet/src/utils/rpc.ts
+++ b/packages/get-starknet/src/utils/rpc.ts
@@ -2,6 +2,7 @@ import type { RpcMessage, RpcTypeToMessageMap } from 'get-starknet-core';
 
 import type { MetaMaskSnap } from '../snap';
 import type { MetaMaskSnapWallet } from '../wallet';
+import { createStarkError } from './error';
 
 export type IStarknetWalletRpc = {
   execute<Rpc extends RpcMessage['type']>(
@@ -22,9 +23,12 @@ export abstract class StarknetWalletRpc implements IStarknetWalletRpc {
   async execute<Rpc extends RpcMessage['type']>(
     params?: RpcTypeToMessageMap[Rpc]['params'],
   ): Promise<RpcTypeToMessageMap[Rpc]['result']> {
-    await this.wallet.init();
-
-    return this.handleRequest(params);
+    try {
+      await this.wallet.init(false);
+      return await this.handleRequest(params);
+    } catch (error) {
+      throw createStarkError(error?.data?.walletRpcError?.code);
+    }
   }
 
   abstract handleRequest<Rpc extends RpcMessage['type']>(

--- a/packages/get-starknet/src/wallet.ts
+++ b/packages/get-starknet/src/wallet.ts
@@ -11,6 +11,7 @@ import { MetaMaskSigner } from './signer';
 import { MetaMaskSnap } from './snap';
 import type { MetaMaskProvider, Network } from './type';
 import type { IStarknetWalletRpc } from './utils';
+import { WalletRpcError, WalletRpcErrorCode } from './utils/error';
 
 export class MetaMaskSnapWallet implements StarknetWindowObject {
   id: string;
@@ -60,6 +61,13 @@ export class MetaMaskSnapWallet implements StarknetWindowObject {
     ]);
   }
 
+  /**
+   * Execute the Wallet RPC request.
+   * It will call the corresponding RPC handler based on the request type.
+   *
+   * @param call - The RPC request object.
+   * @returns The corresponding RPC response.
+   */
   async request<Data extends RpcMessage>(call: Omit<Data, 'result'>): Promise<Data['result']> {
     const { type, params } = call;
 
@@ -69,7 +77,7 @@ export class MetaMaskSnapWallet implements StarknetWindowObject {
       return await handler.execute(params);
     }
 
-    throw new Error(`Method not supported`);
+    throw new WalletRpcError(`Method not supported`, WalletRpcErrorCode.Unknown);
   }
 
   async #getNetwork(): Promise<Network> {
@@ -120,37 +128,54 @@ export class MetaMaskSnapWallet implements StarknetWindowObject {
     return this.#chainId;
   }
 
-  // This method is to make sure the local state network is sync with the snap,
-  // Hence to set the updated address, account object, provider object and chainId
-  async init(net?: Network) {
+  /**
+   * Initializes the wallet by fetching the network and account information.
+   * and set the network, address, account object and provider object.
+   *
+   * @param createLock - The flag to enable/disable the mutex lock. Default is true.
+   */
+  async init(createLock = true) {
+    if (createLock) {
+      await this.lock.runExclusive(async () => {
+        await this.#init();
+      });
+    } else {
+      await this.#init();
+    }
+  }
+
+  async #init() {
     // Always reject any request if the snap is not installed
     if (!(await this.snap.installIfNot())) {
       throw new Error('Snap is not installed');
     }
 
-    const network = net ?? (await this.#getNetwork());
+    const network = await this.#getNetwork();
     if (!network) {
       throw new Error('Unable to find the selected network');
     }
 
-    // in case of multiple calls to init, we need to ensure that only one call is in progress
-    await this.lock.runExclusive(async () => {
-      if (!this.#network || network.chainId !== this.#network.chainId) {
-        // address is depends on network, if network changes, address will update
-        this.#selectedAddress = await this.#getWalletAddress(network.chainId);
-        // provider is depends on network.nodeUrl, if network changes, set provider to undefine for reinitialization
-        this.#provider = undefined;
-        // account is depends on address and provider, if network changes, address will update,
-        // hence set account to undefine for reinitialization
-        this.#account = undefined;
-      }
+    if (!this.#network || network.chainId !== this.#network.chainId) {
+      // address is depends on network, if network changes, address will update
+      this.#selectedAddress = await this.#getWalletAddress(network.chainId);
+      // provider is depends on network.nodeUrl, if network changes, set provider to undefine for reinitialization
+      this.#provider = undefined;
+      // account is depends on address and provider, if network changes, address will update,
+      // hence set account to undefine for reinitialization
+      this.#account = undefined;
+    }
 
-      this.#network = network;
-      this.#chainId = network.chainId;
-      this.isConnected = true;
-    });
+    this.#network = network;
+    this.#chainId = network.chainId;
+    this.isConnected = true;
   }
 
+  /**
+   * The entry point that trigger by `connect()` in get-starknet.
+   * It initializes the `MetaMaskSnapWallet` object and return the address that collect from Snap.
+   *
+   * @returns An array of address.
+   */
   async enable() {
     await this.init();
     return [this.selectedAddress];

--- a/packages/get-starknet/src/wallet.ts
+++ b/packages/get-starknet/src/wallet.ts
@@ -130,7 +130,7 @@ export class MetaMaskSnapWallet implements StarknetWindowObject {
 
   /**
    * Initializes the wallet by fetching the network and account information.
-   * and set the network, address, account object and provider object.
+   * and sets the network, address, account object and provider object.
    *
    * @param createLock - The flag to enable/disable the mutex lock. Default is true.
    */
@@ -171,8 +171,9 @@ export class MetaMaskSnapWallet implements StarknetWindowObject {
   }
 
   /**
-   * The entry point that trigger by `connect()` in get-starknet.
-   * It initializes the `MetaMaskSnapWallet` object and return the address that collect from Snap.
+   * Initializes the `MetaMaskSnapWallet` object and retrieves an array of addresses derived from Snap.
+   * Currently, the array contains only one address, but it is returned as an array to
+   * accommodate potential support for multiple addresses in the future.
    *
    * @returns An array of address.
    */


### PR DESCRIPTION
This PR is to change the `MetaMaskSnapWallet` lock handling on `init` method

This is because, we no longer need to init with given network,
But we might have a use case that the caller of `init` already running a lock
With the update , we can allow caller to choose init with lock or not

in addtional, this PR also update the test of the MetaMaskSnapWallet to increase the coverage 