### PR TITLE
chore(get-starknet): remove `Method not supported` exception for "`on` " and "`off`" event handlers

### DIFF
--- a/packages/get-starknet/src/wallet.test.ts
+++ b/packages/get-starknet/src/wallet.test.ts
@@ -140,7 +140,7 @@ describe('MetaMaskSnapWallet', () => {
     it('throws `Method not supported` error', async () => {
       const wallet = createWallet();
 
-      expect(() => wallet.on()).toThrow('Method not supported');
+      expect(() => wallet.on('accountsChanged', jest.fn())).not.toThrow();
     });
   });
 
@@ -148,7 +148,7 @@ describe('MetaMaskSnapWallet', () => {
     it('throws `Method not supported` error', async () => {
       const wallet = createWallet();
 
-      expect(() => wallet.off()).toThrow('Method not supported');
+      expect(() => wallet.off('accountsChanged', jest.fn())).not.toThrow();
     });
   });
 });

--- a/packages/get-starknet/src/wallet.test.ts
+++ b/packages/get-starknet/src/wallet.test.ts
@@ -145,7 +145,7 @@ describe('MetaMaskSnapWallet', () => {
   });
 
   describe('off', () => {
-    it('throws `Method not supported` error', async () => {
+    it('does nothing and not throw any error', async () => {
       const wallet = createWallet();
 
       expect(() => wallet.off('accountsChanged', jest.fn())).not.toThrow();

--- a/packages/get-starknet/src/wallet.test.ts
+++ b/packages/get-starknet/src/wallet.test.ts
@@ -137,7 +137,7 @@ describe('MetaMaskSnapWallet', () => {
   });
 
   describe('on', () => {
-    it('throws `Method not supported` error', async () => {
+    it('does nothing and not throw any error', async () => {
       const wallet = createWallet();
 
       expect(() => wallet.on('accountsChanged', jest.fn())).not.toThrow();

--- a/packages/get-starknet/src/wallet.ts
+++ b/packages/get-starknet/src/wallet.ts
@@ -1,6 +1,7 @@
 import type { MutexInterface } from 'async-mutex';
 import { Mutex } from 'async-mutex';
-import { type RpcMessage, type WalletEvents, type StarknetWindowObject } from 'get-starknet-core';
+import type { WalletEventHandlers } from 'get-starknet-core';
+import { type RpcMessage, type StarknetWindowObject } from 'get-starknet-core';
 import type { AccountInterface, ProviderInterface } from 'starknet';
 import { Provider } from 'starknet';
 
@@ -208,12 +209,12 @@ export class MetaMaskSnapWallet implements StarknetWindowObject {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  on<Event extends WalletEvents>() {
-    throw new Error('Method not supported');
+  on<Event extends keyof WalletEventHandlers>(_event: Event, _handleEvent: WalletEventHandlers[Event]): void {
+    // No operation for now
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  off<Event extends WalletEvents>() {
-    throw new Error('Method not supported');
+  off<Event extends keyof WalletEventHandlers>(_event: Event, _handleEvent?: WalletEventHandlers[Event]): void {
+    // No operation for now
   }
 }

--- a/packages/starknet-snap/src/index.ts
+++ b/packages/starknet-snap/src/index.ts
@@ -185,7 +185,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
 
       case 'starkNet_signDeclareTransaction':
         return await signDeclareTransaction.execute(
-          apiParams as unknown as SignDeclareTransactionParams,
+          apiParams.requestParams as unknown as SignDeclareTransactionParams,
         );
 
       case 'starkNet_signDeployAccountTransaction':
@@ -196,7 +196,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
 
       case 'starkNet_verifySignedMessage':
         return await verifySignature.execute(
-          apiParams as unknown as VerifySignatureParams,
+          apiParams.requestParams as unknown as VerifySignatureParams,
         );
 
       case 'starkNet_getErc20TokenBalance':
@@ -278,7 +278,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
 
       case 'starkNet_declareContract':
         return await declareContract.execute(
-          apiParams as unknown as DeclareContractParams,
+          apiParams.requestParams as unknown as DeclareContractParams,
         );
 
       case 'starkNet_getStarkName':
@@ -286,7 +286,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
 
       case 'starkNet_getDeploymentData':
         return await getDeploymentData.execute(
-          apiParams as unknown as GetDeploymentDataParams,
+          apiParams.requestParams as unknown as GetDeploymentDataParams,
         );
 
       default:


### PR DESCRIPTION
This PR is to fix the on/off event. The signature is updated to match interface. And the throw is removed to allow the use of WalletAccount as per the starknet documentation: http://starknetjs.com/docs/next/guides/walletAccount#select-a-wallet. If we through the WalletAccount object can't be created. 
