### PR TITLE
fix: remove duplicate snap installation prompt in get-starknet if it has installed

### DIFF
--- a/packages/get-starknet/src/snap.ts
+++ b/packages/get-starknet/src/snap.ts
@@ -426,7 +426,7 @@ export class MetaMaskSnap {
   async installIfNot(): Promise<boolean> {
     // if the snap is already installed, return true, to bypass the prompt
     if (await this.isInstalled()) {
-      return true
+      return true;
     }
 
     const response = (await this.#provider.request({

--- a/packages/get-starknet/src/snap.ts
+++ b/packages/get-starknet/src/snap.ts
@@ -424,15 +424,23 @@ export class MetaMaskSnap {
   }
 
   async installIfNot(): Promise<boolean> {
+    // if the snap is already installed, return true, to bypass the prompt
+    if (await this.isInstalled()) {
+      return true
+    }
+
     const response = (await this.#provider.request({
       method: 'wallet_requestSnaps',
       params: {
         [this.#snapId]: { version: this.#version },
       },
     })) as RequestSnapResponse;
+
+    // if the snap installation is deined by end user, return false
     if (!response?.[this.#snapId]?.enabled) {
       return false;
     }
+
     return true;
   }
 


### PR DESCRIPTION
This PR is to remove duplicate snap installation prompt in get-starknet if it has installed by:

1. Check if it has install by using RPC method `ping`
2. If it does n ot throw error, it means the snap has installed, then we dont need to continue
3. else ask end user install


BEGIN_COMMIT_OVERRIDE
fix: Remove duplicate snap installation prompt in get-starknet if it has installed (#407)
END_COMMIT_OVERRIDE

