### PR TITLE
refactor(get-starknet): remove the snap connection on rpcs that return static information

### DIFF
--- a/packages/get-starknet/src/rpcs/get-permissions.test.ts
+++ b/packages/get-starknet/src/rpcs/get-permissions.test.ts
@@ -1,14 +1,10 @@
 import { Permission } from 'get-starknet-core';
 
-import { mockWalletInit, createWallet } from '../__tests__/helper';
 import { WalletGetPermissions } from './get-permissions';
 
 describe('WalletGetPermissions', () => {
   it('returns the permissions', async () => {
-    const wallet = createWallet();
-    mockWalletInit({});
-
-    const walletGetPermissions = new WalletGetPermissions(wallet);
+    const walletGetPermissions = new WalletGetPermissions();
     const result = await walletGetPermissions.execute();
 
     expect(result).toStrictEqual([Permission.ACCOUNTS]);

--- a/packages/get-starknet/src/rpcs/get-permissions.ts
+++ b/packages/get-starknet/src/rpcs/get-permissions.ts
@@ -1,13 +1,12 @@
 import { Permission, type RpcTypeToMessageMap } from 'get-starknet-core';
 
-import { StarknetWalletRpc } from '../utils/rpc';
+import type { IStarknetWalletRpc } from '../utils/rpc';
 
 export type WalletGetPermissionsMethod = 'wallet_getPermissions';
-type Params = RpcTypeToMessageMap[WalletGetPermissionsMethod]['params'];
 type Result = RpcTypeToMessageMap[WalletGetPermissionsMethod]['result'];
 
-export class WalletGetPermissions extends StarknetWalletRpc {
-  async handleRequest(_param: Params): Promise<Result> {
+export class WalletGetPermissions implements IStarknetWalletRpc {
+  async execute(): Promise<Result> {
     return [Permission.ACCOUNTS];
   }
 }

--- a/packages/get-starknet/src/rpcs/supported-specs.test.ts
+++ b/packages/get-starknet/src/rpcs/supported-specs.test.ts
@@ -1,13 +1,9 @@
-import { mockWalletInit, createWallet, SepoliaNetwork } from '../__tests__/helper';
 import { SupportedStarknetSpecVersion } from '../constants';
 import { WalletSupportedSpecs } from './supported-specs';
 
 describe('WalletSupportedWalletApi', () => {
   it('returns the supported wallet api version', async () => {
-    const wallet = createWallet();
-    mockWalletInit({ currentNetwork: SepoliaNetwork });
-
-    const walletSupportedSpecs = new WalletSupportedSpecs(wallet);
+    const walletSupportedSpecs = new WalletSupportedSpecs();
     const result = await walletSupportedSpecs.execute();
 
     expect(result).toStrictEqual(SupportedStarknetSpecVersion);

--- a/packages/get-starknet/src/rpcs/supported-specs.ts
+++ b/packages/get-starknet/src/rpcs/supported-specs.ts
@@ -1,14 +1,13 @@
 import type { RpcTypeToMessageMap } from 'get-starknet-core';
 
 import { SupportedStarknetSpecVersion } from '../constants';
-import { StarknetWalletRpc } from '../utils/rpc';
+import type { IStarknetWalletRpc } from '../utils';
 
 export type WalletSupportedSpecsMethod = 'wallet_supportedSpecs';
-type Params = RpcTypeToMessageMap[WalletSupportedSpecsMethod]['params'];
 type Result = RpcTypeToMessageMap[WalletSupportedSpecsMethod]['result'];
 
-export class WalletSupportedSpecs extends StarknetWalletRpc {
-  async handleRequest(_param: Params): Promise<Result> {
+export class WalletSupportedSpecs implements IStarknetWalletRpc {
+  async execute(): Promise<Result> {
     return SupportedStarknetSpecVersion;
   }
 }

--- a/packages/get-starknet/src/rpcs/supported-wallet-api.test.ts
+++ b/packages/get-starknet/src/rpcs/supported-wallet-api.test.ts
@@ -1,13 +1,9 @@
-import { mockWalletInit, createWallet, SepoliaNetwork } from '../__tests__/helper';
 import { SupportedWalletApi } from '../constants';
 import { WalletSupportedWalletApi } from './supported-wallet-api';
 
 describe('WalletSupportedWalletApi', () => {
   it('returns the supported wallet api version', async () => {
-    const wallet = createWallet();
-    mockWalletInit({ currentNetwork: SepoliaNetwork });
-
-    const walletSupportedWalletApi = new WalletSupportedWalletApi(wallet);
+    const walletSupportedWalletApi = new WalletSupportedWalletApi();
     const result = await walletSupportedWalletApi.execute();
 
     expect(result).toStrictEqual(SupportedWalletApi);

--- a/packages/get-starknet/src/rpcs/supported-wallet-api.ts
+++ b/packages/get-starknet/src/rpcs/supported-wallet-api.ts
@@ -1,14 +1,13 @@
 import type { RpcTypeToMessageMap } from 'get-starknet-core';
 
 import { SupportedWalletApi } from '../constants';
-import { StarknetWalletRpc } from '../utils/rpc';
+import type { IStarknetWalletRpc } from '../utils/rpc';
 
 export type WalletSupportedWalletApiMethod = 'wallet_supportedWalletApi';
-type Params = RpcTypeToMessageMap[WalletSupportedWalletApiMethod]['params'];
 type Result = RpcTypeToMessageMap[WalletSupportedWalletApiMethod]['result'];
 
-export class WalletSupportedWalletApi extends StarknetWalletRpc {
-  async handleRequest(_param: Params): Promise<Result> {
+export class WalletSupportedWalletApi implements IStarknetWalletRpc {
+  async execute(): Promise<Result> {
     return SupportedWalletApi as unknown as Result;
   }
 }

--- a/packages/get-starknet/src/wallet.ts
+++ b/packages/get-starknet/src/wallet.ts
@@ -69,15 +69,15 @@ export class MetaMaskSnapWallet implements StarknetWindowObject {
 
     this.#rpcHandlers = new Map<string, IStarknetWalletRpc>([
       [RpcMethod.WalletSwitchStarknetChain, new WalletSwitchStarknetChain(this)],
-      [RpcMethod.WalletSupportedSpecs, new WalletSupportedSpecs(this)],
+      [RpcMethod.WalletSupportedSpecs, new WalletSupportedSpecs()],
       [RpcMethod.WalletDeploymentData, new WalletDeploymentData(this)],
-      [RpcMethod.WalletSupportedWalletApi, new WalletSupportedWalletApi(this)],
+      [RpcMethod.WalletSupportedWalletApi, new WalletSupportedWalletApi()],
       [RpcMethod.WalletRequestAccounts, new WalletRequestAccount(this)],
       [RpcMethod.WalletRequestChainId, new WalletRequestChainId(this)],
       [RpcMethod.WalletAddInvokeTransaction, new WalletAddInvokeTransaction(this)],
       [RpcMethod.WalletWatchAsset, new WalletWatchAsset(this)],
       [RpcMethod.WalletSignTypedData, new WalletSignTypedData(this)],
-      [RpcMethod.WalletGetPermissions, new WalletGetPermissions(this)],
+      [RpcMethod.WalletGetPermissions, new WalletGetPermissions()],
       [RpcMethod.WalletAddDeclareTransaction, new WalletAddDeclareTransaction(this)],
     ]);
   }


### PR DESCRIPTION
This PR is to remove the snap connection on rpcs that return static information

as they dont necessary to connect to the snap

APIs include:
- wallet_supportedWalletApi
- wallet_supportedSpecs
- wallet_getPermissions