### PR TITLE
chore: refine SNAP for StarkScan migration

### DIFF
--- a/packages/starknet-snap/src/__tests__/helper.ts
+++ b/packages/starknet-snap/src/__tests__/helper.ts
@@ -26,6 +26,7 @@ import type {
 } from '../chain/data-client/starkscan.type';
 import { FeeToken } from '../types/snapApi';
 import {
+  ContractFuncName,
   TransactionDataVersion,
   type AccContract,
   type Transaction,
@@ -268,7 +269,7 @@ export function generateTransactions({
     const txnType = getRandomData(_txnTypes);
     const contractFuncName =
       txnType == TransactionType.INVOKE
-        ? getRandomData(['transfer', 'upgrade'])
+        ? getRandomData(Object.values(ContractFuncName))
         : '';
 
     transactions.push(
@@ -466,7 +467,7 @@ export function generateTransactionRequests({
             to: address,
             amount: '1',
           }),
-          entrypoint: 'transfer',
+          entrypoint: ContractFuncName.Transfer,
         },
       ],
       includeDeploy: false,

--- a/packages/starknet-snap/src/state/transaction-state-manager.test.ts
+++ b/packages/starknet-snap/src/state/transaction-state-manager.test.ts
@@ -7,7 +7,7 @@ import {
 
 import { generateTransactions } from '../__tests__/helper';
 import type { V2Transaction } from '../types/snapState';
-import { TransactionDataVersion } from '../types/snapState';
+import { ContractFuncName, TransactionDataVersion } from '../types/snapState';
 import { PRELOADED_TOKENS } from '../utils/constants';
 import { mockAcccounts, mockState } from './__tests__/helper';
 import { StateManagerError } from './state-manager';
@@ -147,7 +147,7 @@ describe('TransactionStateManager', () => {
         chainId: legacyData.chainId,
         senderAddress: legacyData.senderAddress,
         contractAddress: legacyData.contractAddress,
-        contractFuncName: 'transfer',
+        contractFuncName: ContractFuncName.Transfer,
         contractCallData: ['0x123', '0x456'],
         executionStatus: legacyData.executionStatus,
         finalityStatus: legacyData.finalityStatus,

--- a/packages/starknet-snap/src/ui/utils.test.tsx
+++ b/packages/starknet-snap/src/ui/utils.test.tsx
@@ -1,7 +1,11 @@
 import type { constants } from 'starknet';
 
 import { generateAccounts } from '../__tests__/helper';
-import type { Erc20Token, FormattedCallData } from '../types/snapState';
+import {
+  ContractFuncName,
+  type Erc20Token,
+  type FormattedCallData,
+} from '../types/snapState';
 import {
   DEFAULT_DECIMAL_PLACES,
   BlockIdentifierEnum,
@@ -138,7 +142,7 @@ describe('hasSufficientFundsForFee', () => {
     const calls: FormattedCallData[] = [];
     for (let i = 0; i < cnt; i++) {
       calls.push({
-        entrypoint: 'transfer',
+        entrypoint: ContractFuncName.Transfer,
         contractAddress: token.address,
         tokenTransferData: {
           amount,

--- a/packages/starknet-snap/src/upgradeAccContract.ts
+++ b/packages/starknet-snap/src/upgradeAccContract.ts
@@ -5,6 +5,7 @@ import type {
   ApiParamsWithKeyDeriver,
   UpgradeTransactionRequestParams,
 } from './types/snapApi';
+import { ContractFuncName } from './types/snapState';
 import { ACCOUNT_CLASS_HASH, CAIRO_VERSION_LEGACY } from './utils/constants';
 import { logger } from './utils/logger';
 import { toJson } from './utils/serializer';
@@ -66,7 +67,7 @@ export async function upgradeAccContract(params: ApiParamsWithKeyDeriver) {
       contractAddress,
     );
 
-    const method = 'upgrade';
+    const method = ContractFuncName.Upgrade;
 
     const calldata = CallData.compile({
       implementation: ACCOUNT_CLASS_HASH,

--- a/packages/starknet-snap/src/utils/formatter-utils.test.ts
+++ b/packages/starknet-snap/src/utils/formatter-utils.test.ts
@@ -3,7 +3,7 @@ import { constants } from 'starknet';
 import { singleCall } from '../__tests__/fixture/callsExamples.json';
 import { generateAccounts } from '../__tests__/helper';
 import { TokenStateManager } from '../state/token-state-manager';
-import type { Erc20Token } from '../types/snapState';
+import { ContractFuncName, type Erc20Token } from '../types/snapState';
 import { ETHER_SEPOLIA_TESTNET } from './constants';
 import {
   callToTransactionReqCall,
@@ -129,7 +129,7 @@ describe('callToTransactionReqCall', () => {
     const { senderAddress, recipientAddress } = await getSenderAndRecipient();
     const call = {
       ...singleCall.calls,
-      entrypoint: 'transfer',
+      entrypoint: ContractFuncName.Transfer,
       calldata: [recipientAddress, '1000'],
     };
 
@@ -177,7 +177,7 @@ describe('callToTransactionReqCall', () => {
     const transferAmt = '1000';
     const call = {
       ...singleCall.calls,
-      entrypoint: 'transfer',
+      entrypoint: ContractFuncName.Transfer,
       calldata: [recipientAddress, transferAmt],
     };
     const token = ETHER_SEPOLIA_TESTNET;

--- a/packages/starknet-snap/src/utils/formatter-utils.ts
+++ b/packages/starknet-snap/src/utils/formatter-utils.ts
@@ -2,7 +2,7 @@ import type { Call } from 'starknet';
 import { assert } from 'superstruct';
 
 import type { TokenStateManager } from '../state/token-state-manager';
-import type { FormattedCallData } from '../types/snapState';
+import { ContractFuncName, type FormattedCallData } from '../types/snapState';
 import { logger } from './logger';
 import { AddressStruct, NumberStringStruct } from './superstruct';
 
@@ -61,7 +61,7 @@ export const callToTransactionReqCall = async (
   };
 
   // Check if the entrypoint is 'transfer' and the populate transfer fields
-  if (entrypoint === 'transfer' && calldata) {
+  if (entrypoint === ContractFuncName.Transfer && calldata) {
     try {
       const token = await tokenStateManager.getToken({
         address: contractAddress,

--- a/packages/starknet-snap/src/utils/snapUtils.ts
+++ b/packages/starknet-snap/src/utils/snapUtils.ts
@@ -16,7 +16,7 @@ import type {
 
 import { Config } from '../config';
 import { FeeToken, type AddNetworkRequestParams } from '../types/snapApi';
-import { TransactionStatus } from '../types/snapState';
+import { ContractFuncName, TransactionStatus } from '../types/snapState';
 import type {
   Network,
   Erc20Token,
@@ -312,7 +312,7 @@ export function getSendTxnText(
   );
   addDialogTxt(components, 'Network', network.name);
 
-  if (token && contractFuncName === 'transfer') {
+  if (token && contractFuncName === ContractFuncName.Transfer) {
     try {
       let amount = '';
       if ([3, 6, 9, 12, 15, 18].includes(token.decimals)) {

--- a/packages/starknet-snap/src/utils/starknetUtils.ts
+++ b/packages/starknet-snap/src/utils/starknetUtils.ts
@@ -51,7 +51,7 @@ import type {
   SnapState,
   Transaction,
 } from '../types/snapState';
-import { TransactionType } from '../types/snapState';
+import { ContractFuncName, TransactionType } from '../types/snapState';
 import type {
   DeployAccountPayload,
   TransactionResponse,
@@ -596,10 +596,10 @@ export const getMassagedTransactions = async (
       let txContractFuncName = '';
       switch (txFuncSelector) {
         case bigIntTransferSelectorHex:
-          txContractFuncName = 'transfer';
+          txContractFuncName = ContractFuncName.Transfer;
           break;
         case bigIntUpgradeSelectorHex:
-          txContractFuncName = 'upgrade';
+          txContractFuncName = ContractFuncName.Upgrade;
           break;
         default:
           txContractFuncName = '';

--- a/packages/starknet-snap/src/utils/superstruct.test.ts
+++ b/packages/starknet-snap/src/utils/superstruct.test.ts
@@ -5,6 +5,7 @@ import contractExample from '../__tests__/fixture/contract-example.json';
 import transactionExample from '../__tests__/fixture/transactionExample.json';
 import typedDataExample from '../__tests__/fixture/typedDataExample.json';
 import { generateTransactions } from '../__tests__/helper';
+import { ContractFuncName } from '../types/snapState';
 import {
   ACCOUNT_CLASS_HASH,
   CAIRO_VERSION,
@@ -394,7 +395,7 @@ describe('InvocationsStruct', () => {
       type: TransactionType.INVOKE,
       payload: {
         contractAddress: ETHER_SEPOLIA_TESTNET.address,
-        entrypoint: 'transfer',
+        entrypoint: ContractFuncName.Transfer,
       },
     },
     {
@@ -426,7 +427,7 @@ describe('InvocationsStruct', () => {
     {
       type: TransactionType.INVOKE,
       payload: {
-        entrypoint: 'transfer',
+        entrypoint: ContractFuncName.Transfer,
       },
     },
     {
@@ -502,7 +503,7 @@ describe('InvocationsStruct', () => {
       payload: [
         {
           contractAddress: ETHER_SEPOLIA_TESTNET.address,
-          entrypoint: 'transfer',
+          entrypoint: ContractFuncName.Transfer,
         },
       ],
     },


### PR DESCRIPTION
This PR is to refine the SNAP for StarkScan migration

it includes:
- update hardcode value `transfer` and `upgrade` to enum ContractFuncName ,