### PR TITLE
chore: replace secrets ` ALCHEMY_API_KEY` to `DIN_API_KEY` in CICD pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,7 +116,7 @@ jobs:
           SNAP_ENV: ${{ needs.prepare-deployment.outputs.ENV }}
           VERSION: ${{ needs.prepare-deployment.outputs.VERSION }}
           VOYAGER_API_KEY: ${{ secrets.VOYAGER_API_KEY }}
-          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
+          DIN_API_KEY: ${{ secrets.DIN_API_KEY }}
           GET_STARKNET_PUBLIC_PATH: ${{ needs.prepare-deployment.outputs.GET_STARKNET_PUBLIC_PATH }}
           LOG_LEVEL: ${{ needs.prepare-deployment.outputs.LOG_LEVEL }}
       - name: Cache Build

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -73,7 +73,7 @@ jobs:
           VERSION: ${{ needs.prepare-deployment.outputs.VERSION }}
           LOG_LEVEL: ${{ needs.prepare-deployment.outputs.LOG_LEVEL }}
           VOYAGER_API_KEY: ${{ secrets.VOYAGER_API_KEY }}
-          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
+          DIN_API_KEY: ${{ secrets.DIN_API_KEY }}
       - name: Cache Build
         uses: actions/cache@v3
         id: cache


### PR DESCRIPTION
This PR to replace VOYAGER API KEY secrets to DIN API KEY secrets in the CICD pipeline