### PR TITLE
feat: add RPC `starkNet_getDeploymentData`

### DIFF
--- a/packages/starknet-snap/src/index.ts
+++ b/packages/starknet-snap/src/index.ts
@@ -35,6 +35,7 @@ import type {
   SignDeclareTransactionParams,
   VerifySignatureParams,
   SwitchNetworkParams,
+  GetDeploymentDataParams,
 } from './rpcs';
 import {
   displayPrivateKey,
@@ -45,6 +46,7 @@ import {
   signDeclareTransaction,
   verifySignature,
   switchNetwork,
+  getDeploymentData,
 } from './rpcs';
 import { sendTransaction } from './sendTransaction';
 import { signDeployAccountTransaction } from './signDeployAccountTransaction';
@@ -278,6 +280,11 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
 
       case 'starkNet_getStarkName':
         return await getStarkName(apiParams);
+
+      case 'starkNet_getDeploymentData':
+        return await getDeploymentData.execute(
+          apiParams as unknown as GetDeploymentDataParams,
+        );
 
       default:
         throw new MethodNotFoundError() as unknown as Error;

--- a/packages/starknet-snap/src/rpcs/get-deployment-data.test.ts
+++ b/packages/starknet-snap/src/rpcs/get-deployment-data.test.ts
@@ -1,0 +1,89 @@
+import { constants } from 'starknet';
+
+import type { SnapState } from '../types/snapState';
+import {
+  ACCOUNT_CLASS_HASH,
+  CAIRO_VERSION,
+  STARKNET_SEPOLIA_TESTNET_NETWORK,
+} from '../utils/constants';
+import {
+  InvalidRequestParamsError,
+  AccountAlreadyDeployedError,
+} from '../utils/exceptions';
+import * as starknetUtils from '../utils/starknetUtils';
+import { mockAccount, prepareMockAccount } from './__tests__/helper';
+import type { GetDeploymentDataParams } from './get-deployment-data';
+import { getDeploymentData } from './get-deployment-data';
+
+jest.mock('../utils/snap');
+jest.mock('../utils/logger');
+
+describe('GetDeploymentDataRpc', () => {
+  const state: SnapState = {
+    accContracts: [],
+    erc20Tokens: [],
+    networks: [STARKNET_SEPOLIA_TESTNET_NETWORK],
+    transactions: [],
+  };
+
+  const createRequest = (
+    chainId: constants.StarknetChainId,
+    address: string,
+  ) => ({
+    address,
+    chainId,
+  });
+
+  const mockIsAccountDeployed = (deployed: boolean) => {
+    const spy = jest.spyOn(starknetUtils, 'isAccountDeployed');
+    spy.mockResolvedValue(deployed);
+    return spy;
+  };
+
+  const prepareGetDeploymentDataTest = async (deployed: boolean) => {
+    const chainId = constants.StarknetChainId.SN_SEPOLIA;
+    const account = await mockAccount(chainId);
+    prepareMockAccount(account, state);
+    mockIsAccountDeployed(deployed);
+    const request = createRequest(chainId, account.address);
+
+    return {
+      account,
+      request,
+    };
+  };
+
+  it('returns the deployment data', async () => {
+    const { account, request } = await prepareGetDeploymentDataTest(false);
+    const { address, publicKey } = account;
+    const expectedResult = {
+      address,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      class_hash: ACCOUNT_CLASS_HASH,
+      salt: publicKey,
+      calldata: starknetUtils.getDeployAccountCallData(
+        publicKey,
+        CAIRO_VERSION,
+      ),
+      version: CAIRO_VERSION,
+    };
+
+    const result = await getDeploymentData.execute(request);
+
+    expect(result).toStrictEqual(expectedResult);
+  });
+
+  it('throws `AccountAlreadyDeployedError` if the account has deployed', async () => {
+    const { request } = await prepareGetDeploymentDataTest(true);
+
+    await expect(getDeploymentData.execute(request)).rejects.toThrow(
+      AccountAlreadyDeployedError,
+    );
+  });
+
+  it('throws `InvalidRequestParamsError` when request parameter is not correct', async () => {
+    await expect(
+      getDeploymentData.execute({} as unknown as GetDeploymentDataParams),
+    ).rejects.toThrow(InvalidRequestParamsError);
+  });
+});

--- a/packages/starknet-snap/src/rpcs/get-deployment-data.ts
+++ b/packages/starknet-snap/src/rpcs/get-deployment-data.ts
@@ -40,6 +40,7 @@ export type GetDeploymentDataResponse = Infer<
 
 /**
  * The RPC handler to get the deployment data.
+ *
  */
 export class GetDeploymentDataRpc extends AccountRpcController<
   GetDeploymentDataParams,
@@ -67,8 +68,10 @@ export class GetDeploymentDataRpc extends AccountRpcController<
     params: GetDeploymentDataParams,
   ): Promise<GetDeploymentDataResponse> {
     const { address } = params;
+    // Due to AccountRpcController built-in validation,
     // if the account required to force deploy (Cairo 0 with balance), it will alert with a warning dialog.
     // if the account required to force upgrade (Cairo 0 without balance), it will alert with a warning dialog.
+    // hence we can safely assume that the account is Cairo 1 account.
     if (await isAccountDeployed(this.network, address)) {
       throw new AccountAlreadyDeployedError();
     }

--- a/packages/starknet-snap/src/rpcs/get-deployment-data.ts
+++ b/packages/starknet-snap/src/rpcs/get-deployment-data.ts
@@ -1,0 +1,88 @@
+import type { Infer } from 'superstruct';
+import { object, string, assign, array } from 'superstruct';
+
+import {
+  AddressStruct,
+  BaseRequestStruct,
+  AccountRpcController,
+  CairoVersionStruct,
+} from '../utils';
+import { ACCOUNT_CLASS_HASH, CAIRO_VERSION } from '../utils/constants';
+import { AccountAlreadyDeployedError } from '../utils/exceptions';
+import {
+  getDeployAccountCallData,
+  isAccountDeployed,
+} from '../utils/starknetUtils';
+
+export const GetDeploymentDataRequestStruct = assign(
+  object({
+    address: AddressStruct,
+  }),
+  BaseRequestStruct,
+);
+
+export const GetDeploymentDataResponseStruct = object({
+  address: AddressStruct,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  class_hash: string(),
+  salt: string(),
+  calldata: array(string()),
+  version: CairoVersionStruct,
+});
+
+export type GetDeploymentDataParams = Infer<
+  typeof GetDeploymentDataRequestStruct
+>;
+
+export type GetDeploymentDataResponse = Infer<
+  typeof GetDeploymentDataResponseStruct
+>;
+
+/**
+ * The RPC handler to get the deployment data.
+ */
+export class GetDeploymentDataRpc extends AccountRpcController<
+  GetDeploymentDataParams,
+  GetDeploymentDataResponse
+> {
+  protected requestStruct = GetDeploymentDataRequestStruct;
+
+  protected responseStruct = GetDeploymentDataResponseStruct;
+
+  /**
+   * Execute the get deployment data request handler.
+   *
+   * @param params - The parameters of the request.
+   * @param params.address - The address of the account.
+   * @param params.chainId - The chain id of the network.
+   * @returns A promise that resolve to a `Deployment Data`.
+   */
+  async execute(
+    params: GetDeploymentDataParams,
+  ): Promise<GetDeploymentDataResponse> {
+    return super.execute(params);
+  }
+
+  protected async handleRequest(
+    params: GetDeploymentDataParams,
+  ): Promise<GetDeploymentDataResponse> {
+    const { address } = params;
+    // if the account required to force deploy (Cairo 0 with balance), it will alert with a warning dialog.
+    // if the account required to force upgrade (Cairo 0 without balance), it will alert with a warning dialog.
+    if (await isAccountDeployed(this.network, address)) {
+      throw new AccountAlreadyDeployedError();
+    }
+
+    // We only need to take care the deployment data for Cairo 1 account.
+    return {
+      address: params.address,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      class_hash: ACCOUNT_CLASS_HASH,
+      salt: this.account.publicKey,
+      calldata: getDeployAccountCallData(this.account.publicKey, CAIRO_VERSION),
+      version: CAIRO_VERSION,
+    };
+  }
+}
+
+export const getDeploymentData = new GetDeploymentDataRpc();

--- a/packages/starknet-snap/src/rpcs/index.ts
+++ b/packages/starknet-snap/src/rpcs/index.ts
@@ -6,3 +6,4 @@ export * from './signTransaction';
 export * from './sign-declare-transaction';
 export * from './verify-signature';
 export * from './switch-network';
+export * from './get-deployment-data';

--- a/packages/starknet-snap/src/utils/exceptions.ts
+++ b/packages/starknet-snap/src/utils/exceptions.ts
@@ -54,3 +54,12 @@ export class UnknownError extends SnapError {
     );
   }
 }
+
+export class AccountAlreadyDeployedError extends SnapError {
+  constructor(message?: string) {
+    super(
+      message ?? 'Account already deployed',
+      createWalletRpcErrorWrapper(WalletRpcErrorCode.AccountAlreadyDeployed),
+    );
+  }
+}


### PR DESCRIPTION
This PR is to add RPC `starkNet_getDeploymentData` into the snap

as it is designed for get-starknet v4

The purpose to have this API is to
- having the checking to the account, where it should deployed / upgrade, and enforce the user to deployed / upgrade in our dapp
- does not need to depulicate the deployment data in the snap and get-starkent