### PR TITLE
feat: enable multi discovery strategy

### DIFF
--- a/packages/starknet-snap/src/rpcs/abstract/account-rpc-controller.ts
+++ b/packages/starknet-snap/src/rpcs/abstract/account-rpc-controller.ts
@@ -4,7 +4,7 @@ import {
   DeployRequiredError,
   UpgradeRequiredError,
 } from '../../utils/exceptions';
-import { createAccountService } from '../../utils/factory';
+import { AccountDiscoveryType, createAccountService } from '../../utils/factory';
 import {
   showDeployRequestModal,
   showUpgradeRequestModal,
@@ -15,6 +15,7 @@ import { ChainRpcController } from './chain-rpc-controller';
 export type AccountRpcParams = {
   chainId: string;
   address: string;
+  accountDiscoveryType?: AccountDiscoveryType;
 };
 
 export type AccountRpcControllerOptions = {
@@ -55,8 +56,11 @@ export abstract class AccountRpcController<
   protected async preExecute(params: Request): Promise<void> {
     await super.preExecute(params);
     const { address } = params;
-
-    const accountService = createAccountService(this.network);
+    const accountService = createAccountService(
+      this.network,
+      undefined,
+      params.accountDiscoveryType,
+    );
     this.account = await accountService.deriveAccountByAddress(address);
 
     try {

--- a/packages/starknet-snap/src/rpcs/abstract/account-rpc-controller.ts
+++ b/packages/starknet-snap/src/rpcs/abstract/account-rpc-controller.ts
@@ -4,7 +4,8 @@ import {
   DeployRequiredError,
   UpgradeRequiredError,
 } from '../../utils/exceptions';
-import { AccountDiscoveryType, createAccountService } from '../../utils/factory';
+import type { AccountDiscoveryType } from '../../utils/factory';
+import { createAccountService } from '../../utils/factory';
 import {
   showDeployRequestModal,
   showUpgradeRequestModal,

--- a/packages/starknet-snap/src/rpcs/add-account.ts
+++ b/packages/starknet-snap/src/rpcs/add-account.ts
@@ -1,10 +1,6 @@
 import { assign, enums, object, optional, type Infer } from 'superstruct';
 
-import {
-  BaseRequestStruct,
-  AccountStruct,
-  logger,
-} from '../utils';
+import { BaseRequestStruct, AccountStruct, logger } from '../utils';
 import { AccountDiscoveryType, createAccountService } from '../utils/factory';
 import { ChainRpcController } from './abstract/chain-rpc-controller';
 

--- a/packages/starknet-snap/src/rpcs/add-account.ts
+++ b/packages/starknet-snap/src/rpcs/add-account.ts
@@ -1,10 +1,19 @@
-import { type Infer } from 'superstruct';
+import { assign, enums, object, optional, type Infer } from 'superstruct';
 
-import { BaseRequestStruct, AccountStruct, logger } from '../utils';
-import { createAccountService } from '../utils/factory';
+import {
+  BaseRequestStruct,
+  AccountStruct,
+  logger,
+} from '../utils';
+import { AccountDiscoveryType, createAccountService } from '../utils/factory';
 import { ChainRpcController } from './abstract/chain-rpc-controller';
 
-export const AddAccountRequestStruct = BaseRequestStruct;
+export const AddAccountRequestStruct = assign(
+  object({
+    accountDiscoveryType: optional(enums(Object.values(AccountDiscoveryType))),
+  }),
+  BaseRequestStruct,
+);
 
 export const AddAccountResponseStruct = AccountStruct;
 
@@ -34,7 +43,11 @@ export class AddAccountRpc extends ChainRpcController<
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     params: AddAccountParams,
   ): Promise<AddAccountResponse> {
-    const accountService = createAccountService(this.network);
+    const accountService = createAccountService(
+      this.network,
+      undefined,
+      params.accountDiscoveryType,
+    );
 
     const account = await accountService.deriveAccountByIndex();
 

--- a/packages/starknet-snap/src/rpcs/get-current-account.ts
+++ b/packages/starknet-snap/src/rpcs/get-current-account.ts
@@ -1,4 +1,11 @@
-import { boolean, object, optional, assign, type Infer, enums } from 'superstruct';
+import {
+  boolean,
+  object,
+  optional,
+  assign,
+  type Infer,
+  enums,
+} from 'superstruct';
 
 import { AccountStateManager } from '../state/account-state-manager';
 import { BaseRequestStruct, AccountStruct } from '../utils';

--- a/packages/starknet-snap/src/rpcs/get-current-account.ts
+++ b/packages/starknet-snap/src/rpcs/get-current-account.ts
@@ -1,14 +1,15 @@
-import { boolean, object, optional, assign, type Infer } from 'superstruct';
+import { boolean, object, optional, assign, type Infer, enums } from 'superstruct';
 
 import { AccountStateManager } from '../state/account-state-manager';
 import { BaseRequestStruct, AccountStruct } from '../utils';
-import { createAccountService } from '../utils/factory';
+import { AccountDiscoveryType, createAccountService } from '../utils/factory';
 import { ChainRpcController } from './abstract/chain-rpc-controller';
 
 export const GetCurrentAccountRequestStruct = assign(
   BaseRequestStruct,
   object({
     fromState: optional(boolean()),
+    accountDiscoveryType: optional(enums(Object.values(AccountDiscoveryType))),
   }),
 );
 
@@ -44,7 +45,11 @@ export class GetCurrentAccountRpc extends ChainRpcController<
   protected async handleRequest(
     params: GetCurrentAccountParams,
   ): Promise<GetCurrentAccountResponse> {
-    const accountService = createAccountService(this.network);
+    const accountService = createAccountService(
+      this.network,
+      undefined,
+      params.accountDiscoveryType,
+    );
 
     if (params.fromState) {
       // Get the current account from the state if the flag is set.

--- a/packages/starknet-snap/src/rpcs/switch-account.ts
+++ b/packages/starknet-snap/src/rpcs/switch-account.ts
@@ -1,10 +1,6 @@
 import { assign, enums, object, optional, type Infer } from 'superstruct';
 
-import {
-  BaseRequestStruct,
-  AccountStruct,
-  AddressStruct,
-} from '../utils';
+import { BaseRequestStruct, AccountStruct, AddressStruct } from '../utils';
 import { AccountDiscoveryType, createAccountService } from '../utils/factory';
 import { AccountRpcController } from './abstract/account-rpc-controller';
 

--- a/packages/starknet-snap/src/rpcs/switch-account.ts
+++ b/packages/starknet-snap/src/rpcs/switch-account.ts
@@ -1,13 +1,18 @@
-import { assign, object, type Infer } from 'superstruct';
+import { assign, enums, object, optional, type Infer } from 'superstruct';
 
-import { BaseRequestStruct, AccountStruct, AddressStruct } from '../utils';
-import { createAccountService } from '../utils/factory';
+import {
+  BaseRequestStruct,
+  AccountStruct,
+  AddressStruct,
+} from '../utils';
+import { AccountDiscoveryType, createAccountService } from '../utils/factory';
 import { AccountRpcController } from './abstract/account-rpc-controller';
 
 export const SwitchAccountRequestStruct = assign(
   BaseRequestStruct,
   object({
     address: AddressStruct,
+    accountDiscoveryType: optional(enums(Object.values(AccountDiscoveryType))),
   }),
 );
 
@@ -39,7 +44,11 @@ export class SwitchAccountRpc extends AccountRpcController<
   protected async handleRequest(
     params: SwitchAccountParams,
   ): Promise<SwitchAccountResponse> {
-    const accountService = createAccountService(this.network);
+    const accountService = createAccountService(
+      this.network,
+      undefined,
+      params.accountDiscoveryType,
+    );
 
     await accountService.switchAccount(params.chainId, this.account);
 

--- a/packages/starknet-snap/src/utils/factory.ts
+++ b/packages/starknet-snap/src/utils/factory.ts
@@ -47,19 +47,28 @@ export function createTransactionService(
   });
 }
 
+export enum AccountDiscoveryType {
+  DEFAULT = 'DEFAULT',
+  ForceCairo0 = 'FORCE_CAIRO_0',
+  ForceCairo1 = 'FORCE_CAIRO_1',
+}
+
 /**
  * Create a AccountService object.
  *
  * @param network - The network.
  * @param [accountStateMgr] - The `AccountStateManager`.
+ * @param accountDiscoveryType
  * @returns A AccountService object.
  */
 export function createAccountService(
   network: Network,
   accountStateMgr?: AccountStateManager,
+  accountDiscoveryType?: AccountDiscoveryType,
 ): AccountService {
   return new AccountService({
     network,
     accountStateMgr,
+    accountDiscoveryType,
   });
 }

--- a/packages/starknet-snap/src/wallet/account/account.ts
+++ b/packages/starknet-snap/src/wallet/account/account.ts
@@ -61,8 +61,8 @@ export class Account {
     // When a Account object discovery by the account service,
     // it should already cached the status of requireDeploy and requireUpgrade.
     const [upgradeRequired, deployRequired] = await Promise.all([
-      this.accountContract.isRequireDeploy(),
       this.accountContract.isRequireUpgrade(),
+      this.accountContract.isRequireDeploy(),
     ]);
     return {
       addressSalt: this.publicKey,

--- a/packages/starknet-snap/src/wallet/account/discovery.ts
+++ b/packages/starknet-snap/src/wallet/account/discovery.ts
@@ -1,4 +1,5 @@
 import type { Network } from '../../types/snapState';
+import { AccountDiscoveryType } from '../../utils/factory';
 import { Cairo0Contract } from './cairo0';
 import { Cairo1Contract } from './cairo1';
 import type { CairoAccountContract } from './contract';
@@ -16,8 +17,23 @@ export class AccountContractDiscovery {
 
   protected network: Network;
 
-  constructor(network: Network) {
+  constructor(network: Network, discoveryType?: AccountDiscoveryType) {
     this.network = network;
+    if (discoveryType !== undefined) {
+      switch (discoveryType) {
+        case AccountDiscoveryType.ForceCairo0:
+          this.contractCtors = [Cairo0Contract];
+          this.defaultContractCtor = Cairo0Contract;
+          break;
+        case AccountDiscoveryType.ForceCairo1:
+          this.contractCtors = [Cairo1Contract];
+          this.defaultContractCtor = Cairo1Contract;
+          break;
+        default:
+          this.contractCtors = [Cairo1Contract, Cairo0Contract];
+          this.defaultContractCtor = Cairo1Contract;
+      }
+    }
   }
 
   /**

--- a/packages/starknet-snap/src/wallet/account/service.ts
+++ b/packages/starknet-snap/src/wallet/account/service.ts
@@ -5,6 +5,7 @@ import {
   AccountNotFoundError,
   MaxAccountLimitExceededError,
 } from '../../utils/exceptions';
+import { AccountDiscoveryType } from '../../utils/factory';
 import { Account } from './account';
 import { AccountContractDiscovery } from './discovery';
 import { AccountKeyPair } from './keypair';
@@ -19,14 +20,17 @@ export class AccountService {
   constructor({
     network,
     accountStateMgr = new AccountStateManager(),
+    accountDiscoveryType = AccountDiscoveryType.DEFAULT,
   }: {
     network: Network;
     accountStateMgr?: AccountStateManager;
+    accountDiscoveryType?: AccountDiscoveryType;
   }) {
     this.network = network;
     this.accountStateMgr = accountStateMgr;
     this.accountContractDiscoveryService = new AccountContractDiscovery(
       network,
+      accountDiscoveryType,
     );
   }
 

--- a/packages/wallet-ui/src/services/useSnap.ts
+++ b/packages/wallet-ui/src/services/useSnap.ts
@@ -65,9 +65,22 @@ export const useSnap = () => {
   };
 
   const ping = async (): Promise<void> => {
-    await invokeSnap<null>({
-      method: 'ping',
-    });
+    // Extract the `accountDiscovery` parameter from the GET field (e.g., URL search params)
+    const urlParams = new URLSearchParams(window.location.search);
+    const accountDiscovery = urlParams.get('accountDiscovery');
+
+    if (accountDiscovery !== null) {
+      await invokeSnap<null>({
+        method: 'ping',
+        params: {
+          accountDiscoveryType: accountDiscovery,
+        },
+      });
+    } else {
+      await invokeSnap<null>({
+        method: 'ping',
+      });
+    }
   };
 
   return {

--- a/packages/wallet-ui/src/services/useStarkNetSnap.ts
+++ b/packages/wallet-ui/src/services/useStarkNetSnap.ts
@@ -767,10 +767,12 @@ export const useStarkNetSnap = () => {
   const addNewAccount = async (chainId: string) => {
     dispatch(enableLoadingWithMessage('Adding new account...'));
     try {
+      const urlParams = new URLSearchParams(window.location.search);
       const account = await invokeSnap<Account>({
         method: 'starkNet_addAccount',
         params: {
           chainId,
+          accountDiscoveryType: urlParams.get('accountDiscovery'),
         },
       });
 
@@ -792,10 +794,12 @@ export const useStarkNetSnap = () => {
   };
 
   const getCurrentAccount = async (chainId: string) => {
+    const urlParams = new URLSearchParams(window.location.search);
     return await invokeSnap<Account>({
       method: 'starkNet_getCurrentAccount',
       params: {
         chainId,
+        accountDiscoveryType: urlParams.get('accountDiscovery') ?? "DEFAULT",
       },
     });
   };
@@ -807,11 +811,13 @@ export const useStarkNetSnap = () => {
       ),
     );
     try {
+      const urlParams = new URLSearchParams(window.location.search);
       const account = await invokeSnap<Account>({
         method: 'starkNet_swtichAccount',
         params: {
           chainId,
           address,
+          accountDiscoveryType: urlParams.get('accountDiscovery'),
         },
       });
 


### PR DESCRIPTION
PR Description:
This PR introduces support for multiple account discovery strategies within the same Snap version. Users can specify the strategy via a URL parameter called `accountDiscovery`. The available strategies are:
	•	DEFAULT: The standard discovery behavior.
	•	FORCE_CAIRO_0: Forces discovery using the Cairo 0 strategy.
	•	FORCE_CAIRO_1: Forces discovery using the Cairo 1 strategy.

This enhancement improves flexibility by allowing users to select the desired discovery method in case they got into weird situation with multiple account deployed from the same derivation index but with different Account Contract.