### PR TITLE
fix: mute wallet ui error message on rejected request

### DIFF
--- a/packages/wallet-ui/src/services/useStarkNetSnap.ts
+++ b/packages/wallet-ui/src/services/useStarkNetSnap.ts
@@ -324,8 +324,9 @@ export const useStarkNetSnap = () => {
         },
       });
     } catch (err) {
-      //eslint-disable-next-line no-console
-      console.error(err);
+      if (!isUserDenyError(err)) {
+        throw err;
+      }
     }
   }
 

--- a/packages/wallet-ui/src/services/useStarkNetSnap.ts
+++ b/packages/wallet-ui/src/services/useStarkNetSnap.ts
@@ -40,7 +40,6 @@ import {
   TransactionType,
   UniversalDetails,
 } from 'starknet';
-import { DENY_ERROR_CODE } from 'utils/constants';
 
 export const useStarkNetSnap = () => {
   const dispatch = useAppDispatch();

--- a/packages/wallet-ui/src/services/useStarkNetSnap.ts
+++ b/packages/wallet-ui/src/services/useStarkNetSnap.ts
@@ -21,6 +21,7 @@ import {
   retry,
   isGTEMinVersion,
   getTokenBalanceWithDetails,
+  isUserDenyError,
 } from '../utils/utils';
 import { setWalletConnection } from '../slices/walletSlice';
 import { Network, VoyagerTransactionType } from '../types';
@@ -39,6 +40,7 @@ import {
   TransactionType,
   UniversalDetails,
 } from 'starknet';
+import { DENY_ERROR_CODE } from 'utils/constants';
 
 export const useStarkNetSnap = () => {
   const dispatch = useAppDispatch();
@@ -409,13 +411,14 @@ export const useStarkNetSnap = () => {
           },
         },
       });
-      dispatch(disableLoading());
+
       return response;
     } catch (err) {
+      if (!isUserDenyError(err)) {
+        throw err;
+      }
+    } finally {
       dispatch(disableLoading());
-      //eslint-disable-next-line no-console
-      console.error(err);
-      throw err;
     }
   }
 
@@ -494,13 +497,14 @@ export const useStarkNetSnap = () => {
           },
         },
       });
-      dispatch(disableLoading());
       return response;
     } catch (err) {
+      if (!isUserDenyError(err)) {
+        throw err;
+      }
+      return false;
+    } finally {
       dispatch(disableLoading());
-      //eslint-disable-next-line no-console
-      console.error(err);
-      throw err;
     }
   };
 
@@ -526,13 +530,15 @@ export const useStarkNetSnap = () => {
           },
         },
       });
-      dispatch(disableLoading());
+
       return response;
     } catch (err) {
+      if (!isUserDenyError(err)) {
+        throw err;
+      }
+      return false;
+    } finally {
       dispatch(disableLoading());
-      //eslint-disable-next-line no-console
-      console.error(err);
-      throw err;
     }
   };
 
@@ -618,7 +624,7 @@ export const useStarkNetSnap = () => {
   ) => {
     dispatch(enableLoadingWithMessage('Adding Token...'));
     try {
-      const token = await provider.request({
+      await provider.request({
         method: 'wallet_invokeSnap',
         params: {
           snapId,
@@ -635,28 +641,36 @@ export const useStarkNetSnap = () => {
           },
         },
       });
-      if (token) {
-        const tokenBalance = await getTokenBalance(
-          tokenAddress,
-          accountAddress,
-          chainId,
-        );
-        const usdPrice = await getAssetPriceUSD(token);
-        const tokenWithBalance: Erc20TokenBalance = getTokenBalanceWithDetails(
-          tokenBalance,
-          token,
-          usdPrice,
-        );
-        dispatch(upsertErc20TokenBalance(tokenWithBalance));
-        dispatch(disableLoading());
-        return tokenWithBalance;
-      } else {
-        dispatch(disableLoading());
-        return null;
-      }
+
+      const token = {
+        address: tokenAddress,
+        name: tokenName,
+        symbol: tokenSymbol,
+        decimals: tokenDecimals,
+        chainId,
+      };
+
+      const tokenBalance = await getTokenBalance(
+        tokenAddress,
+        accountAddress,
+        chainId,
+      );
+
+      const usdPrice = await getAssetPriceUSD(token);
+      const tokenWithBalance: Erc20TokenBalance = getTokenBalanceWithDetails(
+        tokenBalance,
+        token,
+        usdPrice,
+      );
+      dispatch(upsertErc20TokenBalance(tokenWithBalance));
+      return tokenWithBalance;
     } catch (err) {
+      if (!isUserDenyError(err)) {
+        throw err;
+      }
+      return null;
+    } finally {
       dispatch(disableLoading());
-      throw err;
     }
   };
 

--- a/packages/wallet-ui/src/utils/constants.ts
+++ b/packages/wallet-ui/src/utils/constants.ts
@@ -66,3 +66,5 @@ export const DUMMY_ADDRESS = '0xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
 export const DEFAULT_FEE_TOKEN = FeeToken.ETH;
 
 export const MIN_METAMASK_VERSION = '12.5.0';
+
+export const DENY_ERROR_CODE = 113;

--- a/packages/wallet-ui/src/utils/utils.ts
+++ b/packages/wallet-ui/src/utils/utils.ts
@@ -7,6 +7,7 @@ import {
   SEPOLIA_CHAINID,
   TIMEOUT_DURATION,
   MIN_ACC_CONTRACT_VERSION,
+  DENY_ERROR_CODE,
 } from './constants';
 import { Erc20Token, Erc20TokenBalance, TokenBalance } from 'types';
 import { constants } from 'starknet';
@@ -247,4 +248,11 @@ export const isValidStarkName = (starkName: string): boolean => {
   return /^(?:[a-z0-9-]{1,48}(?:[a-z0-9-]{1,48}[a-z0-9-])?\.)*[a-z0-9-]{1,48}\.stark$/.test(
     starkName,
   );
+};
+
+export const isUserDenyError = (error: any): Boolean => {
+  if (error?.data?.walletRpcError?.code) {
+    return error?.data?.walletRpcError?.code === DENY_ERROR_CODE;
+  }
+  return false;
 };


### PR DESCRIPTION
Mute the error message if user denied the operation of : 

- starkNet_executeTxn
- starkNet_addErc20Token
- starkNet_upgradeAccContract
- starkNet_createAccountLegacy
- starkNet_displayPrivateKey

BEGIN_COMMIT_OVERRIDE
fix: Mute Wallet UI error message when user deny a request (#460)
END_COMMIT_OVERRIDE