### PR TITLE
chore: add transaction request state manager

### DIFF
--- a/packages/starknet-snap/src/state/__tests__/helper.ts
+++ b/packages/starknet-snap/src/state/__tests__/helper.ts
@@ -1,7 +1,12 @@
 import type { constants } from 'starknet';
 
 import { generateAccounts, type StarknetAccount } from '../../__tests__/helper';
-import type { Erc20Token, Network, Transaction } from '../../types/snapState';
+import type {
+  Erc20Token,
+  Network,
+  Transaction,
+  TransactionRequest,
+} from '../../types/snapState';
 import * as snapHelper from '../../utils/snap';
 
 jest.mock('../../utils/snap');
@@ -20,12 +25,14 @@ export const mockState = async ({
   networks,
   transactions,
   currentNetwork,
+  transactionRequests,
 }: {
   accounts?: StarknetAccount[];
   tokens?: Erc20Token[];
   networks?: Network[];
   transactions?: Transaction[];
   currentNetwork?: Network;
+  transactionRequests?: TransactionRequest[];
 }) => {
   const getDataSpy = jest.spyOn(snapHelper, 'getStateData');
   const setDataSpy = jest.spyOn(snapHelper, 'setStateData');
@@ -35,6 +42,7 @@ export const mockState = async ({
     networks: networks ?? [],
     transactions: transactions ?? [],
     currentNetwork,
+    transactionRequests: transactionRequests ?? [],
   };
   getDataSpy.mockResolvedValue(state);
   return {

--- a/packages/starknet-snap/src/state/request-state-manager.test.ts
+++ b/packages/starknet-snap/src/state/request-state-manager.test.ts
@@ -1,0 +1,173 @@
+import { constants } from 'starknet';
+
+import { generateTransactionRequests } from '../__tests__/helper';
+import type { TransactionRequest } from '../types/snapState';
+import { mockAcccounts, mockState } from './__tests__/helper';
+import { TransactionRequestStateManager } from './request-state-manager';
+import { StateManagerError } from './state-manager';
+
+describe('TransactionRequestStateManager', () => {
+  const getChainId = () => constants.StarknetChainId.SN_SEPOLIA;
+
+  const prepareMockData = async () => {
+    const chainId = getChainId();
+    const accounts = await mockAcccounts(chainId, 1);
+    const transactionRequests = generateTransactionRequests({
+      chainId,
+      address: accounts[0].address,
+      cnt: 10,
+    });
+
+    const { state, setDataSpy, getDataSpy } = await mockState({
+      transactionRequests,
+    });
+
+    return {
+      state,
+      setDataSpy,
+      getDataSpy,
+      account: accounts[0],
+      transactionRequests,
+    };
+  };
+
+  const getNewEntity = (address) => {
+    const chainId = getChainId();
+    const transactionRequests = generateTransactionRequests({
+      chainId,
+      address,
+      cnt: 1,
+    });
+
+    return transactionRequests[0];
+  };
+
+  const getUpdateEntity = (request: TransactionRequest) => {
+    return {
+      ...request,
+      maxFee: '999999',
+    };
+  };
+
+  describe('getTransactionRequest', () => {
+    it('returns the transaction request', async () => {
+      const {
+        transactionRequests: [transactionRequest],
+      } = await prepareMockData();
+
+      const stateManager = new TransactionRequestStateManager();
+      const result = await stateManager.getTransactionRequest({
+        requestId: transactionRequest.id,
+      });
+
+      expect(result).toStrictEqual(transactionRequest);
+    });
+
+    it('finds the request by interfaceId', async () => {
+      const {
+        transactionRequests: [transactionRequest],
+      } = await prepareMockData();
+
+      const stateManager = new TransactionRequestStateManager();
+      const result = await stateManager.getTransactionRequest({
+        interfaceId: transactionRequest.interfaceId,
+      });
+
+      expect(result).toStrictEqual(transactionRequest);
+    });
+
+    it('returns null if the transaction request can not be found', async () => {
+      await prepareMockData();
+
+      const stateManager = new TransactionRequestStateManager();
+
+      const result = await stateManager.getTransactionRequest({
+        requestId: 'something',
+      });
+      expect(result).toBeNull();
+    });
+
+    it('throws a `At least one search condition must be provided` error if no search criteria given', async () => {
+      const stateManager = new TransactionRequestStateManager();
+
+      await expect(stateManager.getTransactionRequest({})).rejects.toThrow(
+        'At least one search condition must be provided',
+      );
+    });
+  });
+
+  describe('upsertTransactionRequest', () => {
+    it('updates the transaction request if the transaction request found', async () => {
+      const {
+        state,
+        transactionRequests: [transactionRequest],
+      } = await prepareMockData();
+      const entity = getUpdateEntity(transactionRequest);
+
+      const stateManager = new TransactionRequestStateManager();
+      await stateManager.upsertTransactionRequest(entity);
+
+      expect(
+        state.transactionRequests.find(
+          (req) => req.id === transactionRequest.id,
+        ),
+      ).toStrictEqual(entity);
+    });
+
+    it('add a new transaction request if the transaction request does not found', async () => {
+      const { state, account } = await prepareMockData();
+      const entity = getNewEntity(account.address);
+      const orgLength = state.transactionRequests.length;
+
+      const stateManager = new TransactionRequestStateManager();
+      await stateManager.upsertTransactionRequest(entity);
+
+      expect(state.transactionRequests).toHaveLength(orgLength + 1);
+      expect(
+        state.transactionRequests.find((req) => req.id === entity.id),
+      ).toStrictEqual(entity);
+    });
+
+    it('throws a `StateManagerError` error if an error was thrown', async () => {
+      const { account, setDataSpy } = await prepareMockData();
+      const entity = getNewEntity(account.address);
+      setDataSpy.mockRejectedValue(new Error('Error'));
+
+      const stateManager = new TransactionRequestStateManager();
+
+      await expect(
+        stateManager.upsertTransactionRequest(entity),
+      ).rejects.toThrow(StateManagerError);
+    });
+  });
+
+  describe('removeTransactionRequests', () => {
+    it('removes the request', async () => {
+      const {
+        transactionRequests: [{ id }],
+        state,
+      } = await prepareMockData();
+      const stateManager = new TransactionRequestStateManager();
+
+      await stateManager.removeTransactionRequest(id);
+
+      expect(
+        state.transactionRequests.filter((req) => req.id === id),
+      ).toStrictEqual([]);
+    });
+
+    it('throws a `StateManagerError` error if an error was thrown', async () => {
+      const {
+        transactionRequests: [{ id }],
+        setDataSpy,
+      } = await prepareMockData();
+      setDataSpy.mockRejectedValue(new Error('Error'));
+
+      const stateManager = new TransactionRequestStateManager();
+
+      await expect(stateManager.removeTransactionRequest(id)).rejects.toThrow(
+        StateManagerError,
+      );
+    });
+  });
+});

--- a/packages/starknet-snap/src/state/request-state-manager.ts
+++ b/packages/starknet-snap/src/state/request-state-manager.ts
@@ -1,0 +1,123 @@
+import type { TransactionRequest, SnapState } from '../types/snapState';
+import { logger } from '../utils';
+import type { IFilter } from './filter';
+import { StringFllter } from './filter';
+import { StateManager, StateManagerError } from './state-manager';
+
+export type ITransactionRequestFilter = IFilter<TransactionRequest>;
+
+export class IdFilter
+  extends StringFllter<TransactionRequest>
+  implements ITransactionRequestFilter
+{
+  dataKey = 'id';
+}
+
+export class InterfaceIdFilter
+  extends StringFllter<TransactionRequest>
+  implements ITransactionRequestFilter
+{
+  dataKey = 'interfaceId';
+}
+
+export class TransactionRequestStateManager extends StateManager<TransactionRequest> {
+  protected getCollection(state: SnapState): TransactionRequest[] {
+    return state.transactionRequests ?? [];
+  }
+
+  protected updateEntity(
+    dataInState: TransactionRequest,
+    data: TransactionRequest,
+  ): void {
+    // This is the only field that can be updated
+    dataInState.maxFee = data.maxFee;
+    dataInState.feeToken = data.feeToken;
+  }
+
+  /**
+   * Finds a `TransactionRequest` object based on the given requestId or interfaceId.
+   *
+   * @param param - The param object.
+   * @param param.requestId - The requestId to search for.
+   * @param param.interfaceId - The interfaceId to search for.
+   * @param [state] - The optional SnapState object.
+   * @returns A Promise that resolves with the `TransactionRequest` object if found, or null if not found.
+   */
+  async getTransactionRequest(
+    {
+      requestId,
+      interfaceId,
+    }: {
+      requestId?: string;
+      interfaceId?: string;
+    },
+    state?: SnapState,
+  ): Promise<TransactionRequest | null> {
+    const filters: ITransactionRequestFilter[] = [];
+    if (requestId) {
+      filters.push(new IdFilter([requestId]));
+    }
+    if (interfaceId) {
+      filters.push(new InterfaceIdFilter([interfaceId]));
+    }
+    if (filters.length === 0) {
+      throw new StateManagerError(
+        'At least one search condition must be provided',
+      );
+    }
+    return await this.find(filters, state);
+  }
+
+  /**
+   * Upsert a `TransactionRequest` in the state with the given data.
+   *
+   * @param data - The `TransactionRequest` object.
+   * @returns A Promise that resolves when the upsert is complete.
+   */
+  async upsertTransactionRequest(data: TransactionRequest): Promise<void> {
+    try {
+      await this.update(async (state: SnapState) => {
+        const dataInState = await this.getTransactionRequest(
+          {
+            requestId: data.id,
+          },
+          state,
+        );
+
+        if (dataInState === null) {
+          this.getCollection(state)?.push(data);
+        } else {
+          this.updateEntity(dataInState, data);
+        }
+      });
+    } catch (error) {
+      throw new StateManagerError(error.message);
+    }
+  }
+
+  /**
+   * Removes the `TransactionRequest` objects in the state with the given requestId.
+   *
+   * @param requestId - The requestId to search for.
+   * @returns A Promise that resolves when the remove is complete.
+   */
+  async removeTransactionRequest(requestId: string): Promise<void> {
+    try {
+      await this.update(async (state: SnapState) => {
+        const sizeOfTransactionRequests = this.getCollection(state).length;
+
+        state.transactionRequests = this.getCollection(state).filter((req) => {
+          return req.id !== requestId;
+        });
+
+        // Check if the TransactionRequest was removed
+        if (sizeOfTransactionRequests === this.getCollection(state).length) {
+          // If the TransactionRequest does not exist, log a warning instead of throwing an error
+          logger.warn(`TransactionRequest with id ${requestId} does not exist`);
+        }
+      });
+    } catch (error) {
+      throw new StateManagerError(error.message);
+    }
+  }
+}

--- a/packages/starknet-snap/src/state/state-manager.ts
+++ b/packages/starknet-snap/src/state/state-manager.ts
@@ -14,7 +14,12 @@ export abstract class StateManager<Entity> extends SnapStateManager<SnapState> {
           erc20Tokens: [],
           networks: [],
           transactions: [],
+          transactionRequests: [],
         };
+      }
+
+      if (!state.transactionRequests) {
+        state.transactionRequests = [];
       }
 
       if (!state.accContracts) {

--- a/packages/starknet-snap/src/types/snapState.ts
+++ b/packages/starknet-snap/src/types/snapState.ts
@@ -7,6 +7,22 @@ export type SnapState = {
   networks: Network[];
   transactions: Transaction[];
   currentNetwork?: Network;
+  transactionRequests?: TransactionRequest[];
+};
+
+export type TransactionRequest = {
+  id: string;
+  interfaceId: string;
+  type: string;
+  signer: string;
+  chainId: string;
+  maxFee: string;
+  calls: {
+    contractAddress: string;
+    calldata: RawCalldata;
+    entrypoint: string;
+  }[];
+  feeToken: string;
 };
 
 export type AccContract = {


### PR DESCRIPTION
This PR is to add transaction request state manager to prepare the task when using interactive UI for token unit selection when process execute transaction