### PR TITLE
chore: set get-starknet Snap's version through env variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,7 +111,7 @@ jobs:
 
           echo "Building Get Starknet with GET_STARKNET_PUBLIC_PATH=$GET_STARKNET_PUBLIC_PATH" 
 
-          GET_STARKNET_PUBLIC_PATH=$GET_STARKNET_PUBLIC_PATH yarn workspace @consensys/get-starknet build
+          SNAP_VERSION="${VERSION}" GET_STARKNET_PUBLIC_PATH=$GET_STARKNET_PUBLIC_PATH yarn workspace @consensys/get-starknet build
         env:
           SNAP_ENV: ${{ needs.prepare-deployment.outputs.ENV }}
           VERSION: ${{ needs.prepare-deployment.outputs.VERSION }}

--- a/packages/get-starknet/src/wallet.ts
+++ b/packages/get-starknet/src/wallet.ts
@@ -64,7 +64,7 @@ export class MetaMaskSnapWallet implements StarknetWindowObject {
   /**
    * Initializes a new instance of the MetaMaskSnapWallet class.
    *
-   * The Snap version is now enforced globally via a static `snapVersion` property, 
+   * The Snap version is now enforced globally via a static `snapVersion` property,
    * this ensures consistent versioning across all instances and removes the need for consumers to specify it.
    *
    * @param metamaskProvider - The MetaMask Wallet Provider.

--- a/packages/get-starknet/src/wallet.ts
+++ b/packages/get-starknet/src/wallet.ts
@@ -58,14 +58,27 @@ export class MetaMaskSnapWallet implements StarknetWindowObject {
   // eslint-disable-next-line @typescript-eslint/naming-convention, no-restricted-globals
   static readonly snapId = process.env.SNAP_ID ?? 'npm:@consensys/starknet-snap';
 
-  constructor(metamaskProvider: MetaMaskProvider, snapVersion = '*') {
+  // eslint-disable-next-line @typescript-eslint/naming-convention, no-restricted-globals
+  static readonly snapVersion = process.env.SNAP_VERSION ?? '*';
+
+  /**
+   * Initializes a new instance of the MetaMaskSnapWallet class.
+   *
+   * The Snap version is now enforced globally via a static `snapVersion` property:
+   *
+   * This ensures consistent versioning across all instances and removes the need for consumers to specify it.
+   * However, the `_snapVersion` parameter remains to maintain compatibility with existing usage.
+   * @param metamaskProvider
+   * @param _snapVersion
+   */
+  constructor(metamaskProvider: MetaMaskProvider, _snapVersion = '*') {
     this.id = 'metamask';
     this.name = 'Metamask';
     this.version = 'v2.0.0';
     this.icon = WalletIconMetaData;
     this.lock = new Mutex();
     this.metamaskProvider = metamaskProvider;
-    this.snap = new MetaMaskSnap(MetaMaskSnapWallet.snapId, snapVersion, this.metamaskProvider);
+    this.snap = new MetaMaskSnap(MetaMaskSnapWallet.snapId, MetaMaskSnapWallet.snapVersion, this.metamaskProvider);
     this.isConnected = false;
 
     this.#rpcHandlers = new Map<string, IStarknetWalletRpc>([

--- a/packages/get-starknet/src/wallet.ts
+++ b/packages/get-starknet/src/wallet.ts
@@ -64,12 +64,11 @@ export class MetaMaskSnapWallet implements StarknetWindowObject {
   /**
    * Initializes a new instance of the MetaMaskSnapWallet class.
    *
-   * The Snap version is now enforced globally via a static `snapVersion` property:
+   * The Snap version is now enforced globally via a static `snapVersion` property, 
+   * this ensures consistent versioning across all instances and removes the need for consumers to specify it.
    *
-   * This ensures consistent versioning across all instances and removes the need for consumers to specify it.
-   * However, the `_snapVersion` parameter remains to maintain compatibility with existing usage.
-   * @param metamaskProvider
-   * @param _snapVersion
+   * @param metamaskProvider - The MetaMask Wallet Provider.
+   * @param _snapVersion - The `_snapVersion` parameter remains to maintain compatibility with existing usage.
    */
   constructor(metamaskProvider: MetaMaskProvider, _snapVersion = '*') {
     this.id = 'metamask';

--- a/packages/get-starknet/webpack.config.build.js
+++ b/packages/get-starknet/webpack.config.build.js
@@ -23,6 +23,7 @@ module.exports = (env) =>
     plugins: [
       new webpack.DefinePlugin({
         'process.env.SNAP_ID': JSON.stringify(process.env.SNAP_ID || 'npm:@consensys/starknet-snap'),
+        'process.env.SNAP_VERSION': JSON.stringify(process.env.SNAP_VERSION || '*'),
       }),
       new ModuleFederationPlugin({
         name: 'MetaMaskStarknetSnapWallet',


### PR DESCRIPTION
Version enforcement is now handled globally using `process.env.SNAP_VERSION`. 

Retained the `_snapVersion` parameter in the MetaMaskSnapWallet constructor for backward compatibility, as some existing consumers explicitly pass it. 