### PR TITLE
chore: set new account to current current in RPC `starkNet_addAccount`

### DIFF
--- a/packages/starknet-snap/src/rpcs/add-account.test.ts
+++ b/packages/starknet-snap/src/rpcs/add-account.test.ts
@@ -1,7 +1,9 @@
-import type { constants } from 'starknet';
+import { Logger } from 'ethers/lib/utils';
+import { Account, type constants } from 'starknet';
 
 import { STARKNET_SEPOLIA_TESTNET_NETWORK } from '../utils/constants';
 import { InvalidRequestParamsError } from '../utils/exceptions';
+import { AccountService } from '../wallet/account';
 import { setupAccountController } from './__tests__/helper';
 import { addAccount } from './add-account';
 import type { AddAccountParams } from './add-account';
@@ -19,25 +21,46 @@ describe('AddAccountRpc', () => {
       {},
     );
 
+    const switchAccountSpy = jest.spyOn(
+      AccountService.prototype,
+      'switchAccount',
+    );
+    switchAccountSpy.mockReturnThis();
+
     const request = {
       chainId: network.chainId as unknown as constants.StarknetChainId,
     };
 
     return {
       deriveAccountByIndexSpy,
+      switchAccountSpy,
       account,
       request,
     };
   };
 
   it('add a `Account`', async () => {
-    const { account, request, deriveAccountByIndexSpy } =
+    const { account, request, deriveAccountByIndexSpy, switchAccountSpy } =
       await setupAddAccountTest();
 
     const result = await addAccount.execute(request);
 
     expect(result).toStrictEqual(await account.serialize());
     expect(deriveAccountByIndexSpy).toHaveBeenCalled();
+    expect(switchAccountSpy).toHaveBeenCalledWith(network.chainId, account);
+  });
+
+  it('does not throw an error if switch account failed', async () => {
+    const { account, request, switchAccountSpy } = await setupAddAccountTest();
+    switchAccountSpy.mockRejectedValueOnce(
+      new Error('Failed to switch account'),
+    );
+    const loggerSpy = jest.spyOn(Logger.prototype, 'warn');
+
+    const result = await addAccount.execute(request);
+
+    expect(result).toStrictEqual(await account.serialize());
+    expect(loggerSpy).toHaveBeenCalled();
   });
 
   it('throws `InvalidRequestParamsError` when request parameter is not correct', async () => {

--- a/packages/starknet-snap/src/rpcs/add-account.test.ts
+++ b/packages/starknet-snap/src/rpcs/add-account.test.ts
@@ -1,5 +1,5 @@
 import { Logger } from 'ethers/lib/utils';
-import { Account, type constants } from 'starknet';
+import { type constants } from 'starknet';
 
 import { STARKNET_SEPOLIA_TESTNET_NETWORK } from '../utils/constants';
 import { InvalidRequestParamsError } from '../utils/exceptions';

--- a/packages/starknet-snap/src/rpcs/add-account.ts
+++ b/packages/starknet-snap/src/rpcs/add-account.ts
@@ -1,3 +1,4 @@
+import { logger } from 'ethers';
 import { type Infer } from 'superstruct';
 
 import { BaseRequestStruct, AccountStruct } from '../utils';
@@ -38,7 +39,15 @@ export class AddAccountRpc extends ChainRpcController<
 
     const account = await accountService.deriveAccountByIndex();
 
-    // TODO: after derive an account, we should store it as a active account.
+    try {
+      // after derive an account, the current account will switch to the new account.
+      // however if the account is failed to switch,
+      // it is better not to throw an error to maintain the user experience.
+      await accountService.switchAccount(this.network.chainId, account);
+    } catch (error) {
+      logger.warn(`Failed to switch account: ${error.message}`);
+    }
+
     return account.serialize() as unknown as AddAccountResponse;
   }
 }

--- a/packages/starknet-snap/src/rpcs/add-account.ts
+++ b/packages/starknet-snap/src/rpcs/add-account.ts
@@ -45,6 +45,7 @@ export class AddAccountRpc extends ChainRpcController<
       // it is better not to throw an error to maintain the user experience.
       await accountService.switchAccount(this.network.chainId, account);
     } catch (error) {
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       logger.warn(`Failed to switch account: ${error.message}`);
     }
 


### PR DESCRIPTION
This PR is to set new account to current current in RPC `starkNet_addAccount`