### PR TITLE
fix(SNAP): fix incorrect params passed to SNAP RPCs

### DIFF
--- a/packages/starknet-snap/src/index.ts
+++ b/packages/starknet-snap/src/index.ts
@@ -185,7 +185,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
 
       case 'starkNet_signDeclareTransaction':
         return await signDeclareTransaction.execute(
-          apiParams as unknown as SignDeclareTransactionParams,
+          apiParams.requestParams as unknown as SignDeclareTransactionParams,
         );
 
       case 'starkNet_signDeployAccountTransaction':
@@ -196,7 +196,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
 
       case 'starkNet_verifySignedMessage':
         return await verifySignature.execute(
-          apiParams as unknown as VerifySignatureParams,
+          apiParams.requestParams as unknown as VerifySignatureParams,
         );
 
       case 'starkNet_getErc20TokenBalance':
@@ -278,7 +278,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
 
       case 'starkNet_declareContract':
         return await declareContract.execute(
-          apiParams as unknown as DeclareContractParams,
+          apiParams.requestParams as unknown as DeclareContractParams,
         );
 
       case 'starkNet_getStarkName':
@@ -286,7 +286,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
 
       case 'starkNet_getDeploymentData':
         return await getDeploymentData.execute(
-          apiParams as unknown as GetDeploymentDataParams,
+          apiParams.requestParams as unknown as GetDeploymentDataParams,
         );
 
       default:


### PR DESCRIPTION
This PR is to fix the incorrect params passed to SNAP RPCs :
- starkNet_signDeclareTransaction
- starkNet_verifySignedMessage
- starkNet_declareContract
- starkNet_getDeploymentData

BEGIN_COMMIT_OVERRIDE
fix: Fix incorrect params passed to RPCs `starkNet_signDeclareTransaction`, `starkNet_verifySignedMessage`, `starkNet_declareContract` and `starkNet_getDeploymentData`
END_COMMIT_OVERRIDE