### PR TITLE
feat: add account service factory

### DIFF
--- a/packages/starknet-snap/src/utils/factory.test.ts
+++ b/packages/starknet-snap/src/utils/factory.test.ts
@@ -1,8 +1,13 @@
 import { StarkScanClient } from '../chain/data-client/starkscan';
 import { TransactionService } from '../chain/transaction-service';
 import { Config, DataClient } from '../config';
+import { AccountService } from '../wallet/account';
 import { STARKNET_SEPOLIA_TESTNET_NETWORK } from './constants';
-import { createStarkScanClient, createTransactionService } from './factory';
+import {
+  createAccountService,
+  createStarkScanClient,
+  createTransactionService,
+} from './factory';
 
 const config = Config.dataClient[DataClient.STARKSCAN];
 
@@ -29,5 +34,13 @@ describe('createTransactionService', () => {
       createTransactionService(STARKNET_SEPOLIA_TESTNET_NETWORK),
     ).toBeInstanceOf(TransactionService);
     config.apiKey = undefined;
+  });
+});
+
+describe('createAccountService', () => {
+  it('creates a Account service', () => {
+    expect(
+      createAccountService(STARKNET_SEPOLIA_TESTNET_NETWORK),
+    ).toBeInstanceOf(AccountService);
   });
 });

--- a/packages/starknet-snap/src/utils/factory.ts
+++ b/packages/starknet-snap/src/utils/factory.ts
@@ -2,8 +2,10 @@ import type { IDataClient } from '../chain/data-client';
 import { StarkScanClient } from '../chain/data-client/starkscan';
 import { TransactionService } from '../chain/transaction-service';
 import { Config, DataClient } from '../config';
+import type { AccountStateManager } from '../state/account-state-manager';
 import type { TransactionStateManager } from '../state/transaction-state-manager';
 import type { Network } from '../types/snapState';
+import { AccountService } from '../wallet/account';
 
 /**
  * Create a StarkScan client.
@@ -42,5 +44,22 @@ export function createTransactionService(
     dataClient,
     network,
     txnStateMgr,
+  });
+}
+
+/**
+ * Create a AccountService object.
+ *
+ * @param network - The network.
+ * @param [accountStateMgr] - The `AccountStateManager`.
+ * @returns A AccountService object.
+ */
+export function createAccountService(
+  network: Network,
+  accountStateMgr?: AccountStateManager,
+): AccountService {
+  return new AccountService({
+    network,
+    accountStateMgr,
   });
 }

--- a/packages/starknet-snap/src/wallet/account/contract.ts
+++ b/packages/starknet-snap/src/wallet/account/contract.ts
@@ -49,6 +49,20 @@ export abstract class CairoAccountContract {
     return this.getCallData();
   }
 
+  get deployPaylod(): {
+    classHash: string;
+    contractAddress: string;
+    constructorCalldata: Calldata;
+    addressSalt: string;
+  } {
+    return {
+      classHash: this.classhash,
+      contractAddress: this.address,
+      constructorCalldata: this.callData,
+      addressSalt: this.publicKey,
+    };
+  }
+
   get address(): string {
     if (this._address === undefined) {
       this._address = this.calculateAddress();

--- a/packages/starknet-snap/src/wallet/account/contract.ts
+++ b/packages/starknet-snap/src/wallet/account/contract.ts
@@ -49,7 +49,7 @@ export abstract class CairoAccountContract {
     return this.getCallData();
   }
 
-  get deployPaylod(): {
+  get deployPayload(): {
     classHash: string;
     contractAddress: string;
     constructorCalldata: Calldata;

--- a/packages/starknet-snap/src/wallet/account/index.ts
+++ b/packages/starknet-snap/src/wallet/account/index.ts
@@ -6,3 +6,4 @@ export * from './type';
 export * from './contract';
 export * from './discovery';
 export * from './service';
+export * from './account';

--- a/packages/starknet-snap/src/wallet/account/service.test.ts
+++ b/packages/starknet-snap/src/wallet/account/service.test.ts
@@ -5,6 +5,7 @@ import { generateAccounts, generateKeyDeriver } from '../../__tests__/helper';
 import { AccountStateManager } from '../../state/account-state-manager';
 import { STARKNET_SEPOLIA_TESTNET_NETWORK } from '../../utils/constants';
 import { AccountNotFoundError } from '../../utils/exceptions';
+import { createAccountService } from '../../utils/factory';
 import * as snapUtils from '../../utils/snap';
 import {
   createAccountObject,
@@ -19,7 +20,7 @@ describe('AccountService', () => {
   const network = STARKNET_SEPOLIA_TESTNET_NETWORK;
 
   describe('deriveAccountByIndex', () => {
-    const prepareDeriveAccountByIndex = async (hdIndex) => {
+    const setupDeriveAccountByIndexTest = async (hdIndex) => {
       const mnemonicString = generateMnemonic();
 
       const [account] = await generateAccounts(
@@ -72,9 +73,9 @@ describe('AccountService', () => {
         upsertAccountSpy,
         cairo1Contract,
         account,
-      } = await prepareDeriveAccountByIndex(hdIndex);
+      } = await setupDeriveAccountByIndexTest(hdIndex);
 
-      const service = new AccountService(network, new AccountStateManager());
+      const service = createAccountService(network);
       const accountObject = await service.deriveAccountByIndex();
 
       expect(getNextIndexSpy).toHaveBeenCalled();
@@ -100,9 +101,9 @@ describe('AccountService', () => {
         cairo1Contract,
         account,
         upsertAccountSpy,
-      } = await prepareDeriveAccountByIndex(hdIndex);
+      } = await setupDeriveAccountByIndexTest(hdIndex);
 
-      const service = new AccountService(network, new AccountStateManager());
+      const service = createAccountService(network);
       const accountObject = await service.deriveAccountByIndex(hdIndex);
 
       expect(getNextIndexSpy).not.toHaveBeenCalled();
@@ -122,7 +123,7 @@ describe('AccountService', () => {
   });
 
   describe('deriveAccountFromAddress', () => {
-    const prepareDeriveAccountByAddress = async () => {
+    const setupDeriveAccountByAddressTest = async () => {
       const getAccountSpy = jest.spyOn(
         AccountStateManager.prototype,
         'getAccount',
@@ -146,9 +147,9 @@ describe('AccountService', () => {
 
     it('derive an account by address', async () => {
       const { getAccountSpy, deriveAccountByIndexSpy, accountObj } =
-        await prepareDeriveAccountByAddress();
+        await setupDeriveAccountByAddressTest();
 
-      const service = new AccountService(network, new AccountStateManager());
+      const service = createAccountService(network);
       const accountObject = await service.deriveAccountByAddress(
         accountObj.address,
       );
@@ -160,11 +161,11 @@ describe('AccountService', () => {
 
     it('throws `AccountNotFoundError` if the given address is not found', async () => {
       const { getAccountSpy, accountObj } =
-        await prepareDeriveAccountByAddress();
+        await setupDeriveAccountByAddressTest();
 
       getAccountSpy.mockResolvedValue(null);
 
-      const service = new AccountService(network, new AccountStateManager());
+      const service = createAccountService(network);
 
       await expect(
         service.deriveAccountByAddress(accountObj.address),
@@ -181,7 +182,7 @@ describe('AccountService', () => {
       );
       removeAccountSpy.mockResolvedValue();
 
-      const service = new AccountService(network, new AccountStateManager());
+      const service = createAccountService(network);
       await service.removeAccount(accountObj);
 
       expect(removeAccountSpy).toHaveBeenCalledWith({

--- a/packages/starknet-snap/src/wallet/account/service.ts
+++ b/packages/starknet-snap/src/wallet/account/service.ts
@@ -1,4 +1,4 @@
-import type { AccountStateManager } from '../../state/account-state-manager';
+import { AccountStateManager } from '../../state/account-state-manager';
 import type { Network } from '../../types/snapState';
 import { getBip44Deriver } from '../../utils';
 import { AccountNotFoundError } from '../../utils/exceptions';
@@ -13,7 +13,13 @@ export class AccountService {
 
   protected accountContractDiscoveryService: AccountContractDiscovery;
 
-  constructor(network: Network, accountStateMgr: AccountStateManager) {
+  constructor({
+    network,
+    accountStateMgr = new AccountStateManager(),
+  }: {
+    network: Network;
+    accountStateMgr?: AccountStateManager;
+  }) {
     this.network = network;
     this.accountStateMgr = accountStateMgr;
     this.accountContractDiscoveryService = new AccountContractDiscovery(


### PR DESCRIPTION
This PR is to add a factory method to create `AccountService` 

This PR also include a change on how to construct a  `AccountService`  and add  get deploy payload method in `CairoAccountContract`