### PR TITLE
fix(get starknet): fix incorrect params in RPC `wallet_signTypedData`

### DIFF
--- a/packages/get-starknet/src/rpcs/deployment-data.ts
+++ b/packages/get-starknet/src/rpcs/deployment-data.ts
@@ -8,6 +8,6 @@ type Result = RpcTypeToMessageMap[WalletDeploymentDataMethod]['result'];
 
 export class WalletDeploymentData extends StarknetWalletRpc {
   async handleRequest(_param: Params): Promise<Result> {
-    return await this.wallet.snap.getDeploymentData(this.wallet.chainId, this.wallet.selectedAddress);
+    return await this.snap.getDeploymentData(this.wallet.chainId, this.wallet.selectedAddress);
   }
 }

--- a/packages/get-starknet/src/rpcs/sign-typed-data.test.ts
+++ b/packages/get-starknet/src/rpcs/sign-typed-data.test.ts
@@ -1,5 +1,5 @@
 import typedDataExample from '../../../__tests__/fixture/typedDataExample.json';
-import { mockWalletInit, createWallet, SepoliaNetwork } from '../__tests__/helper';
+import { mockWalletInit, createWallet, SepoliaNetwork, generateAccount } from '../__tests__/helper';
 import { SupportedWalletApi } from '../constants';
 import { MetaMaskSnap } from '../snap';
 import { WalletSignTypedData } from './sign-typed-data';
@@ -7,7 +7,8 @@ import { WalletSignTypedData } from './sign-typed-data';
 describe('WalletSignTypedData', () => {
   it('returns the signature', async () => {
     const wallet = createWallet();
-    mockWalletInit({ currentNetwork: SepoliaNetwork });
+    const account = generateAccount({ chainId: SepoliaNetwork.chainId });
+    mockWalletInit({ currentNetwork: SepoliaNetwork, address: account.address });
     const expectedResult = ['signature1', 'signature2'];
     const signSpy = jest.spyOn(MetaMaskSnap.prototype, 'signMessage');
     signSpy.mockResolvedValue(expectedResult);
@@ -19,7 +20,7 @@ describe('WalletSignTypedData', () => {
       api_version: SupportedWalletApi[0],
     });
 
-    expect(signSpy).toHaveBeenCalledWith(typedDataExample, true, SepoliaNetwork.chainId);
+    expect(signSpy).toHaveBeenCalledWith(typedDataExample, true, account.address);
     expect(result).toStrictEqual(expectedResult);
   });
 });

--- a/packages/get-starknet/src/rpcs/sign-typed-data.ts
+++ b/packages/get-starknet/src/rpcs/sign-typed-data.ts
@@ -8,7 +8,7 @@ type Result = RpcTypeToMessageMap[WalletSignTypedDataMethod]['result'];
 
 export class WalletSignTypedData extends StarknetWalletRpc {
   async handleRequest(params: Params): Promise<Result> {
-    return (await this.wallet.snap.signMessage(
+    return (await this.snap.signMessage(
       // To form the `TypedData` object in a more specific way,
       // preventing the `params` contains other properties that we dont need
       {
@@ -19,7 +19,7 @@ export class WalletSignTypedData extends StarknetWalletRpc {
       },
       // Ensure there will be a dialog to confirm the sign operation
       true,
-      this.wallet.chainId,
+      this.wallet.selectedAddress,
     )) as unknown as Result;
   }
 }

--- a/packages/get-starknet/src/rpcs/watch-asset.ts
+++ b/packages/get-starknet/src/rpcs/watch-asset.ts
@@ -13,6 +13,6 @@ export class WalletWatchAsset extends StarknetWalletRpc {
     // All parameters are required in the snap,
     // However, some are optional in get-starknet framework.
     // Therefore, we assigned default values to bypass the type issue, and let the snap throw the validation error.
-    return (await this.wallet.snap.watchAsset(address, name ?? '', symbol ?? '', decimals ?? 0)) as unknown as Result;
+    return (await this.snap.watchAsset(address, name ?? '', symbol ?? '', decimals ?? 0)) as unknown as Result;
   }
 }


### PR DESCRIPTION
this PR is to fix the incorrect params in `wallet_signTypedData` when calling the snap API
- it was using chain id as the address
- but it should use the address