### PR TITLE
feat: add support for CallGetStarknetV4 format in rpc execute

### DIFF
--- a/packages/starknet-snap/src/__tests__/fixture/callsExamples.json
+++ b/packages/starknet-snap/src/__tests__/fixture/callsExamples.json
@@ -14,6 +14,21 @@
     },
     "hash": "0x042f5e546b2e55eb6b1b735f15fbfbd7621fc01ea7c96dcf87928ac27f054adb"
   },
+  "callGetStarknetV4Format": {
+    "calls": [
+      {
+        "contract_address": "0x00b28a089e7fb83debee4607b6334d687918644796b47d9e9e38ea8213833137",
+        "entry_point": "functionName",
+        "calldata": ["1", "1"]
+      }
+    ],
+    "details": {
+      "nonce": "0x1",
+      "version": "0x1",
+      "maxFee": "1000000000000000"
+    },
+    "hash": "0x042f5e546b2e55eb6b1b735f15fbfbd7621fc01ea7c96dcf87928ac27f054adb"
+  },
   "singleCall": {
     "calls": {
       "contractAddress": "0x00b28a089e7fb83debee4607b6334d687918644796b47d9e9e38ea8213833137",

--- a/packages/starknet-snap/src/utils/formatterUtils.test.ts
+++ b/packages/starknet-snap/src/utils/formatterUtils.test.ts
@@ -1,4 +1,4 @@
-import { mapDeprecatedParams } from './formatterUtils';
+import { mapDeprecatedParams, formatCalls } from './formatterUtils';
 
 describe('mapDeprecatedParams', () => {
   it('maps deprecated parameters to their new equivalents', () => {
@@ -63,5 +63,82 @@ describe('mapDeprecatedParams', () => {
     mapDeprecatedParams(requestParams, mappings);
 
     expect(requestParams).toStrictEqual(expected);
+  });
+});
+
+describe('formatCalls', () => {
+  it('converts CallGetStarknetV4 to Call', () => {
+    const calls = [
+      {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        contract_address: '0xabc',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        entry_point: 'transfer',
+        calldata: ['0x1', '0x2'],
+      },
+    ];
+
+    const expected = [
+      {
+        contractAddress: '0xabc',
+        entrypoint: 'transfer',
+        calldata: ['0x1', '0x2'],
+      },
+    ];
+
+    const result = formatCalls(calls);
+
+    expect(result).toStrictEqual(expected);
+  });
+
+  it('leaves Call unchanged if already in correct format', () => {
+    const calls = [
+      {
+        contractAddress: '0xdef',
+        entrypoint: 'approve',
+        calldata: ['0x3', '0x4'],
+      },
+    ];
+
+    const expected = [
+      {
+        contractAddress: '0xdef',
+        entrypoint: 'approve',
+        calldata: ['0x3', '0x4'],
+      },
+    ];
+
+    const result = formatCalls(calls);
+
+    expect(result).toStrictEqual(expected);
+  });
+
+  it('sets calldata to an empty array if undefined in CallGetStarknetV4', () => {
+    const calls = [
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      { contract_address: '0xabc', entry_point: 'transfer' }, // no calldata
+    ];
+
+    const expected = [
+      { contractAddress: '0xabc', entrypoint: 'transfer', calldata: [] }, // empty calldata
+    ];
+
+    const result = formatCalls(calls);
+
+    expect(result).toStrictEqual(expected);
+  });
+
+  it('sets calldata to an empty array if undefined in Call', () => {
+    const calls = [
+      { contractAddress: '0xdef', entrypoint: 'approve' }, // no calldata
+    ];
+
+    const expected = [
+      { contractAddress: '0xdef', entrypoint: 'approve', calldata: [] }, // empty calldata
+    ];
+
+    const result = formatCalls(calls);
+
+    expect(result).toStrictEqual(expected);
   });
 });

--- a/packages/starknet-snap/src/utils/formatterUtils.ts
+++ b/packages/starknet-snap/src/utils/formatterUtils.ts
@@ -1,3 +1,6 @@
+import type { Call } from 'starknet';
+import type { Call as CallGetStarknetV4 } from 'starknet-types-07';
+
 export const hexToString = (hexStr) => {
   let str = '';
   for (let i = 0; i < hexStr.length; i += 2) {
@@ -35,5 +38,46 @@ export const mapDeprecatedParams = <Params>(
       requestParams[newParam] = requestParams[oldParam];
       delete requestParams[oldParam]; // Remove old param after mapping
     }
+  });
+};
+
+/**
+ * Converts an array of calls from either the `CallGetStarknetV4[]` format
+ * or the standard `Call[]` format into the standard `Call[]` format. If the input
+ * calls are already in the correct format, no changes are made.
+ *
+ * The function ensures that:
+ * - `contract_address` from `CallGetStarknetV4` is renamed to `contractAddress` if needed.
+ * - `entry_point` from `CallGetStarknetV4` is renamed to `entrypoint` if needed.
+ * - `calldata` is set to an empty array if undefined.
+ *
+ * @template T - The type of the calls array, either `CallGetStarknetV4[]` or `Call[]`.
+ * @param calls - The array of call objects to be formatted.
+ * @returns The array of formatted calls in the `Call[]` format.
+ * @example
+ * const calls = [
+ *   { contract_address: '0xabc', entry_point: 'transfer', calldata: ['0x1', '0x2'] }, // CallGetStarknetV4
+ *   { contractAddress: '0xdef', entrypoint: 'approve', calldata: ['0x3', '0x4'] }     // Call
+ * ];
+ * const formattedCalls = formatCalls(calls);
+ * console.log(formattedCalls);
+ * // Output: [{ contractAddress: '0xabc', entrypoint: 'transfer', calldata: ['0x1', '0x2'] },
+ * //          { contractAddress: '0xdef', entrypoint: 'approve', calldata: ['0x3', '0x4'] }]
+ */
+export const formatCalls = <CallType extends Call | CallGetStarknetV4>(
+  calls: CallType[],
+): Call[] => {
+  return calls.map((call) => {
+    const contractAddress =
+      'contract_address' in call ? call.contract_address : call.contractAddress;
+    const entrypoint =
+      'entry_point' in call ? call.entry_point : call.entrypoint;
+    const calldata = call.calldata ?? [];
+
+    return {
+      contractAddress,
+      entrypoint,
+      calldata,
+    };
   });
 };

--- a/packages/starknet-snap/src/utils/superstruct.ts
+++ b/packages/starknet-snap/src/utils/superstruct.ts
@@ -7,6 +7,7 @@ import type {
   UniversalDetails,
 } from 'starknet';
 import { constants, TransactionType, validateAndParseAddress } from 'starknet';
+import type { Call as CallGetStarknetV4 } from 'starknet-types-07';
 import type { Struct } from 'superstruct';
 import {
   boolean,
@@ -29,6 +30,7 @@ import {
 } from 'superstruct';
 
 import { CAIRO_VERSION_LEGACY, CAIRO_VERSION } from './constants';
+import { formatCalls } from './formatterUtils';
 
 export const AddressStruct = refine(
   string(),
@@ -294,7 +296,9 @@ export const BaseInvocationStruct = object({
   ]),
 });
 
-export const CallsStruct = define<Call[] | Call>(
+export const CallsStruct = define<
+  Call[] | Call | CallGetStarknetV4[] | CallGetStarknetV4
+>(
   // We do use a custom `define` for this type to avoid having to use a `union` since error
   // messages are a bit confusing.
   //
@@ -302,7 +306,11 @@ export const CallsStruct = define<Call[] | Call>(
   // use a much nicer message from `superstruct`.
   'CallsStruct',
   (value: unknown[] | unknown) => {
-    const calls = Array.isArray(value) ? (value as Call[]) : [value as Call];
+    const calls = formatCalls(
+      Array.isArray(value) ? (value as Call[]) : [value as Call],
+    );
+
+    // We try to format it to correct format if needed
     return validate(calls, array(CallDataStruct))[0] ?? true;
   },
 );


### PR DESCRIPTION
### Pull Request Summary:

This PR adds support for handling `CallGetStarknetV4` structures and converts them to the standard `Call` format across relevant modules in the `starknet-snap` package.

### Key Changes:
1. **Fixture Update**: 
   - Added `callGetStarknetV4Format` example to `callsExamples.json` for testing the new format.
   
2. **Functionality**:
   - Introduced `formatCalls` function to convert `CallGetStarknetV4[]` to `Call[]`.
   - Updated `executeTxn` to handle `CallGetStarknetV4` by converting the input via `formatCalls` after validation.

3. **Tests**:
   - Added a new test in `executeTxn.test.ts` to ensure `CallGetStarknetV4` format is accepted and converted correctly.
   - Added a dedicated test suite for `formatCalls` in `formatterUtils.test.ts`.

4. **Superstruct Validation**:
   - Updated `CallsStruct` to accept `CallGetStarknetV4[]` and `Call[]`, while applying `formatCalls` for correct formatting before validation.

This ensures compatibility with both `Call` and `Call GetStarknet V4` formats and guarantees correct transaction execution.