### PR TITLE
feat: update RPC `starkNet_getCurrentAccount` to return the account from state

### DIFF
--- a/packages/starknet-snap/src/rpcs/get-current-account.test.ts
+++ b/packages/starknet-snap/src/rpcs/get-current-account.test.ts
@@ -31,6 +31,7 @@ describe('GetCurrentAccountRpc', () => {
     };
 
     return {
+      getCurrentAccountSpy,
       deriveAccountByIndexSpy,
       account,
       request,
@@ -42,6 +43,33 @@ describe('GetCurrentAccountRpc', () => {
       await setupGetCurrentAccountTest();
 
     const result = await getCurrentAccount.execute(request);
+
+    expect(result).toStrictEqual(await account.serialize());
+    expect(deriveAccountByIndexSpy).toHaveBeenCalled();
+  });
+
+  it('returns the selected `Account` from state if the param `fromState` was given', async () => {
+    const { account, request, deriveAccountByIndexSpy } =
+      await setupGetCurrentAccountTest();
+
+    const result = await getCurrentAccount.execute({
+      ...request,
+      fromState: true,
+    });
+
+    expect(result).toStrictEqual(await account.serialize());
+    expect(deriveAccountByIndexSpy).not.toHaveBeenCalled();
+  });
+
+  it('derives the selected `Account` if the param `fromState` was given but the account does not found from state', async () => {
+    const { account, request, deriveAccountByIndexSpy, getCurrentAccountSpy } =
+      await setupGetCurrentAccountTest();
+    getCurrentAccountSpy.mockResolvedValue(null);
+
+    const result = await getCurrentAccount.execute({
+      ...request,
+      fromState: true,
+    });
 
     expect(result).toStrictEqual(await account.serialize());
     expect(deriveAccountByIndexSpy).toHaveBeenCalled();

--- a/packages/starknet-snap/src/rpcs/get-current-account.ts
+++ b/packages/starknet-snap/src/rpcs/get-current-account.ts
@@ -1,10 +1,16 @@
-import { type Infer } from 'superstruct';
+import { boolean, object, optional, assign, type Infer } from 'superstruct';
 
+import { AccountStateManager } from '../state/account-state-manager';
 import { BaseRequestStruct, AccountStruct } from '../utils';
 import { createAccountService } from '../utils/factory';
 import { ChainRpcController } from './abstract/chain-rpc-controller';
 
-export const GetCurrentAccountRequestStruct = BaseRequestStruct;
+export const GetCurrentAccountRequestStruct = assign(
+  BaseRequestStruct,
+  object({
+    fromState: optional(boolean()),
+  }),
+);
 
 export const GetCurrentAccountResponseStruct = AccountStruct;
 
@@ -32,13 +38,31 @@ export class GetCurrentAccountRpc extends ChainRpcController<
    *
    * @param params - The parameters of the request.
    * @param params.chainId - The chain id of the network.
+   * @param params.fromState - Optional. If true, the account will only fetched from the state.
    * @returns A promise that resolves to the selected account.
    */
   protected async handleRequest(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     params: GetCurrentAccountParams,
   ): Promise<GetCurrentAccountResponse> {
     const accountService = createAccountService(this.network);
+
+    if (params.fromState) {
+      // Get the current account from the state if the flag is set.
+      // This is to by pass the account discovery process, and only relied on the state data.
+      // If the account is not found from the state, it will fallback to the account discover process.
+      // As a trade-off, some data might not be up-to-date, such as:
+      // - `deployRequired`.
+      // - `upgradeRequired`.
+      // - `cairoVersion`.
+      // FIXME: This logic can be remove after a cache layer introduced.
+      const accountMgr = new AccountStateManager();
+      const currentAccountFromState = await accountMgr.getCurrentAccount({
+        chainId: this.network.chainId,
+      });
+      if (currentAccountFromState) {
+        return currentAccountFromState as unknown as GetCurrentAccountResponse;
+      }
+    }
 
     const account = await accountService.getCurrentAccount();
 


### PR DESCRIPTION
This change is to enable RPC `starkNet_getCurrentAccount` to return the account data from state or derive it directly

### Changes:
- add a boolean optional params `fromState` to configurate the RPC `starkNet_getCurrentAccount` to return data from state or derive it from account service
- if the state does not contains a data, it will fall back to use account service to derive a default current account
