### PR TITLE
chore(wallet-ui): remove ending slash on localSnapId 

### DIFF
--- a/packages/wallet-ui/src/services/useStarkNetSnap.ts
+++ b/packages/wallet-ui/src/services/useStarkNetSnap.ts
@@ -48,7 +48,7 @@ export const useStarkNetSnap = () => {
   );
   const snapId = process.env.REACT_APP_SNAP_ID
     ? process.env.REACT_APP_SNAP_ID
-    : 'local:http://localhost:8081/';
+    : 'local:http://localhost:8081';
   const snapVersion = process.env.REACT_APP_SNAP_VERSION
     ? process.env.REACT_APP_SNAP_VERSION
     : '*';


### PR DESCRIPTION
This PR is to ensure snapId name compatibility between get-starknet and wallet-ui. 

In get-starknet the snapId is set with an env variable. However ending / are removed when loaded with `process.env` hence the snapId does not match the one in wallet-ui. We remove the ending / in wallet-ui to ensure compatibility between the two.

BEGIN_COMMIT_OVERRIDE
chore: remove ending slash on localSnapId
END_COMMIT_OVERRIDE