### PR TITLE
refactor(get-starknet): change get starknet snap params structure

### DIFF
--- a/packages/get-starknet/src/accounts.ts
+++ b/packages/get-starknet/src/accounts.ts
@@ -37,22 +37,32 @@ export class MetaMaskAccount extends Account {
   async execute(
     calls: AllowArray<Call>,
     abisOrTransactionsDetail?: Abi[] | InvocationsDetails,
-    transactionsDetail?: InvocationsDetails,
+    details?: InvocationsDetails,
   ): Promise<InvokeFunctionResponse> {
-    if (!transactionsDetail) {
-      return this.#snap.execute(this.#address, calls, undefined, abisOrTransactionsDetail as InvocationsDetails);
-    }
-    return this.#snap.execute(this.#address, calls, abisOrTransactionsDetail as Abi[], transactionsDetail);
+    return this.#snap.execute({
+      address: this.#address,
+      calls,
+      details: details ?? (abisOrTransactionsDetail as unknown as InvocationsDetails),
+      abis: details ? (abisOrTransactionsDetail as Abi[]) : undefined,
+    });
   }
 
-  async signMessage(typedData: TypedData): Promise<Signature> {
-    return this.#snap.signMessage(typedData, true, this.#address);
+  async signMessage(typedDataMessage: TypedData): Promise<Signature> {
+    return this.#snap.signMessage({
+      typedDataMessage,
+      address: this.#address,
+      enableAuthorize: true,
+    });
   }
 
   async declare(
     contractPayload: DeclareContractPayload,
-    transactionsDetails?: InvocationsDetails,
+    invocationsDetails?: InvocationsDetails,
   ): Promise<DeclareContractResponse> {
-    return this.#snap.declare(this.#address, contractPayload, transactionsDetails);
+    return this.#snap.declare({
+      senderAddress: this.#address,
+      contractPayload,
+      invocationsDetails,
+    });
   }
 }

--- a/packages/get-starknet/src/accounts.ts
+++ b/packages/get-starknet/src/accounts.ts
@@ -36,14 +36,24 @@ export class MetaMaskAccount extends Account {
 
   async execute(
     calls: AllowArray<Call>,
+    // ABIs is deprecated and will be removed in the future
     abisOrTransactionsDetail?: Abi[] | InvocationsDetails,
     details?: InvocationsDetails,
   ): Promise<InvokeFunctionResponse> {
+    // if abisOrTransactionsDetail is an array, we assume it's an array of ABIs
+    // otherwise, we assume it's an InvocationsDetails object
+    if (Array.isArray(abisOrTransactionsDetail)) {
+      return this.#snap.execute({
+        address: this.#address,
+        calls,
+        details,
+        abis: abisOrTransactionsDetail,
+      });
+    }
     return this.#snap.execute({
       address: this.#address,
       calls,
-      details: details ?? (abisOrTransactionsDetail as unknown as InvocationsDetails),
-      abis: details ? (abisOrTransactionsDetail as Abi[]) : undefined,
+      details: abisOrTransactionsDetail as unknown as InvocationsDetails,
     });
   }
 

--- a/packages/get-starknet/src/rpcs/add-declare.test.ts
+++ b/packages/get-starknet/src/rpcs/add-declare.test.ts
@@ -38,7 +38,11 @@ describe('WalletAddDeclareTransaction', () => {
     const result = await walletAddDeclareTransaction.execute(params);
 
     expect(result).toStrictEqual(expectedResult);
-    expect(declareSpy).toHaveBeenCalledWith(account.address, formattedParams);
+    expect(declareSpy).toHaveBeenCalledWith({
+      senderAddress: account.address,
+      contractPayload: formattedParams,
+      chainId: wallet.chainId,
+    });
   });
 });
 /* eslint-enable @typescript-eslint/naming-convention */

--- a/packages/get-starknet/src/rpcs/add-declare.ts
+++ b/packages/get-starknet/src/rpcs/add-declare.ts
@@ -9,6 +9,10 @@ type Result = RpcTypeToMessageMap[WalletAddDeclareTransactionMethod]['result'];
 
 export class WalletAddDeclareTransaction extends StarknetWalletRpc {
   async handleRequest(params: Params): Promise<Result> {
-    return await this.snap.declare(this.wallet.selectedAddress, formatDeclareTransaction(params));
+    return await this.snap.declare({
+      senderAddress: this.wallet.selectedAddress,
+      contractPayload: formatDeclareTransaction(params),
+      chainId: this.wallet.chainId,
+    });
   }
 }

--- a/packages/get-starknet/src/rpcs/add-invoke.test.ts
+++ b/packages/get-starknet/src/rpcs/add-invoke.test.ts
@@ -31,6 +31,10 @@ describe('WalletAddInvokeTransaction', () => {
     });
 
     expect(result).toStrictEqual(expectedResult);
-    expect(executeSpy).toHaveBeenCalledWith(account.address, callsFormated);
+    expect(executeSpy).toHaveBeenCalledWith({
+      calls: callsFormated,
+      address: account.address,
+      chainId: wallet.chainId,
+    });
   });
 });

--- a/packages/get-starknet/src/rpcs/add-invoke.ts
+++ b/packages/get-starknet/src/rpcs/add-invoke.ts
@@ -10,6 +10,10 @@ type Result = RpcTypeToMessageMap[WalletAddInvokeTransactionMethod]['result'];
 export class WalletAddInvokeTransaction extends StarknetWalletRpc {
   async handleRequest(params: Params): Promise<Result> {
     const { calls } = params;
-    return await this.snap.execute(this.wallet.selectedAddress, formatCalls(calls));
+    return await this.snap.execute({
+      address: this.wallet.selectedAddress,
+      calls: formatCalls(calls),
+      chainId: this.wallet.chainId,
+    });
   }
 }

--- a/packages/get-starknet/src/rpcs/deployment-data.ts
+++ b/packages/get-starknet/src/rpcs/deployment-data.ts
@@ -8,6 +8,6 @@ type Result = RpcTypeToMessageMap[WalletDeploymentDataMethod]['result'];
 
 export class WalletDeploymentData extends StarknetWalletRpc {
   async handleRequest(_param: Params): Promise<Result> {
-    return await this.wallet.snap.getDeploymentData(this.wallet.chainId, this.wallet.selectedAddress);
+    return await this.snap.getDeploymentData(this.wallet.chainId, this.wallet.selectedAddress);
   }
 }

--- a/packages/get-starknet/src/rpcs/deployment-data.ts
+++ b/packages/get-starknet/src/rpcs/deployment-data.ts
@@ -8,6 +8,9 @@ type Result = RpcTypeToMessageMap[WalletDeploymentDataMethod]['result'];
 
 export class WalletDeploymentData extends StarknetWalletRpc {
   async handleRequest(_param: Params): Promise<Result> {
-    return await this.snap.getDeploymentData(this.wallet.chainId, this.wallet.selectedAddress);
+    return await this.snap.getDeploymentData({
+      chainId: this.wallet.chainId,
+      address: this.wallet.selectedAddress,
+    });
   }
 }

--- a/packages/get-starknet/src/rpcs/sign-typed-data.test.ts
+++ b/packages/get-starknet/src/rpcs/sign-typed-data.test.ts
@@ -6,9 +6,10 @@ import { WalletSignTypedData } from './sign-typed-data';
 
 describe('WalletSignTypedData', () => {
   it('returns the signature', async () => {
+    const network = SepoliaNetwork;
     const wallet = createWallet();
-    const account = generateAccount({ chainId: SepoliaNetwork.chainId });
-    mockWalletInit({ currentNetwork: SepoliaNetwork, address: account.address });
+    const account = generateAccount({ chainId: network.chainId });
+    mockWalletInit({ currentNetwork: network, address: account.address });
     const expectedResult = ['signature1', 'signature2'];
     const signSpy = jest.spyOn(MetaMaskSnap.prototype, 'signMessage');
     signSpy.mockResolvedValue(expectedResult);
@@ -20,7 +21,12 @@ describe('WalletSignTypedData', () => {
       api_version: SupportedWalletApi[0],
     });
 
-    expect(signSpy).toHaveBeenCalledWith(typedDataExample, true, account.address);
+    expect(signSpy).toHaveBeenCalledWith({
+      chainId: network.chainId,
+      typedDataMessage: typedDataExample,
+      enableAuthorize: true,
+      address: account.address,
+    });
     expect(result).toStrictEqual(expectedResult);
   });
 });

--- a/packages/get-starknet/src/rpcs/sign-typed-data.test.ts
+++ b/packages/get-starknet/src/rpcs/sign-typed-data.test.ts
@@ -1,5 +1,5 @@
 import typedDataExample from '../../../__tests__/fixture/typedDataExample.json';
-import { mockWalletInit, createWallet, SepoliaNetwork } from '../__tests__/helper';
+import { mockWalletInit, createWallet, SepoliaNetwork, generateAccount } from '../__tests__/helper';
 import { SupportedWalletApi } from '../constants';
 import { MetaMaskSnap } from '../snap';
 import { WalletSignTypedData } from './sign-typed-data';
@@ -7,7 +7,8 @@ import { WalletSignTypedData } from './sign-typed-data';
 describe('WalletSignTypedData', () => {
   it('returns the signature', async () => {
     const wallet = createWallet();
-    mockWalletInit({ currentNetwork: SepoliaNetwork });
+    const account = generateAccount({ chainId: SepoliaNetwork.chainId });
+    mockWalletInit({ currentNetwork: SepoliaNetwork, address: account.address });
     const expectedResult = ['signature1', 'signature2'];
     const signSpy = jest.spyOn(MetaMaskSnap.prototype, 'signMessage');
     signSpy.mockResolvedValue(expectedResult);
@@ -19,7 +20,7 @@ describe('WalletSignTypedData', () => {
       api_version: SupportedWalletApi[0],
     });
 
-    expect(signSpy).toHaveBeenCalledWith(typedDataExample, true, SepoliaNetwork.chainId);
+    expect(signSpy).toHaveBeenCalledWith(typedDataExample, true, account.address);
     expect(result).toStrictEqual(expectedResult);
   });
 });

--- a/packages/get-starknet/src/rpcs/sign-typed-data.ts
+++ b/packages/get-starknet/src/rpcs/sign-typed-data.ts
@@ -8,18 +8,19 @@ type Result = RpcTypeToMessageMap[WalletSignTypedDataMethod]['result'];
 
 export class WalletSignTypedData extends StarknetWalletRpc {
   async handleRequest(params: Params): Promise<Result> {
-    return (await this.snap.signMessage(
+    return (await this.snap.signMessage({
+      chainId: this.wallet.chainId,
       // To form the `TypedData` object in a more specific way,
       // preventing the `params` contains other properties that we dont need
-      {
+      typedDataMessage: {
         domain: params.domain,
         types: params.types,
         message: params.message,
         primaryType: params.primaryType,
       },
       // Ensure there will be a dialog to confirm the sign operation
-      true,
-      this.wallet.selectedAddress,
-    )) as unknown as Result;
+      enableAuthorize: true,
+      address: this.wallet.selectedAddress,
+    })) as unknown as Result;
   }
 }

--- a/packages/get-starknet/src/rpcs/sign-typed-data.ts
+++ b/packages/get-starknet/src/rpcs/sign-typed-data.ts
@@ -8,7 +8,7 @@ type Result = RpcTypeToMessageMap[WalletSignTypedDataMethod]['result'];
 
 export class WalletSignTypedData extends StarknetWalletRpc {
   async handleRequest(params: Params): Promise<Result> {
-    return (await this.wallet.snap.signMessage(
+    return (await this.snap.signMessage(
       // To form the `TypedData` object in a more specific way,
       // preventing the `params` contains other properties that we dont need
       {
@@ -19,7 +19,7 @@ export class WalletSignTypedData extends StarknetWalletRpc {
       },
       // Ensure there will be a dialog to confirm the sign operation
       true,
-      this.wallet.chainId,
+      this.wallet.selectedAddress,
     )) as unknown as Result;
   }
 }

--- a/packages/get-starknet/src/rpcs/watch-asset.test.ts
+++ b/packages/get-starknet/src/rpcs/watch-asset.test.ts
@@ -6,7 +6,8 @@ import { WalletWatchAsset } from './watch-asset';
 describe('WalletWatchAsset', () => {
   it('watches the specified asset and returns a success response', async () => {
     const wallet = createWallet();
-    mockWalletInit({ currentNetwork: SepoliaNetwork });
+    const network = SepoliaNetwork;
+    mockWalletInit({ currentNetwork: network });
     const expectedResult = true;
     const watchAssetSpy = jest.spyOn(MetaMaskSnap.prototype, 'watchAsset');
     watchAssetSpy.mockResolvedValue(expectedResult);
@@ -19,7 +20,13 @@ describe('WalletWatchAsset', () => {
       api_version: SupportedWalletApi[0],
     });
 
-    expect(watchAssetSpy).toHaveBeenCalledWith(EthAsset.address, EthAsset.name, EthAsset.symbol, EthAsset.decimals);
+    expect(watchAssetSpy).toHaveBeenCalledWith({
+      address: EthAsset.address,
+      symbol: EthAsset.symbol,
+      decimals: EthAsset.decimals,
+      name: EthAsset.name,
+      chainId: network.chainId,
+    });
     expect(result).toStrictEqual(expectedResult);
   });
 });

--- a/packages/get-starknet/src/rpcs/watch-asset.ts
+++ b/packages/get-starknet/src/rpcs/watch-asset.ts
@@ -13,6 +13,6 @@ export class WalletWatchAsset extends StarknetWalletRpc {
     // All parameters are required in the snap,
     // However, some are optional in get-starknet framework.
     // Therefore, we assigned default values to bypass the type issue, and let the snap throw the validation error.
-    return (await this.wallet.snap.watchAsset(address, name ?? '', symbol ?? '', decimals ?? 0)) as unknown as Result;
+    return (await this.snap.watchAsset(address, name ?? '', symbol ?? '', decimals ?? 0)) as unknown as Result;
   }
 }

--- a/packages/get-starknet/src/rpcs/watch-asset.ts
+++ b/packages/get-starknet/src/rpcs/watch-asset.ts
@@ -13,6 +13,12 @@ export class WalletWatchAsset extends StarknetWalletRpc {
     // All parameters are required in the snap,
     // However, some are optional in get-starknet framework.
     // Therefore, we assigned default values to bypass the type issue, and let the snap throw the validation error.
-    return (await this.snap.watchAsset(address, name ?? '', symbol ?? '', decimals ?? 0)) as unknown as Result;
+    return (await this.snap.watchAsset({
+      address,
+      symbol: symbol ?? '',
+      decimals: decimals ?? 0,
+      name: name ?? '',
+      chainId: this.wallet.chainId,
+    })) as unknown as Result;
   }
 }

--- a/packages/get-starknet/src/signer.ts
+++ b/packages/get-starknet/src/signer.ts
@@ -24,11 +24,17 @@ export class MetaMaskSigner implements SignerInterface {
   }
 
   async getPubKey(): Promise<string> {
-    return this.#snap.getPubKey(this.#address);
+    return this.#snap.getPubKey({
+      userAddress: this.#address,
+    });
   }
 
-  async signMessage(typedData: TypedData, accountAddress: string): Promise<Signature> {
-    const result = (await this.#snap.signMessage(typedData, false, accountAddress)) as ArraySignatureType;
+  async signMessage(typedDataMessage: TypedData, address: string): Promise<Signature> {
+    const result = (await this.#snap.signMessage({
+      typedDataMessage,
+      enableAuthorize: false,
+      address,
+    })) as ArraySignatureType;
     return new ec.starkCurve.Signature(numUtils.toBigInt(result[0]), numUtils.toBigInt(result[1]));
   }
 
@@ -45,21 +51,27 @@ export class MetaMaskSigner implements SignerInterface {
     transactionsDetail: InvocationsSignerDetails,
     _abis?: Abi[] | undefined,
   ): Promise<Signature> {
-    const result = (await this.#snap.signTransaction(
-      this.#address,
+    const result = (await this.#snap.signTransaction({
+      address: this.#address,
       transactions,
       transactionsDetail,
-    )) as ArraySignatureType;
+    })) as ArraySignatureType;
     return new ec.starkCurve.Signature(numUtils.toBigInt(result[0]), numUtils.toBigInt(result[1]));
   }
 
   async signDeployAccountTransaction(transaction: DeployAccountSignerDetails): Promise<Signature> {
-    const result = (await this.#snap.signDeployAccountTransaction(this.#address, transaction)) as ArraySignatureType;
+    const result = (await this.#snap.signDeployAccountTransaction({
+      signerAddress: this.#address,
+      transaction,
+    })) as ArraySignatureType;
     return new ec.starkCurve.Signature(numUtils.toBigInt(result[0]), numUtils.toBigInt(result[1]));
   }
 
   async signDeclareTransaction(transaction: DeclareSignerDetails): Promise<Signature> {
-    const result = (await this.#snap.signDeclareTransaction(this.#address, transaction)) as ArraySignatureType;
+    const result = (await this.#snap.signDeclareTransaction({
+      address: this.#address,
+      details: transaction,
+    })) as ArraySignatureType;
     return new ec.starkCurve.Signature(numUtils.toBigInt(result[0]), numUtils.toBigInt(result[1]));
   }
 }

--- a/packages/get-starknet/src/snap.ts
+++ b/packages/get-starknet/src/snap.ts
@@ -35,10 +35,10 @@ export class MetaMaskSnap {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_extractPublicKey',
-          params: {
+          params: await this.#getSnapParams({
             userAddress,
             chainId,
-          },
+          }),
         },
       },
     })) as string;
@@ -61,7 +61,7 @@ export class MetaMaskSnap {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_signTransaction',
-          params: this.#getSnapParams({
+          params: await this.#getSnapParams({
             address,
             transactions,
             transactionsDetail,
@@ -87,7 +87,7 @@ export class MetaMaskSnap {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_signDeployAccountTransaction',
-          params: this.#getSnapParams({
+          params: await this.#getSnapParams({
             signerAddress,
             transaction,
             chainId,
@@ -112,7 +112,7 @@ export class MetaMaskSnap {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_signDeclareTransaction',
-          params: this.#getSnapParams({
+          params: await this.#getSnapParams({
             address,
             details,
             chainId,
@@ -141,7 +141,7 @@ export class MetaMaskSnap {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_executeTxn',
-          params: this.#getSnapParams({
+          params: await this.#getSnapParams({
             address,
             calls,
             details,
@@ -170,7 +170,7 @@ export class MetaMaskSnap {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_signMessage',
-          params: this.#getSnapParams({
+          params: await this.#getSnapParams({
             address,
             typedDataMessage,
             enableAuthorize,
@@ -198,7 +198,7 @@ export class MetaMaskSnap {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_declareContract',
-          params: this.#getSnapParams({
+          params: await this.#getSnapParams({
             senderAddress,
             contractPayload,
             invocationsDetails,
@@ -256,7 +256,7 @@ export class MetaMaskSnap {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_recoverAccounts',
-          params: this.#getSnapParams({
+          params: await this.#getSnapParams({
             startScanIndex,
             maxScanned,
             maxMissed,
@@ -331,7 +331,7 @@ export class MetaMaskSnap {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_addErc20Token',
-          params: this.#getSnapParams({
+          params: await this.#getSnapParams({
             tokenAddress: address,
             tokenName: name,
             tokenSymbol: symbol,

--- a/packages/get-starknet/src/snap.ts
+++ b/packages/get-starknet/src/snap.ts
@@ -209,7 +209,8 @@ export class MetaMaskSnap {
     })) as DeclareContractResponse;
   }
 
-  async getNetwork({ chainId }: { chainId: string }): Promise<Network | undefined> {
+  // Method will be deprecated, replaced by get current network
+  async getNetwork(chainId): Promise<Network | undefined> {
     const response = (await this.#provider.request({
       method: 'wallet_invokeSnap',
       params: {
@@ -282,14 +283,25 @@ export class MetaMaskSnap {
     })) as boolean;
   }
 
-  async addStarknetChain(chainName: string, chainId: string, rpcUrl: string, explorerUrl: string): Promise<boolean> {
+  // Method to be deprecated, no longer supported
+  async addStarknetChain({
+    chainName,
+    chainId,
+    rpcUrl,
+    explorerUrl,
+  }: {
+    chainName: string;
+    chainId: string;
+    rpcUrl: string;
+    explorerUrl: string;
+  }): Promise<boolean> {
     return (await this.#provider.request({
       method: 'wallet_invokeSnap',
       params: {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_addNetwork',
-          params: this.#getSnapParams({
+          params: this.#removeUndefined({
             networkName: chainName,
             networkChainId: chainId,
             networkNodeUrl: rpcUrl,

--- a/packages/get-starknet/src/snap.ts
+++ b/packages/get-starknet/src/snap.ts
@@ -28,7 +28,7 @@ export class MetaMaskSnap {
     this.#version = version;
   }
 
-  async getPubKey(userAddress: string): Promise<string> {
+  async getPubKey({ userAddress, chainId }: { userAddress: string; chainId?: string }): Promise<string> {
     return (await this.#provider.request({
       method: 'wallet_invokeSnap',
       params: {
@@ -37,137 +37,179 @@ export class MetaMaskSnap {
           method: 'starkNet_extractPublicKey',
           params: {
             userAddress,
-            ...(await this.#getSnapParams()),
+            chainId,
           },
         },
       },
     })) as string;
   }
 
-  async signTransaction(
-    address: string,
-    transactions: Call[],
-    transactionsDetail: InvocationsSignerDetails,
-  ): Promise<Signature> {
+  async signTransaction({
+    address,
+    transactions,
+    transactionsDetail,
+    chainId,
+  }: {
+    address: string;
+    transactions: Call[];
+    transactionsDetail: InvocationsSignerDetails;
+    chainId?: string;
+  }): Promise<Signature> {
     return (await this.#provider.request({
       method: 'wallet_invokeSnap',
       params: {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_signTransaction',
-          params: this.removeUndefined({
+          params: this.#getSnapParams({
             address,
             transactions,
             transactionsDetail,
-            ...(await this.#getSnapParams()),
+            chainId,
           }),
         },
       },
     })) as Signature;
   }
 
-  async signDeployAccountTransaction(
-    signerAddress: string,
-    transaction: DeployAccountSignerDetails,
-  ): Promise<Signature> {
+  async signDeployAccountTransaction({
+    signerAddress,
+    transaction,
+    chainId,
+  }: {
+    signerAddress: string;
+    transaction: DeployAccountSignerDetails;
+    chainId?: string;
+  }): Promise<Signature> {
     return (await this.#provider.request({
       method: 'wallet_invokeSnap',
       params: {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_signDeployAccountTransaction',
-          params: this.removeUndefined({
+          params: this.#getSnapParams({
             signerAddress,
             transaction,
-            ...(await this.#getSnapParams()),
+            chainId,
           }),
         },
       },
     })) as Signature;
   }
 
-  async signDeclareTransaction(address: string, details: DeclareSignerDetails): Promise<Signature> {
+  async signDeclareTransaction({
+    address,
+    details,
+    chainId,
+  }: {
+    address: string;
+    details: DeclareSignerDetails;
+    chainId?: string;
+  }): Promise<Signature> {
     return (await this.#provider.request({
       method: 'wallet_invokeSnap',
       params: {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_signDeclareTransaction',
-          params: this.removeUndefined({
+          params: this.#getSnapParams({
             address,
             details,
-            ...(await this.#getSnapParams()),
+            chainId,
           }),
         },
       },
     })) as Signature;
   }
 
-  async execute(
-    address: string,
-    calls: AllowArray<Call>,
-    abis?: Abi[],
-    details?: InvocationsDetails,
-  ): Promise<InvokeFunctionResponse> {
+  async execute({
+    address,
+    calls,
+    abis,
+    details,
+    chainId,
+  }: {
+    address: string;
+    calls: AllowArray<Call>;
+    abis?: Abi[];
+    details?: InvocationsDetails;
+    chainId?: string;
+  }): Promise<InvokeFunctionResponse> {
     return (await this.#provider.request({
       method: 'wallet_invokeSnap',
       params: {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_executeTxn',
-          params: this.removeUndefined({
+          params: this.#getSnapParams({
             address,
             calls,
             details,
             abis,
-            ...(await this.#getSnapParams()),
+            chainId,
           }),
         },
       },
     })) as InvokeFunctionResponse;
   }
 
-  async signMessage(typedDataMessage: TypedData, enableAuthorize: boolean, address: string): Promise<Signature> {
+  async signMessage({
+    typedDataMessage,
+    enableAuthorize,
+    address,
+    chainId,
+  }: {
+    typedDataMessage: TypedData;
+    enableAuthorize: boolean;
+    address: string;
+    chainId?: string;
+  }): Promise<Signature> {
     return (await this.#provider.request({
       method: 'wallet_invokeSnap',
       params: {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_signMessage',
-          params: this.removeUndefined({
+          params: this.#getSnapParams({
             address,
             typedDataMessage,
             enableAuthorize,
-            ...(await this.#getSnapParams()),
+            chainId,
           }),
         },
       },
     })) as Signature;
   }
 
-  async declare(
-    senderAddress: string,
-    contractPayload: DeclareContractPayload,
-    invocationsDetails?: InvocationsDetails,
-  ): Promise<DeclareContractResponse> {
+  async declare({
+    senderAddress,
+    contractPayload,
+    invocationsDetails,
+    chainId,
+  }: {
+    senderAddress: string;
+    contractPayload: DeclareContractPayload;
+    invocationsDetails?: InvocationsDetails;
+    chainId?: string;
+  }): Promise<DeclareContractResponse> {
     return (await this.#provider.request({
       method: 'wallet_invokeSnap',
       params: {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_declareContract',
-          params: this.removeUndefined({
+          params: this.#getSnapParams({
             senderAddress,
             contractPayload,
             invocationsDetails,
-            ...(await this.#getSnapParams()),
+            chainId,
           }),
         },
       },
     })) as DeclareContractResponse;
   }
 
-  async getNetwork(chainId: string): Promise<Network | undefined> {
+  async getNetwork({ chainId }: { chainId: string }): Promise<Network | undefined> {
     const response = (await this.#provider.request({
       method: 'wallet_invokeSnap',
       params: {
@@ -187,23 +229,38 @@ export class MetaMaskSnap {
   }
 
   async recoverDefaultAccount(chainId: string): Promise<AccContract> {
-    const result = await this.recoverAccounts(chainId, 0, 1, 1);
+    const result = await this.recoverAccounts({
+      chainId,
+      startScanIndex: 0,
+      maxScanned: 1,
+      maxMissed: 1,
+    });
     return result[0];
   }
 
-  async recoverAccounts(chainId: string, startScanIndex = 0, maxScanned = 1, maxMissed = 1): Promise<AccContract[]> {
+  async recoverAccounts({
+    chainId,
+    startScanIndex = 0,
+    maxScanned = 1,
+    maxMissed = 1,
+  }: {
+    chainId?: string;
+    startScanIndex?: number;
+    maxScanned?: number;
+    maxMissed?: number;
+  }): Promise<AccContract[]> {
     return (await this.#provider.request({
       method: 'wallet_invokeSnap',
       params: {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_recoverAccounts',
-          params: {
+          params: this.#getSnapParams({
             startScanIndex,
             maxScanned,
             maxMissed,
             chainId,
-          },
+          }),
         },
       },
     })) as AccContract[];
@@ -232,7 +289,7 @@ export class MetaMaskSnap {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_addNetwork',
-          params: this.removeUndefined({
+          params: this.#getSnapParams({
             networkName: chainName,
             networkChainId: chainId,
             networkNodeUrl: rpcUrl,
@@ -243,18 +300,31 @@ export class MetaMaskSnap {
     })) as boolean;
   }
 
-  async watchAsset(address: string, name: string, symbol: string, decimals: number): Promise<boolean> {
+  async watchAsset({
+    address,
+    name,
+    symbol,
+    decimals,
+    chainId,
+  }: {
+    address: string;
+    name: string;
+    symbol: string;
+    decimals: number;
+    chainId?: string;
+  }): Promise<boolean> {
     return this.#provider.request({
       method: 'wallet_invokeSnap',
       params: {
         snapId: this.#snapId,
         request: {
           method: 'starkNet_addErc20Token',
-          params: this.removeUndefined({
+          params: this.#getSnapParams({
             tokenAddress: address,
             tokenName: name,
             tokenSymbol: symbol,
             tokenDecimals: decimals,
+            chainId,
           }),
         },
       },
@@ -276,7 +346,7 @@ export class MetaMaskSnap {
     return response;
   }
 
-  async getDeploymentData(chainId: string, address: string): Promise<DeploymentData> {
+  async getDeploymentData({ chainId, address }: { chainId: string; address: string }): Promise<DeploymentData> {
     const response = (await this.#provider.request({
       method: 'wallet_invokeSnap',
       params: {
@@ -294,11 +364,11 @@ export class MetaMaskSnap {
     return response;
   }
 
-  async #getSnapParams() {
-    const network = await this.getCurrentNetwork();
-    return {
-      chainId: network.chainId,
-    };
+  async #getSnapParams(params: Record<string, unknown> & { chainId?: string }): Promise<Record<string, unknown>> {
+    return this.#removeUndefined({
+      ...params,
+      chainId: params.chainId ?? (await this.getCurrentNetwork()).chainId,
+    });
   }
 
   static async getProvider(window: {
@@ -371,7 +441,7 @@ export class MetaMaskSnap {
     }
   }
 
-  removeUndefined(obj: Record<string, unknown>) {
+  #removeUndefined(obj: Record<string, unknown>) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     return Object.fromEntries(Object.entries(obj).filter(([_, val]) => val !== undefined));
   }


### PR DESCRIPTION
This PR is to change the get starknet snap params structure from arguments in array to arguments in object

it is because it will more easy to read and config with default value

And reduce the get current network call from the new get-starknet PRC
- it was called everytime when submit a request to snap
- it will only called if the chain id is undefined 

### Requirements:
Below PRs required to be merged before hand:
- [x] #394 
