### PR TITLE
chore: Add Cache-Busting Query Parameters to Webpack Output Files

### DIFF
--- a/packages/get-starknet/webpack.config.build.js
+++ b/packages/get-starknet/webpack.config.build.js
@@ -18,6 +18,8 @@ module.exports = (env) =>
   merge(common, {
     mode: 'production',
     output: {
+      filename: '[name].[contenthash].js?v=[fullhash]', // Appends a cache-busting query string
+      chunkFilename: '[name].[contenthash].js?v=[fullhash]', // For dynamically imported chunks
       publicPath: process.env.GET_STARKNET_PUBLIC_PATH || 'https://snaps.consensys.io/starknet/get-starknet/v1/',
     },
     plugins: [


### PR DESCRIPTION
## PR Description

This PR introduces cache-busting query parameters to Webpack’s filename and chunkFilename configurations. This change ensures that both entry point files and dynamically imported chunks avoid issues caused by DNS or browser caching, particularly in production environments. The addition of query parameters (?v=[fullhash]) helps load the latest versions of assets, even if stale files are cached.