### PR TITLE
chore: add unit test for `UserInputEventController`

### DIFF
--- a/packages/starknet-snap/src/__tests__/helper.ts
+++ b/packages/starknet-snap/src/__tests__/helper.ts
@@ -83,7 +83,7 @@ export async function generateBip44Entropy(
  * @returns An array of StarknetAccount object.
  */
 export async function generateAccounts(
-  network: constants.StarknetChainId,
+  network: constants.StarknetChainId | string,
   cnt: number = 1,
   cairoVersion = '1',
   mnemonic?: string,
@@ -298,7 +298,7 @@ export function generateTransactionRequests({
   contractAddresses = PRELOADED_TOKENS.map((token) => token.address),
   cnt = 1,
 }: {
-  chainId: constants.StarknetChainId;
+  chainId: constants.StarknetChainId | string;
   address: string;
   contractAddresses?: string[];
   cnt?: number;
@@ -359,12 +359,13 @@ export function generateTransactionRequests({
 
   return requests;
 }
+
 /**
  * Method to generate a mock estimate fee response.
  *
  * @returns An array containing a mock EstimateFee object.
  */
-export function getEstimateFees() {
+export function generateEstimateFeesResponse() {
   return [
     {
       // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/starknet-snap/src/rpcs/estimate-fee.test.ts
+++ b/packages/starknet-snap/src/rpcs/estimate-fee.test.ts
@@ -2,7 +2,7 @@ import type { Invocations } from 'starknet';
 import { constants, TransactionType } from 'starknet';
 import type { Infer } from 'superstruct';
 
-import { getEstimateFees } from '../__tests__/helper';
+import { generateEstimateFeesResponse } from '../__tests__/helper';
 import { FeeTokenUnit } from '../types/snapApi';
 import { STARKNET_SEPOLIA_TESTNET_NETWORK } from '../utils/constants';
 import { InvalidRequestParamsError } from '../utils/exceptions';
@@ -45,7 +45,7 @@ const prepareMockEstimateFee = ({
     details: { version },
   } as unknown as EstimateFeeParams;
 
-  const estimateResults = getEstimateFees();
+  const estimateResults = generateEstimateFeesResponse();
 
   const estimateBulkFeeRespMock = {
     suggestedMaxFee: BigInt(1000000000000000).toString(10),

--- a/packages/starknet-snap/src/rpcs/execute-txn.test.ts
+++ b/packages/starknet-snap/src/rpcs/execute-txn.test.ts
@@ -2,7 +2,7 @@ import type { UniversalDetails, Call, InvokeFunctionResponse } from 'starknet';
 import { constants } from 'starknet';
 
 import callsExamples from '../__tests__/fixture/callsExamples.json'; // Assuming you have a similar fixture
-import { getEstimateFees } from '../__tests__/helper';
+import { generateEstimateFeesResponse } from '../__tests__/helper';
 import type { FeeTokenUnit } from '../types/snapApi';
 import { STARKNET_SEPOLIA_TESTNET_NETWORK } from '../utils/constants';
 import {
@@ -53,7 +53,7 @@ const prepareMockExecuteTxn = async (
     transaction_hash: transactionHash,
   };
 
-  const estimateResults = getEstimateFees();
+  const estimateResults = generateEstimateFeesResponse();
 
   const getEstimatedFeesRepsMock = {
     suggestedMaxFee: generateRandomFee('1000000000000000', '2000000000000000'),

--- a/packages/starknet-snap/src/ui/controllers/user-input-event-controller.test.ts
+++ b/packages/starknet-snap/src/ui/controllers/user-input-event-controller.test.ts
@@ -1,0 +1,551 @@
+import type { InterfaceContext, UserInputEvent } from '@metamask/snaps-sdk';
+import { UserInputEventType } from '@metamask/snaps-sdk';
+import { constants, ec, num as numUtils, TransactionType } from 'starknet';
+
+import type { StarknetAccount } from '../../__tests__/helper';
+import {
+  generateAccounts,
+  generateTransactionRequests,
+  generateEstimateFeesResponse,
+} from '../../__tests__/helper';
+import { NetworkStateManager } from '../../state/network-state-manager';
+import { TransactionRequestStateManager } from '../../state/request-state-manager';
+import { TokenStateManager } from '../../state/token-state-manager';
+import { FeeToken, FeeTokenUnit } from '../../types/snapApi';
+import type { TransactionRequest } from '../../types/snapState';
+import {
+  ETHER_SEPOLIA_TESTNET,
+  STARKNET_TESTNET_NETWORK,
+  STRK_SEPOLIA_TESTNET,
+} from '../../utils/constants';
+import * as keyPairUtils from '../../utils/keyPair';
+import * as StarknetUtils from '../../utils/starknetUtils';
+import * as UiUtils from '../utils';
+import { UserInputEventController } from './user-input-event-controller';
+
+jest.mock('../../utils/logger');
+jest.mock('../../state/token-state-manager');
+
+class MockUserInputEventController extends UserInputEventController {
+  async deriveAccount(index: number) {
+    return super.deriveAccount(index);
+  }
+
+  feeTokenToTransactionVersion(feeToken: FeeToken) {
+    return super.feeTokenToTransactionVersion(feeToken);
+  }
+
+  async getTokenAddress(chainId: string, feeToken: FeeToken) {
+    return super.getTokenAddress(chainId, feeToken);
+  }
+
+  async getNetwork(chainId: string) {
+    return super.getNetwork(chainId);
+  }
+
+  async handleFeeTokenChange() {
+    return super.handleFeeTokenChange();
+  }
+}
+
+describe('UserInputEventController', () => {
+  const createMockController = ({
+    eventId = 'mock-event-id',
+    event = {} as UserInputEvent,
+    context = {} as InterfaceContext,
+  }: {
+    eventId?: string;
+    event?: UserInputEvent;
+    context?: InterfaceContext;
+  }) => {
+    return new MockUserInputEventController(eventId, event, context);
+  };
+
+  const mockKeyPairUtils = ({ addressKey, index }) => {
+    const getAddressKeySpy = jest.spyOn(keyPairUtils, 'getAddressKey');
+    getAddressKeySpy.mockResolvedValue({
+      addressKey,
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      derivationPath: `m / bip32:${9004}' / bip32:${0}' / bip32:${0}' / bip32:${index}'`,
+    });
+    return {
+      getAddressKeySpy,
+    };
+  };
+
+  const mockNetworkStateManager = (network) => {
+    const getNetworkSpy = jest.spyOn(
+      NetworkStateManager.prototype,
+      'getNetwork',
+    );
+    getNetworkSpy.mockResolvedValue(network);
+    return {
+      getNetworkSpy,
+    };
+  };
+
+  const mockTokenStateManager = () => {
+    const getEthTokenSpy = jest.spyOn(
+      TokenStateManager.prototype,
+      'getEthToken',
+    );
+    const getStrkTokenSpy = jest.spyOn(
+      TokenStateManager.prototype,
+      'getStrkToken',
+    );
+    getStrkTokenSpy.mockResolvedValue(STRK_SEPOLIA_TESTNET);
+    getEthTokenSpy.mockResolvedValue(ETHER_SEPOLIA_TESTNET);
+
+    return {
+      getEthTokenSpy,
+      getStrkTokenSpy,
+    };
+  };
+
+  const mockTransactionRequestStateManager = (
+    transactionRequest: TransactionRequest | null,
+  ) => {
+    const getTransactionRequestSpy = jest.spyOn(
+      TransactionRequestStateManager.prototype,
+      'getTransactionRequest',
+    );
+    const upsertTransactionRequestSpy = jest.spyOn(
+      TransactionRequestStateManager.prototype,
+      'upsertTransactionRequest',
+    );
+
+    getTransactionRequestSpy.mockResolvedValue(transactionRequest);
+
+    return {
+      getTransactionRequestSpy,
+      upsertTransactionRequestSpy,
+    };
+  };
+
+  const generateTransactionRequest = async ({
+    chainId,
+    account,
+  }: {
+    chainId: string;
+    account?: StarknetAccount;
+  }) => {
+    const address = account
+      ? account.address
+      : (await generateAccounts(chainId, 1))[0].address;
+
+    const [transactionRequest] = generateTransactionRequests({
+      chainId,
+      address,
+    });
+
+    return transactionRequest;
+  };
+
+  const generateEvent = ({
+    transactionRequest,
+    eventValue = FeeToken.ETH,
+    eventType = UserInputEventType.InputChangeEvent,
+    eventName = 'feeTokenSelector',
+  }) => {
+    return {
+      event: {
+        name: eventName,
+        type: eventType,
+        value: eventValue,
+      },
+      context: {
+        request: transactionRequest,
+      },
+    };
+  };
+
+  describe('deriveAccount', () => {
+    it('returns the privateKey and Public of the derived account', async () => {
+      const { chainId } = STARKNET_TESTNET_NETWORK;
+      const [account] = await generateAccounts(chainId, 1);
+
+      const addressKey = account.privateKey;
+      mockKeyPairUtils({ addressKey, index: 0 });
+
+      const publicKey = ec.starkCurve.getStarkKey(addressKey);
+      const privateKey = numUtils.toHex(addressKey);
+
+      const controller = createMockController({});
+      const result = await controller.deriveAccount(0);
+      expect(result).toStrictEqual({ publicKey, privateKey });
+    });
+  });
+
+  describe('feeTokenToTransactionVersion', () => {
+    it.each([
+      {
+        feeToken: FeeToken.STRK,
+        transactionVersion: constants.TRANSACTION_VERSION.V3,
+      },
+      {
+        feeToken: FeeToken.ETH,
+        transactionVersion: undefined,
+      },
+    ])(
+      'returns transactionVersion: $transactionVersion if fee token is $feeToken',
+      ({ feeToken, transactionVersion }) => {
+        const controller = createMockController({});
+        expect(controller.feeTokenToTransactionVersion(feeToken)).toStrictEqual(
+          transactionVersion,
+        );
+      },
+    );
+  });
+
+  describe('getTokenAddress', () => {
+    it.each([
+      {
+        feeToken: FeeToken.STRK,
+        token: STRK_SEPOLIA_TESTNET,
+      },
+      {
+        feeToken: FeeToken.ETH,
+        token: ETHER_SEPOLIA_TESTNET,
+      },
+      {
+        feeToken: undefined,
+        token: ETHER_SEPOLIA_TESTNET,
+      },
+    ])(
+      'returns the $token.name address for the fee token is $feeToken',
+      async ({ feeToken, token }) => {
+        const { chainId } = STARKNET_TESTNET_NETWORK;
+        mockTokenStateManager();
+
+        const controller = createMockController({});
+        // feeToken could be undefined, so we have to force to cast it as FeeToken
+        const result = await controller.getTokenAddress(
+          chainId,
+          feeToken as unknown as FeeToken,
+        );
+
+        expect(result).toStrictEqual(token.address);
+      },
+    );
+
+    it('throws `Token not found` error if the token is not found', async () => {
+      const { chainId } = STARKNET_TESTNET_NETWORK;
+      const { getEthTokenSpy } = mockTokenStateManager();
+      getEthTokenSpy.mockResolvedValue(null);
+
+      const controller = createMockController({});
+      await expect(
+        controller.getTokenAddress(chainId, FeeToken.ETH),
+      ).rejects.toThrow('Token not found');
+    });
+  });
+
+  describe('getNetwork', () => {
+    it('returns the network with the given chainId', async () => {
+      const network = STARKNET_TESTNET_NETWORK;
+      mockNetworkStateManager(network);
+
+      const controller = createMockController({});
+      const result = await controller.getNetwork(network.chainId);
+
+      expect(result).toStrictEqual(STARKNET_TESTNET_NETWORK);
+    });
+
+    it('throws `Network not found` error if the network is not found', async () => {
+      const network = STARKNET_TESTNET_NETWORK;
+      const { getNetworkSpy } = mockNetworkStateManager(network);
+      getNetworkSpy.mockResolvedValue(null);
+
+      const controller = createMockController({});
+      await expect(controller.getNetwork(network.chainId)).rejects.toThrow(
+        'Network not found',
+      );
+    });
+  });
+
+  describe('handleEvent', () => {
+    const mockHandleFeeTokenChange = () => {
+      const handleFeeTokenChangeSpy = jest.spyOn(
+        MockUserInputEventController.prototype,
+        'handleFeeTokenChange',
+      );
+      handleFeeTokenChangeSpy.mockReturnThis();
+      return {
+        handleFeeTokenChangeSpy,
+      };
+    };
+
+    const prepareHandleEvent = async () => {
+      const { chainId } = STARKNET_TESTNET_NETWORK;
+      const feeToken = FeeToken.STRK;
+      const transactionRequest = await generateTransactionRequest({ chainId });
+      const event = generateEvent({ transactionRequest, eventValue: feeToken });
+      const { getTransactionRequestSpy } =
+        mockTransactionRequestStateManager(transactionRequest);
+      const { handleFeeTokenChangeSpy } = mockHandleFeeTokenChange();
+
+      const controller = createMockController({
+        event: event.event as unknown as UserInputEvent,
+        context: event.context,
+      });
+
+      return {
+        controller,
+        getTransactionRequestSpy,
+        handleFeeTokenChangeSpy,
+        transactionRequest,
+        event,
+      };
+    };
+
+    it('calls `handleFeeTokenChange` if the event key is `FeeTokenSelectorEventKey.FeeTokenChange`', async () => {
+      const {
+        controller,
+        getTransactionRequestSpy,
+        handleFeeTokenChangeSpy,
+        transactionRequest,
+      } = await prepareHandleEvent();
+      await controller.handleEvent();
+
+      expect(getTransactionRequestSpy).toHaveBeenCalledWith({
+        requestId: transactionRequest.id,
+      });
+      expect(handleFeeTokenChangeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws `Transaction request not found` error if the transaction request not found', async () => {
+      const { controller, getTransactionRequestSpy } =
+        await prepareHandleEvent();
+      getTransactionRequestSpy.mockResolvedValue(null);
+
+      await expect(controller.handleEvent()).rejects.toThrow(
+        'Transaction request not found',
+      );
+    });
+
+    it.each([undefined, 'other-event'])('does nothing if the event key is not `FeeTokenSelectorEventKey.FeeTokenChange` -  event name: %s', async (eventName) => {
+      const { handleFeeTokenChangeSpy, event } = await prepareHandleEvent();
+
+      const controller = createMockController({
+        event: {
+          type: event.event.type,
+          value: event.event.value,
+          name: eventName
+        } as unknown as UserInputEvent,
+        context: event.context,
+      });
+      await controller.handleEvent();
+
+      expect(handleFeeTokenChangeSpy).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('handleFeeTokenChange', () => {
+    const mockDeriveAccount = (account: StarknetAccount) => {
+      const deriveAccountSpy = jest.spyOn(
+        MockUserInputEventController.prototype,
+        'deriveAccount',
+      );
+      deriveAccountSpy.mockResolvedValue({
+        publicKey: account.publicKey,
+        privateKey: account.privateKey,
+      });
+      return {
+        deriveAccountSpy,
+      };
+    };
+
+    const mockEstimateFee = (feeToken: FeeToken) => {
+      const getEstimatedFeesSpy = jest.spyOn(StarknetUtils, 'getEstimatedFees');
+      const mockEstimateFeeResponse = generateEstimateFeesResponse();
+      const concatedFee = StarknetUtils.addFeesFromAllTransactions(
+        mockEstimateFeeResponse,
+      );
+
+      const mockGetEstimatedFeesResponse = {
+        suggestedMaxFee: concatedFee.suggestedMaxFee.toString(10),
+        overallFee: concatedFee.overall_fee.toString(10),
+        unit: FeeTokenUnit[feeToken],
+        includeDeploy: true,
+        estimateResults: mockEstimateFeeResponse,
+      };
+
+      getEstimatedFeesSpy.mockResolvedValue(mockGetEstimatedFeesResponse);
+
+      return {
+        getEstimatedFeesSpy,
+        mockGetEstimatedFeesResponse,
+      };
+    };
+
+    const mockUpdateExecuteTxnFlow = () => {
+      const updateExecuteTxnFlowSpy = jest.spyOn(
+        UiUtils,
+        'updateExecuteTxnFlow',
+      );
+      updateExecuteTxnFlowSpy.mockReturnThis();
+      return {
+        updateExecuteTxnFlowSpy,
+      };
+    };
+
+    const mockHasSufficientFundsForFee = (result = true) => {
+      const hasSufficientFundsForFeeSpy = jest.spyOn(
+        UiUtils,
+        'hasSufficientFundsForFee',
+      );
+      hasSufficientFundsForFeeSpy.mockResolvedValue(result);
+
+      return {
+        hasSufficientFundsForFeeSpy,
+      };
+    };
+
+    const prepareHandleFeeTokenChange = async () => {
+      const network = STARKNET_TESTNET_NETWORK;
+      const { chainId } = network;
+      const feeToken = FeeToken.STRK;
+
+      const [account] = await generateAccounts(chainId, 1);
+
+      const transactionRequest = await generateTransactionRequest({
+        chainId,
+        account,
+      });
+      const event = generateEvent({ transactionRequest, eventValue: feeToken });
+
+      mockNetworkStateManager(network);
+      mockDeriveAccount(account);
+      mockTokenStateManager();
+
+      return {
+        ...mockHasSufficientFundsForFee(),
+        ...mockUpdateExecuteTxnFlow(),
+        ...mockEstimateFee(feeToken),
+        ...mockTransactionRequestStateManager(null),
+        event,
+        transactionRequest,
+        account,
+        network,
+        feeToken,
+      };
+    };
+
+    it('updates the transaction request with the updated estimated fee', async () => {
+      const {
+        event,
+        account,
+        network,
+        getEstimatedFeesSpy,
+        hasSufficientFundsForFeeSpy,
+        updateExecuteTxnFlowSpy,
+        mockGetEstimatedFeesResponse,
+        upsertTransactionRequestSpy,
+        transactionRequest,
+        feeToken,
+      } = await prepareHandleFeeTokenChange();
+
+      const controller = createMockController({
+        event: event.event as unknown as UserInputEvent,
+        context: event.context,
+      });
+      await controller.handleFeeTokenChange();
+
+      expect(getEstimatedFeesSpy).toHaveBeenCalledWith(
+        network,
+        transactionRequest.signer,
+        account.privateKey,
+        account.publicKey,
+        [
+          {
+            type: TransactionType.INVOKE,
+            payload: transactionRequest.calls.map((call) => ({
+              calldata: call.calldata,
+              contractAddress: call.contractAddress,
+              entrypoint: call.entrypoint,
+            })),
+          },
+        ],
+        {
+          version: controller.feeTokenToTransactionVersion(feeToken),
+        },
+      );
+      expect(hasSufficientFundsForFeeSpy).toHaveBeenCalledWith({
+        address: account.address,
+        network,
+        calls: transactionRequest.calls,
+        feeTokenAddress: STRK_SEPOLIA_TESTNET.address,
+        suggestedMaxFee: mockGetEstimatedFeesResponse.suggestedMaxFee,
+      });
+      // transactionRequest will be pass by reference, so we can use this to check the updated value
+      expect(transactionRequest.maxFee).toStrictEqual(
+        mockGetEstimatedFeesResponse.suggestedMaxFee,
+      );
+      expect(updateExecuteTxnFlowSpy).toHaveBeenCalledWith(
+        controller.eventId,
+        transactionRequest,
+      );
+      expect(upsertTransactionRequestSpy).toHaveBeenCalledWith(
+        transactionRequest,
+      );
+    });
+
+    it('updates the transaction request with an insufficient funds error message if the account balance is insufficient to cover the fee.', async () => {
+      const {
+        event,
+        hasSufficientFundsForFeeSpy,
+        transactionRequest,
+        updateExecuteTxnFlowSpy,
+        upsertTransactionRequestSpy,
+        feeToken,
+      } = await prepareHandleFeeTokenChange();
+      hasSufficientFundsForFeeSpy.mockResolvedValue(false);
+
+      const controller = createMockController({
+        event: event.event as unknown as UserInputEvent,
+        context: event.context,
+      });
+      await controller.handleFeeTokenChange();
+
+      expect(upsertTransactionRequestSpy).not.toHaveBeenCalled();
+      expect(updateExecuteTxnFlowSpy).toHaveBeenCalledWith(
+        controller.eventId,
+        transactionRequest,
+        {
+          errors: {
+            fees: `Not enough ${feeToken} to pay for fee`,
+          },
+        },
+      );
+    });
+
+    it('updates the transaction request with an general error message if other error was thrown.', async () => {
+      const {
+        event,
+        hasSufficientFundsForFeeSpy,
+        transactionRequest,
+        updateExecuteTxnFlowSpy,
+        upsertTransactionRequestSpy,
+      } = await prepareHandleFeeTokenChange();
+      // Simulate an error thrown to test the error handling
+      hasSufficientFundsForFeeSpy.mockRejectedValue(false);
+
+      const controller = createMockController({
+        event: event.event as unknown as UserInputEvent,
+        context: event.context,
+      });
+      await controller.handleFeeTokenChange();
+
+      expect(upsertTransactionRequestSpy).not.toHaveBeenCalled();
+      expect(updateExecuteTxnFlowSpy).toHaveBeenCalledWith(
+        controller.eventId,
+        transactionRequest,
+        {
+          errors: {
+            fees: `Fail to calculate the fees`,
+          },
+        },
+      );
+    });
+  });
+});

--- a/packages/starknet-snap/src/ui/controllers/user-input-event-controller.ts
+++ b/packages/starknet-snap/src/ui/controllers/user-input-event-controller.ts
@@ -60,7 +60,7 @@ export class UserInputEventController {
 
       if (
         !(await this.reqStateMgr.getTransactionRequest({
-          requestId: request.id,
+          requestId: request?.id,
         }))
       ) {
         throw new Error('Transaction request not found');
@@ -165,6 +165,7 @@ export class UserInputEventController {
         );
 
       if (
+        // TODO: we should create a payment controller class to handle this
         !(await hasSufficientFundsForFee({
           address: signer,
           network,

--- a/packages/starknet-snap/src/utils/starknetUtils.test.ts
+++ b/packages/starknet-snap/src/utils/starknetUtils.test.ts
@@ -1,7 +1,7 @@
 import type { EstimateFee, Invocations } from 'starknet';
 import { constants, TransactionType } from 'starknet';
 
-import { getEstimateFees } from '../__tests__/helper';
+import { generateEstimateFeesResponse } from '../__tests__/helper';
 import { mockAccount, prepareMockAccount } from '../rpcs/__tests__/helper';
 import { FeeTokenUnit } from '../types/snapApi';
 import type { SnapState } from '../types/snapState';
@@ -40,7 +40,7 @@ describe('getEstimatedFees', () => {
     const accountDeployedSpy = jest.spyOn(starknetUtils, 'isAccountDeployed');
     accountDeployedSpy.mockResolvedValue(deployed);
 
-    const estimateResults = getEstimateFees();
+    const estimateResults = generateEstimateFeesResponse();
     const { resourceBounds } = estimateResults[0];
 
     const estimateFeeResp = {


### PR DESCRIPTION
This PR is to add the unit test for `UserInputEventController`

it also includes:
- update naming of the mock function `getEstimateFees` to `generateEstimateFeesResponse`, to be aligned with other mock response method
