### PR TITLE
chore: unblock account create limit

### DIFF
--- a/packages/starknet-snap/src/config.ts
+++ b/packages/starknet-snap/src/config.ts
@@ -36,9 +36,6 @@ export type SnapConfig = {
       txnsInLastNumOfDays: number;
     };
   };
-  account: {
-    maxAccountToCreate: number;
-  };
 };
 
 export enum DataClient {
@@ -63,11 +60,6 @@ export const Config: SnapConfig = {
       txnsInLastNumOfDays: 10,
     },
   },
-
-  account: {
-    maxAccountToCreate: 2,
-  },
-
   // eslint-disable-next-line no-restricted-globals
   rpcApiKey: process.env.DIN_API_KEY ?? '',
 

--- a/packages/starknet-snap/src/state/__tests__/helper.ts
+++ b/packages/starknet-snap/src/state/__tests__/helper.ts
@@ -100,16 +100,11 @@ export const mockAccountStateManager = () => {
     AccountStateManager.prototype,
     'upsertAccount',
   );
-  const isMaxAccountLimitExceededSpy = jest.spyOn(
-    AccountStateManager.prototype,
-    'isMaxAccountLimitExceeded',
-  );
 
   return {
     getAccountSpy,
     getNextIndexSpy,
     upsertAccountSpy,
-    isMaxAccountLimitExceededSpy,
   };
 };
 

--- a/packages/starknet-snap/src/state/account-state-manager.test.ts
+++ b/packages/starknet-snap/src/state/account-state-manager.test.ts
@@ -1,7 +1,6 @@
 import { constants } from 'starknet';
 
 import type { StarknetAccount } from '../__tests__/helper';
-import { Config } from '../config';
 import {
   generateMainnetAccounts,
   generateTestnetAccounts,
@@ -207,36 +206,6 @@ describe('AccountStateManager', () => {
       await expect(stateManager.removeAccount(removeAccount)).rejects.toThrow(
         'Account does not exist',
       );
-    });
-  });
-
-  describe('isMaxAccountLimitExceeded', () => {
-    it('returns true if the account limit is reached', async () => {
-      const accounts = await generateTestnetAccounts(
-        Config.account.maxAccountToCreate + 1,
-      );
-      await mockStateWithMainnetAccounts(accounts);
-
-      const stateManager = new AccountStateManager();
-      const result = await stateManager.isMaxAccountLimitExceeded({
-        chainId: testnetChainId,
-      });
-
-      expect(result).toBe(true);
-    });
-
-    it('returns false if the account limit is not reached', async () => {
-      const accounts = await generateTestnetAccounts(
-        Config.account.maxAccountToCreate,
-      );
-      await mockStateWithMainnetAccounts(accounts);
-
-      const stateManager = new AccountStateManager();
-      const result = await stateManager.isMaxAccountLimitExceeded({
-        chainId: testnetChainId,
-      });
-
-      expect(result).toBe(false);
     });
   });
 

--- a/packages/starknet-snap/src/state/account-state-manager.ts
+++ b/packages/starknet-snap/src/state/account-state-manager.ts
@@ -1,4 +1,3 @@
-import { Config } from '../config';
 import type { AccContract, SnapState } from '../types/snapState';
 import type { IFilter } from './filter';
 import {
@@ -215,28 +214,6 @@ export class AccountStateManager extends StateManager<AccContract> {
     } catch (error) {
       throw new StateManagerError(error.message);
     }
-  }
-
-  /**
-   * Determines whether max account limit exceeded.
-   *
-   * @param params - The parameters for checking the max account limit.
-   * @param params.chainId - The chain ID.
-   * @param [state] - The optional SnapState object.
-   * @returns A Promise that resolves to a boolean indicating whether the max account limit is exceeded.
-   */
-  async isMaxAccountLimitExceeded(
-    {
-      chainId,
-    }: {
-      chainId: string;
-    },
-    state?: SnapState,
-  ): Promise<boolean> {
-    return (
-      (await this.list([new ChainIdFilter([chainId])], undefined, state))
-        .length > Config.account.maxAccountToCreate
-    );
   }
 
   /**

--- a/packages/starknet-snap/src/utils/exceptions.ts
+++ b/packages/starknet-snap/src/utils/exceptions.ts
@@ -4,7 +4,6 @@ import {
   UserRejectedRequestError,
 } from '@metamask/snaps-sdk';
 
-import { Config } from '../config';
 import { createWalletRpcErrorWrapper, WalletRpcErrorCode } from './error';
 
 // Extend SnapError to allow error message visible to client
@@ -45,16 +44,6 @@ export class AccountDiscoveryError extends SnapError {
   constructor(message?: string) {
     super(
       message ?? 'Account discovery found',
-      createWalletRpcErrorWrapper(WalletRpcErrorCode.Unknown),
-    );
-  }
-}
-
-export class MaxAccountLimitExceededError extends SnapError {
-  constructor(message?: string) {
-    super(
-      message ??
-        `Maximum number of accounts reached: ${Config.account.maxAccountToCreate}`,
       createWalletRpcErrorWrapper(WalletRpcErrorCode.Unknown),
     );
   }

--- a/packages/starknet-snap/src/wallet/account/service.ts
+++ b/packages/starknet-snap/src/wallet/account/service.ts
@@ -1,10 +1,7 @@
 import { AccountStateManager } from '../../state/account-state-manager';
 import type { Network } from '../../types/snapState';
 import { getBip44Deriver } from '../../utils';
-import {
-  AccountNotFoundError,
-  MaxAccountLimitExceededError,
-} from '../../utils/exceptions';
+import { AccountNotFoundError } from '../../utils/exceptions';
 import { Account } from './account';
 import { AccountContractDiscovery } from './discovery';
 import { AccountKeyPair } from './keypair';
@@ -53,7 +50,7 @@ export class AccountService {
     const { chainId } = this.network;
 
     // use `withTransaction` to ensure that the state is not modified if an error occurs.
-    return this.accountStateMgr.withTransaction(async (state) => {
+    return this.accountStateMgr.withTransaction(async () => {
       let hdIndex = index;
       if (hdIndex === undefined) {
         hdIndex = await this.accountStateMgr.getNextIndex(chainId);
@@ -81,18 +78,6 @@ export class AccountService {
       });
 
       await this.accountStateMgr.upsertAccount(await account.serialize());
-
-      // FIXME: this is a convenience way to check if the account limit has been exceeded at the last line of the code. However, it is possible to improve if we can check it before the account is derived.
-      if (
-        await this.accountStateMgr.isMaxAccountLimitExceeded(
-          {
-            chainId,
-          },
-          state,
-        )
-      ) {
-        throw new MaxAccountLimitExceededError();
-      }
 
       return account;
     });


### PR DESCRIPTION
This PR is to remove the blocking of account create limit

### Changes:
- remove related test case for account create limit
- remove account limit verification in account service
- remove dead code and config for account create limit

### Requirements: