### PR TITLE
fix: incorrect switch account RPC endpoint in Wallet-UI

### DIFF
--- a/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.view.tsx
@@ -27,16 +27,8 @@ export const AccountSwitchModalView = ({
   starkName,
 }: Props) => {
   const networks = useAppSelector((state) => state.networks);
-  const { switchAccount, initWalletData, addNewAccount } = useStarkNetSnap();
+  const { switchAccount, addNewAccount } = useStarkNetSnap();
   const chainId = networks?.items[networks.activeNetwork]?.chainId;
-
-  const changeAccount = async (currentAddress: string) => {
-    const account = await switchAccount(chainId, currentAddress);
-    await initWalletData({
-      account,
-      chainId,
-    });
-  };
 
   return (
     <Menu as="div" style={{ display: 'inline-block', position: 'relative' }}>
@@ -60,7 +52,7 @@ export const AccountSwitchModalView = ({
         <MenuSection>
           {accounts.map((account) => (
             <Menu.Item key={account}>
-              <NetworkMenuItem onClick={() => changeAccount(account)}>
+              <NetworkMenuItem onClick={() => switchAccount(chainId, account)}>
                 <Radio
                   checked={account === currentAddress}
                   name="radio-buttons"

--- a/packages/wallet-ui/src/services/useStarkNetSnap.ts
+++ b/packages/wallet-ui/src/services/useStarkNetSnap.ts
@@ -1,5 +1,4 @@
 import {
-  setInfoModalVisible,
   setMinVersionModalVisible,
   setUpgradeModalVisible,
   setDeployModalVisible,
@@ -205,7 +204,7 @@ export const useStarkNetSnap = () => {
 
     // FIXME: hardcode to set the info modal visible,
     // but it should only visible when the account is not deployed
-    dispatch(setInfoModalVisible(true));
+    // dispatch(setInfoModalVisible(true));
 
     dispatch(setUpgradeModalVisible(upgradeRequired));
     dispatch(setDeployModalVisible(deployRequired));
@@ -808,7 +807,7 @@ export const useStarkNetSnap = () => {
     );
     try {
       const account = await invokeSnap<Account>({
-        method: 'starkNet_swtichAccount',
+        method: 'starkNet_switchAccount',
         params: {
           chainId,
           address,


### PR DESCRIPTION
This PR is to fix the incorrect switch account RPC endpoint in Wallet-UI

### Change:
- Update switch account RPC endpoint to `starkNet_switchAccount `
- Remove duplicate `initWalletData` when adding a new account
- Disable  `InfoModal` temporarily