### PR TITLE
feat: wallet-ui multiple accounts scrollbar

### DIFF
--- a/packages/wallet-ui/src/App.tsx
+++ b/packages/wallet-ui/src/App.tsx
@@ -37,12 +37,12 @@ function App() {
   } = useAppSelector((state) => state.modals);
   const { loader } = useAppSelector((state) => state.UI);
   const networks = useAppSelector((state) => state.networks);
-  const { currentAccount, currentAccountIndex } = useAppSelector(
+  const { currentAccount } = useAppSelector(
     (state) => state.wallet,
   );
   const { hasMetamask } = useHasMetamask();
   const chainId = networks.items?.[networks.activeNetwork]?.chainId;
-  const address = currentAccount ?? DUMMY_ADDRESS;
+  const address = currentAccount?.address ?? DUMMY_ADDRESS;
 
   useEffect(() => {
     if (!provider) {
@@ -99,7 +99,7 @@ function App() {
         >
           <DeployModal address={address} />
         </PopIn>
-        <Home address={address} addressIndex={currentAccountIndex} />
+        <Home address={address} addressIndex={currentAccount?.addressIndex || 0} />
         <PopIn isOpen={loading}>
           {loading && (
             <LoadingBackdrop>{loader.loadingMessage}</LoadingBackdrop>

--- a/packages/wallet-ui/src/App.tsx
+++ b/packages/wallet-ui/src/App.tsx
@@ -97,10 +97,7 @@ function App() {
         >
           <DeployModal address={address} />
         </PopIn>
-        <Home
-          address={address}
-          addressIndex={currentAccount?.addressIndex || 0}
-        />
+        <Home />
         <PopIn isOpen={loading}>
           {loading && (
             <LoadingBackdrop>{loader.loadingMessage}</LoadingBackdrop>

--- a/packages/wallet-ui/src/App.tsx
+++ b/packages/wallet-ui/src/App.tsx
@@ -37,7 +37,9 @@ function App() {
   } = useAppSelector((state) => state.modals);
   const { loader } = useAppSelector((state) => state.UI);
   const networks = useAppSelector((state) => state.networks);
-  const { currentAccount } = useAppSelector((state) => state.wallet);
+  const { currentAccount, currentAccountIndex } = useAppSelector(
+    (state) => state.wallet,
+  );
   const { hasMetamask } = useHasMetamask();
   const chainId = networks.items?.[networks.activeNetwork]?.chainId;
   const address = currentAccount ?? DUMMY_ADDRESS;
@@ -97,7 +99,7 @@ function App() {
         >
           <DeployModal address={address} />
         </PopIn>
-        <Home address={address} />
+        <Home address={address} addressIndex={currentAccountIndex} />
         <PopIn isOpen={loading}>
           {loading && (
             <LoadingBackdrop>{loader.loadingMessage}</LoadingBackdrop>

--- a/packages/wallet-ui/src/App.tsx
+++ b/packages/wallet-ui/src/App.tsx
@@ -37,9 +37,7 @@ function App() {
   } = useAppSelector((state) => state.modals);
   const { loader } = useAppSelector((state) => state.UI);
   const networks = useAppSelector((state) => state.networks);
-  const { currentAccount } = useAppSelector(
-    (state) => state.wallet,
-  );
+  const { currentAccount } = useAppSelector((state) => state.wallet);
   const { hasMetamask } = useHasMetamask();
   const chainId = networks.items?.[networks.activeNetwork]?.chainId;
   const address = currentAccount?.address ?? DUMMY_ADDRESS;
@@ -99,7 +97,10 @@ function App() {
         >
           <DeployModal address={address} />
         </PopIn>
-        <Home address={address} addressIndex={currentAccount?.addressIndex || 0} />
+        <Home
+          address={address}
+          addressIndex={currentAccount?.addressIndex || 0}
+        />
         <PopIn isOpen={loading}>
           {loading && (
             <LoadingBackdrop>{loader.loadingMessage}</LoadingBackdrop>

--- a/packages/wallet-ui/src/components/pages/Home/Home.view.tsx
+++ b/packages/wallet-ui/src/components/pages/Home/Home.view.tsx
@@ -3,21 +3,20 @@ import { Header } from 'components/ui/organism/Header';
 import { SideBar } from 'components/ui/organism/SideBar';
 import { RightPart, Wrapper, NoTransactions } from './Home.style';
 import { useAppSelector } from 'hooks/redux';
-interface Props {
-  address: string;
-  addressIndex: number;
-}
+import { DUMMY_ADDRESS } from 'utils/constants';
 
-export const HomeView = ({ address, addressIndex }: Props) => {
+export const HomeView = () => {
   const { erc20TokenBalanceSelected, transactions } = useAppSelector(
     (state) => state.wallet,
   );
   const loader = useAppSelector((state) => state.UI.loader);
+  const currentAccount = useAppSelector((state) => state.wallet.currentAccount);
+  const address = currentAccount?.address ?? DUMMY_ADDRESS;
   const { upgradeModalVisible } = useAppSelector((state) => state.modals);
 
   return (
     <Wrapper>
-      <SideBar address={address} addressIndex={addressIndex} />
+      <SideBar />
       <RightPart>
         {!upgradeModalVisible &&
           Object.keys(erc20TokenBalanceSelected).length > 0 && (

--- a/packages/wallet-ui/src/components/pages/Home/Home.view.tsx
+++ b/packages/wallet-ui/src/components/pages/Home/Home.view.tsx
@@ -5,9 +5,10 @@ import { RightPart, Wrapper, NoTransactions } from './Home.style';
 import { useAppSelector } from 'hooks/redux';
 interface Props {
   address: string;
+  addressIndex: number;
 }
 
-export const HomeView = ({ address }: Props) => {
+export const HomeView = ({ address, addressIndex }: Props) => {
   const { erc20TokenBalanceSelected, transactions } = useAppSelector(
     (state) => state.wallet,
   );
@@ -16,7 +17,7 @@ export const HomeView = ({ address }: Props) => {
 
   return (
     <Wrapper>
-      <SideBar address={address} />
+      <SideBar address={address} addressIndex={addressIndex} />
       <RightPart>
         {!upgradeModalVisible &&
           Object.keys(erc20TokenBalanceSelected).length > 0 && (

--- a/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.stories.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.stories.tsx
@@ -17,12 +17,14 @@ const wrapperStyle = {
 };
 
 const accounts = ['0x123...abcd', '0x456...efgh', '0x789...ijkl'];
+const accountsIndex = [0, 1, 2];
 
 export const Default = () => (
   <div style={wrapperStyle}>
     <AccountSwitchModalView
       currentAddress={address}
       accounts={accounts}
+      accountsIndex={accountsIndex}
     ></AccountSwitchModalView>
   </div>
 );
@@ -32,6 +34,7 @@ export const TooltipTop = () => (
     <AccountSwitchModalView
       currentAddress={address}
       accounts={accounts}
+      accountsIndex={accountsIndex}
     ></AccountSwitchModalView>
   </div>
 );
@@ -41,6 +44,7 @@ export const Full = () => (
     <AccountSwitchModalView
       currentAddress={address}
       accounts={accounts}
+      accountsIndex={accountsIndex}
       full
     ></AccountSwitchModalView>
   </div>
@@ -51,6 +55,7 @@ export const DarkerBackground = () => (
     <AccountSwitchModalView
       currentAddress={address}
       accounts={accounts}
+      accountsIndex={accountsIndex}
       full
     ></AccountSwitchModalView>
   </div>

--- a/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.stories.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.stories.tsx
@@ -1,14 +1,11 @@
 import { Meta } from '@storybook/react';
 import { AccountSwitchModalView } from './AccountSwitchModal.view';
-import { Account } from 'types';
 
 export default {
   title: 'Molecule/AccountAddress',
   component: AccountSwitchModalView,
 } as Meta;
 
-const address =
-  '0x683ec5da50476f84a5d47e822cd4dd35ae3a63c6c1f0725bf28526290d1ee13';
 const wrapperStyle = {
   backgroundColor: 'white',
   height: '300px',
@@ -17,55 +14,20 @@ const wrapperStyle = {
   justifyContent: 'center',
 };
 
-const accounts = [
-  {
-    address: '0x123...abcd',
-    addressIndex: 0,
-  },
-  {
-    address: '0x456...efgh',
-    addressIndex: 1,
-  },
-  {
-    address: '0x789...ijkl',
-    addressIndex: 2,
-  },
-] as Account[];
-
 export const Default = () => (
   <div style={wrapperStyle}>
-    <AccountSwitchModalView
-      currentAddress={address}
-      accounts={accounts}
-    ></AccountSwitchModalView>
-  </div>
-);
-
-export const TooltipTop = () => (
-  <div style={wrapperStyle}>
-    <AccountSwitchModalView
-      currentAddress={address}
-      accounts={accounts}
-    ></AccountSwitchModalView>
+    <AccountSwitchModalView></AccountSwitchModalView>
   </div>
 );
 
 export const Full = () => (
   <div style={wrapperStyle}>
-    <AccountSwitchModalView
-      currentAddress={address}
-      accounts={accounts}
-      full
-    ></AccountSwitchModalView>
+    <AccountSwitchModalView full></AccountSwitchModalView>
   </div>
 );
 
 export const DarkerBackground = () => (
   <div style={{ ...wrapperStyle, backgroundColor: 'grey' }}>
-    <AccountSwitchModalView
-      currentAddress={address}
-      accounts={accounts}
-      full
-    ></AccountSwitchModalView>
+    <AccountSwitchModalView full></AccountSwitchModalView>
   </div>
 );

--- a/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.stories.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta } from '@storybook/react';
 import { AccountSwitchModalView } from './AccountSwitchModal.view';
+import { Account } from 'types';
 
 export default {
   title: 'Molecule/AccountAddress',
@@ -16,15 +17,24 @@ const wrapperStyle = {
   justifyContent: 'center',
 };
 
-const accounts = ['0x123...abcd', '0x456...efgh', '0x789...ijkl'];
-const accountsIndex = [0, 1, 2];
+const accounts = [
+  {
+    address: '0x123...abcd',
+    addressIndex: 0,
+  },{
+    address: '0x456...efgh',
+    addressIndex: 1,
+  },{
+    address: '0x789...ijkl',
+    addressIndex: 2,
+  }, 
+] as Account[];
 
 export const Default = () => (
   <div style={wrapperStyle}>
     <AccountSwitchModalView
       currentAddress={address}
       accounts={accounts}
-      accountsIndex={accountsIndex}
     ></AccountSwitchModalView>
   </div>
 );
@@ -34,7 +44,6 @@ export const TooltipTop = () => (
     <AccountSwitchModalView
       currentAddress={address}
       accounts={accounts}
-      accountsIndex={accountsIndex}
     ></AccountSwitchModalView>
   </div>
 );
@@ -44,7 +53,6 @@ export const Full = () => (
     <AccountSwitchModalView
       currentAddress={address}
       accounts={accounts}
-      accountsIndex={accountsIndex}
       full
     ></AccountSwitchModalView>
   </div>
@@ -55,7 +63,6 @@ export const DarkerBackground = () => (
     <AccountSwitchModalView
       currentAddress={address}
       accounts={accounts}
-      accountsIndex={accountsIndex}
       full
     ></AccountSwitchModalView>
   </div>

--- a/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.stories.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.stories.tsx
@@ -21,13 +21,15 @@ const accounts = [
   {
     address: '0x123...abcd',
     addressIndex: 0,
-  },{
+  },
+  {
     address: '0x456...efgh',
     addressIndex: 1,
-  },{
+  },
+  {
     address: '0x789...ijkl',
     addressIndex: 2,
-  }, 
+  },
 ] as Account[];
 
 export const Default = () => (

--- a/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.style.ts
+++ b/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.style.ts
@@ -1,3 +1,4 @@
+import { AccountImage } from 'components/ui/atom/AccountImage';
 import { Button } from 'components/ui/atom/Button';
 import styled from 'styled-components';
 
@@ -23,4 +24,20 @@ export const Wrapper = styled(Button).attrs((props) => ({
     background-color: ${(props) => props.theme.palette.grey.grey4};
     border: none;
   }
+`;
+
+export const Normal = styled.div`
+  font-size: ${(props) => props.theme.typography.p1.fontSize};
+`;
+
+export const AccountSwitchMenuItem = styled.div`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  padding: 14px;
+`;
+
+export const AccountImageStyled = styled(AccountImage)`
+  margin-left: ${(props) => props.theme.spacing.small};
+  cursor: pointer;
 `;

--- a/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.view.tsx
@@ -17,11 +17,11 @@ import { theme } from 'theme/default';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useAppSelector } from 'hooks/redux';
 import { useStarkNetSnap } from 'services';
+import { Account } from 'types';
 
 interface Props {
   currentAddress: string;
-  accounts: string[];
-  accountsIndex: number[];
+  accounts: Account[];
   full?: boolean;
   starkName?: string;
 }
@@ -29,7 +29,6 @@ interface Props {
 export const AccountSwitchModalView = ({
   currentAddress,
   accounts,
-  accountsIndex,
   full,
   starkName,
 }: Props) => {
@@ -59,11 +58,11 @@ export const AccountSwitchModalView = ({
         <MenuDivider />
         <MenuSection style={{ height: 201, overflowY: 'auto' }}>
           {accounts.map((account, index) => {
-            const isSelected = account === currentAddress; // Check if the account is selected
+            const isSelected = account.address === currentAddress; // Check if the account is selected
             return (
-              <Menu.Item key={account}>
+              <Menu.Item key={account.address}>
                 <AccountSwitchMenuItem
-                  onClick={() => switchAccount(chainId, account)}
+                  onClick={() => switchAccount(chainId, account.address)}
                   style={{
                     backgroundColor: isSelected
                       ? theme.palette.grey.grey4
@@ -76,13 +75,13 @@ export const AccountSwitchModalView = ({
                 >
                   <AccountImageStyled
                     size={30}
-                    address={account}
-                    connected={account === currentAddress}
+                    address={account.address}
+                    connected={account.address === currentAddress}
                   />
                   <MenuItemText style={{ marginLeft: isSelected ? 19 : 20 }}>
                     <div>
-                      <div>Account {accountsIndex[index] + 1}</div>
-                      <div>{full ? account : shortenAddress(account)}</div>
+                      <div>Account {account.addressIndex + 1}</div>
+                      <div>{full ? account.address : shortenAddress(account.address)}</div>
                     </div>
                   </MenuItemText>
                 </AccountSwitchMenuItem>

--- a/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.view.tsx
@@ -1,13 +1,18 @@
 import { shortenAddress, shortenDomain } from 'utils/utils';
-import { Wrapper } from './AccountSwitchModal.style';
+import {
+  AccountImageStyled,
+  Normal,
+  Wrapper,
+  AccountSwitchMenuItem,
+} from './AccountSwitchModal.style';
 import { Menu } from '@headlessui/react';
 import {
   MenuItems,
   MenuSection,
   NetworkMenuItem,
   MenuItemText,
+  MenuDivider,
 } from 'components/ui/organism/Menu/Menu.style';
-import { Radio } from '@mui/material';
 import { theme } from 'theme/default';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useAppSelector } from 'hooks/redux';
@@ -16,6 +21,7 @@ import { useStarkNetSnap } from 'services';
 interface Props {
   currentAddress: string;
   accounts: string[];
+  accountsIndex: number[];
   full?: boolean;
   starkName?: string;
 }
@@ -23,6 +29,7 @@ interface Props {
 export const AccountSwitchModalView = ({
   currentAddress,
   accounts,
+  accountsIndex,
   full,
   starkName,
 }: Props) => {
@@ -42,36 +49,48 @@ export const AccountSwitchModalView = ({
         </Wrapper>
       </Menu.Button>
 
-      <MenuItems style={{ right: 'auto', zIndex: '1' }}>
+      <MenuItems style={{ right: 'auto', zIndex: '1', width: 'auto' }}>
         {/* Account List */}
         <MenuSection>
           <Menu.Item disabled>
-            <div style={{ padding: '8px 0px 0px 8px' }}>Accounts</div>
+            <Normal>Accounts</Normal>
           </Menu.Item>
         </MenuSection>
-        <MenuSection>
-          {accounts.map((account) => (
-            <Menu.Item key={account}>
-              <NetworkMenuItem onClick={() => switchAccount(chainId, account)}>
-                <Radio
-                  checked={account === currentAddress}
-                  name="radio-buttons"
-                  inputProps={{ 'aria-label': account }}
-                  sx={{
-                    color: theme.palette.grey.grey1,
-                    '&.Mui-checked': {
-                      color: theme.palette.secondary.main,
-                    },
+        <MenuDivider />
+        <MenuSection style={{ height: 201, overflowY: 'auto' }}>
+          {accounts.map((account, index) => {
+            const isSelected = account === currentAddress; // Check if the account is selected
+            return (
+              <Menu.Item key={account}>
+                <AccountSwitchMenuItem
+                  onClick={() => switchAccount(chainId, account)}
+                  style={{
+                    backgroundColor: isSelected
+                      ? theme.palette.grey.grey4
+                      : 'transparent', // Change background color if selected
+                    borderLeft: isSelected
+                      ? `4px solid ${theme.palette.secondary.main}`
+                      : 'none', // Add left border if selected
+                    paddingLeft: isSelected ? 15 : 20, // Add some padding if selected to make space for the border
                   }}
-                />
-                <MenuItemText>
-                  {full ? account : shortenAddress(account)}
-                </MenuItemText>
-              </NetworkMenuItem>
-            </Menu.Item>
-          ))}
+                >
+                  <AccountImageStyled
+                    size={30}
+                    address={account}
+                    connected={account === currentAddress}
+                  />
+                  <MenuItemText style={{ marginLeft: isSelected ? 19 : 20 }}>
+                    <div>
+                      <div>Account {accountsIndex[index] + 1}</div>
+                      <div>{full ? account : shortenAddress(account)}</div>
+                    </div>
+                  </MenuItemText>
+                </AccountSwitchMenuItem>
+              </Menu.Item>
+            );
+          })}
         </MenuSection>
-
+        <MenuDivider />
         <MenuSection>
           <Menu.Item>
             <NetworkMenuItem

--- a/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.view.tsx
@@ -17,25 +17,19 @@ import { theme } from 'theme/default';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useAppSelector } from 'hooks/redux';
 import { useStarkNetSnap } from 'services';
-import { Account } from 'types';
+import { DUMMY_ADDRESS } from 'utils/constants';
 
 interface Props {
-  currentAddress: string;
-  accounts: Account[];
   full?: boolean;
   starkName?: string;
 }
 
-export const AccountSwitchModalView = ({
-  currentAddress,
-  accounts,
-  full,
-  starkName,
-}: Props) => {
+export const AccountSwitchModalView = ({ full, starkName }: Props) => {
   const networks = useAppSelector((state) => state.networks);
+  const { currentAccount, accounts } = useAppSelector((state) => state.wallet);
   const { switchAccount, addNewAccount } = useStarkNetSnap();
   const chainId = networks?.items[networks.activeNetwork]?.chainId;
-
+  const currentAddress = currentAccount?.address ?? DUMMY_ADDRESS;
   return (
     <Menu as="div" style={{ display: 'inline-block', position: 'relative' }}>
       <Menu.Button style={{ background: 'none', border: 'none' }}>

--- a/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/AccountSwitchModal/AccountSwitchModal.view.tsx
@@ -81,7 +81,11 @@ export const AccountSwitchModalView = ({
                   <MenuItemText style={{ marginLeft: isSelected ? 19 : 20 }}>
                     <div>
                       <div>Account {account.addressIndex + 1}</div>
-                      <div>{full ? account.address : shortenAddress(account.address)}</div>
+                      <div>
+                        {full
+                          ? account.address
+                          : shortenAddress(account.address)}
+                      </div>
                     </div>
                   </MenuItemText>
                 </AccountSwitchMenuItem>

--- a/packages/wallet-ui/src/components/ui/molecule/TransactionsList/TransactionsList.view.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/TransactionsList/TransactionsList.view.tsx
@@ -29,7 +29,7 @@ export const TransactionsListView = ({ transactions }: Props) => {
       timeoutHandle.current = setTimeout(
         () =>
           getTransactions(
-            currentAccount,
+            currentAccount.address,
             erc20TokenBalanceSelected.address,
             10,
             chainId,
@@ -48,7 +48,7 @@ export const TransactionsListView = ({ transactions }: Props) => {
       if (chainId && currentAccount && erc20TokenBalanceSelected.address) {
         clearTimeout(timeoutHandle.current); // cancel the timeout that was in-flight
         getTransactions(
-          currentAccount,
+          currentAccount.address,
           erc20TokenBalanceSelected.address,
           10,
           chainId,

--- a/packages/wallet-ui/src/components/ui/organism/AccountDetailsModal/AccountDetailsModal.stories.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AccountDetailsModal/AccountDetailsModal.stories.tsx
@@ -10,8 +10,11 @@ export default {
 
 const address =
   '0x683ec5da50476f84a5d47e822cd4dd35ae3a63c6c1f0725bf28526290d1ee13';
+const addressIndex = 0;
 
-export const ContentOnly = () => <AccountDetailsModalView address={address} />;
+export const ContentOnly = () => (
+  <AccountDetailsModalView address={address} addressIndex={addressIndex} />
+);
 
 export const WithModal = () => {
   let [isOpen, setIsOpen] = useState(false);
@@ -24,7 +27,10 @@ export const WithModal = () => {
         showClose={false}
         style={{ backgroundColor: 'transparent' }}
       >
-        <AccountDetailsModalView address={address} />
+        <AccountDetailsModalView
+          address={address}
+          addressIndex={addressIndex}
+        />
       </PopIn>
     </>
   );

--- a/packages/wallet-ui/src/components/ui/organism/AccountDetailsModal/AccountDetailsModal.stories.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AccountDetailsModal/AccountDetailsModal.stories.tsx
@@ -8,13 +8,7 @@ export default {
   component: AccountDetailsModalView,
 } as Meta;
 
-const address =
-  '0x683ec5da50476f84a5d47e822cd4dd35ae3a63c6c1f0725bf28526290d1ee13';
-const addressIndex = 0;
-
-export const ContentOnly = () => (
-  <AccountDetailsModalView address={address} addressIndex={addressIndex} />
-);
+export const ContentOnly = () => <AccountDetailsModalView />;
 
 export const WithModal = () => {
   let [isOpen, setIsOpen] = useState(false);
@@ -27,10 +21,7 @@ export const WithModal = () => {
         showClose={false}
         style={{ backgroundColor: 'transparent' }}
       >
-        <AccountDetailsModalView
-          address={address}
-          addressIndex={addressIndex}
-        />
+        <AccountDetailsModalView />
       </PopIn>
     </>
   );

--- a/packages/wallet-ui/src/components/ui/organism/AccountDetailsModal/AccountDetailsModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AccountDetailsModal/AccountDetailsModal.view.tsx
@@ -15,9 +15,10 @@ import { useStarkNetSnap } from 'services';
 
 interface Props {
   address: string;
+  addressIndex: number;
 }
 
-export const AccountDetailsModalView = ({ address }: Props) => {
+export const AccountDetailsModalView = ({ address, addressIndex }: Props) => {
   const networks = useAppSelector((state) => state.networks);
   const { getPrivateKeyFromAddress } = useStarkNetSnap();
   const chainId = networks?.items[networks.activeNetwork]?.chainId;
@@ -28,7 +29,7 @@ export const AccountDetailsModalView = ({ address }: Props) => {
       </AccountImageDiv>
       <Wrapper>
         <TitleDiv>
-          <Title>My account</Title>
+          <Title>Account {addressIndex + 1}</Title>
           {/* <ModifyIcon /> */}
         </TitleDiv>
         <AddressQrCode value={address} />

--- a/packages/wallet-ui/src/components/ui/organism/AccountDetailsModal/AccountDetailsModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AccountDetailsModal/AccountDetailsModal.view.tsx
@@ -12,16 +12,15 @@ import {
 import { openExplorerTab } from 'utils/utils';
 import { useAppSelector } from 'hooks/redux';
 import { useStarkNetSnap } from 'services';
+import { DUMMY_ADDRESS } from 'utils/constants';
 
-interface Props {
-  address: string;
-  addressIndex: number;
-}
-
-export const AccountDetailsModalView = ({ address, addressIndex }: Props) => {
+export const AccountDetailsModalView = () => {
   const networks = useAppSelector((state) => state.networks);
+  const currentAccount = useAppSelector((state) => state.wallet.currentAccount);
   const { getPrivateKeyFromAddress } = useStarkNetSnap();
   const chainId = networks?.items[networks.activeNetwork]?.chainId;
+  const address = currentAccount?.address ?? DUMMY_ADDRESS;
+  const addressIndex = currentAccount?.addressIndex ?? 0;
   return (
     <div>
       <AccountImageDiv>

--- a/packages/wallet-ui/src/components/ui/organism/AddTokenModal/AddTokenModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AddTokenModal/AddTokenModal.view.tsx
@@ -106,7 +106,7 @@ export const AddTokenModalView = ({ closeModal }: Props) => {
                 fields.symbol,
                 parseFloat(fields.decimal),
                 chainId,
-                currentAccount,
+                currentAccount?.address || '0x',
               );
               if (newToken) {
                 setErc20TokenBalance(newToken);

--- a/packages/wallet-ui/src/components/ui/organism/AddTokenModal/AddTokenModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AddTokenModal/AddTokenModal.view.tsx
@@ -100,19 +100,21 @@ export const AddTokenModalView = ({ closeModal }: Props) => {
           enabled={enabled}
           onClick={async () => {
             try {
-              const newToken = await addErc20Token(
-                fields.address,
-                fields.name,
-                fields.symbol,
-                parseFloat(fields.decimal),
-                chainId,
-                currentAccount?.address || '0x',
-              );
-              if (newToken) {
-                setErc20TokenBalance(newToken);
-                toastr.success('Token added successfully');
+              if (currentAccount) {
+                const newToken = await addErc20Token(
+                  fields.address,
+                  fields.name,
+                  fields.symbol,
+                  parseFloat(fields.decimal),
+                  chainId,
+                  currentAccount.address,
+                );
+                if (newToken) {
+                  setErc20TokenBalance(newToken);
+                  toastr.success('Token added successfully');
+                }
+                closeModal();
               }
-              closeModal();
             } catch (err) {
               toastr.error('Error while adding token');
             }

--- a/packages/wallet-ui/src/components/ui/organism/Header/SendSummaryModal/SendSummaryModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/Header/SendSummaryModal/SendSummaryModal.view.tsx
@@ -93,7 +93,7 @@ export const SendSummaryModalView = ({
           wallet.erc20TokenBalanceSelected.address,
           ContractFuncName.Transfer,
           callData,
-          currentAccount,
+          currentAccount.address,
           chainId,
           selectedFeeToken === FeeToken.STRK
             ? constants.TRANSACTION_VERSION.V3
@@ -181,7 +181,7 @@ export const SendSummaryModalView = ({
         wallet.erc20TokenBalanceSelected.address,
         ContractFuncName.Transfer,
         callData,
-        currentAccount,
+        currentAccount.address,
         gasFees.suggestedMaxFee,
         chainId,
         selectedFeeToken,
@@ -190,7 +190,7 @@ export const SendSummaryModalView = ({
           if (result) {
             toastr.success('Transaction sent successfully');
             getTransactions(
-              currentAccount,
+              currentAccount.address,
               wallet.erc20TokenBalanceSelected.address,
               10,
               chainId,

--- a/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.stories.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.stories.tsx
@@ -6,15 +6,10 @@ export default {
   component: SideBarView,
 } as Meta;
 
-const address =
-  '0x683ec5da50476f84a5d47e822cd4dd35ae3a63c6c1f0725bf28526290d1ee13';
-
-const addressIndex = 0;
-
 export const Default = () => {
   return (
     <div style={{ width: '33%' }}>
-      <SideBarView address={address} addressIndex={addressIndex} />
+      <SideBarView />
     </div>
   );
 };

--- a/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.stories.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.stories.tsx
@@ -9,10 +9,12 @@ export default {
 const address =
   '0x683ec5da50476f84a5d47e822cd4dd35ae3a63c6c1f0725bf28526290d1ee13';
 
+const addressIndex = 0;
+
 export const Default = () => {
   return (
     <div style={{ width: '33%' }}>
-      <SideBarView address={address} />
+      <SideBarView address={address} addressIndex={addressIndex} />
     </div>
   );
 };

--- a/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.view.tsx
@@ -27,14 +27,9 @@ import { useStarkNetSnap } from 'services';
 import { DUMMY_ADDRESS } from 'utils/constants';
 import { PopperTooltip } from 'components/ui/molecule/PopperTooltip';
 
-interface Props {
-  address: string;
-  addressIndex: number;
-}
-
-export const SideBarView = ({ address, addressIndex }: Props) => {
+export const SideBarView = () => {
   const networks = useAppSelector((state) => state.networks);
-  const accounts = useAppSelector((state) => state.wallet.accounts);
+  const currentAccount = useAppSelector((state) => state.wallet.currentAccount);
   const chainId = networks?.items[networks.activeNetwork]?.chainId;
   const [listOverflow, setListOverflow] = useState(false);
   const [infoModalOpen, setInfoModalOpen] = useState(false);
@@ -43,7 +38,8 @@ export const SideBarView = ({ address, addressIndex }: Props) => {
   const [addTokenOpen, setAddTokenOpen] = useState(false);
   const { getStarkName } = useStarkNetSnap();
   const [starkName, setStarkName] = useState<string | undefined>(undefined);
-
+  const address = currentAccount?.address ?? DUMMY_ADDRESS;
+  const addressIndex = currentAccount?.addressIndex ?? 0;
   const ref = useRef<HTMLDivElement>();
 
   useEffect(() => {
@@ -76,7 +72,7 @@ export const SideBarView = ({ address, addressIndex }: Props) => {
         isOpen={accountDetailsOpen}
         setIsOpen={setAccountDetailsOpen}
       >
-        <AccountDetailsModal address={address} addressIndex={addressIndex} />
+        <AccountDetailsModal />
       </PopInStyled>
       <PopIn
         isOpen={infoModalOpen}
@@ -117,11 +113,7 @@ export const SideBarView = ({ address, addressIndex }: Props) => {
       <AccountLabel>Account {addressIndex + 1} </AccountLabel>
       <RowDiv>
         <InfoIcon onClick={() => setInfoModalOpen(true)}>i</InfoIcon>
-        <AccountSwitchModal
-          currentAddress={address}
-          starkName={starkName}
-          accounts={accounts.map((account) => account)}
-        />
+        <AccountSwitchModal starkName={starkName} />
         <PopperTooltip content="Copied!" closeTrigger="click">
           <CopyIcon
             onClick={async () => navigator.clipboard.writeText(address)}

--- a/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.view.tsx
@@ -29,9 +29,10 @@ import { PopperTooltip } from 'components/ui/molecule/PopperTooltip';
 
 interface Props {
   address: string;
+  addressIndex: number;
 }
 
-export const SideBarView = ({ address }: Props) => {
+export const SideBarView = ({ address, addressIndex }: Props) => {
   const networks = useAppSelector((state) => state.networks);
   const accounts = useAppSelector((state) => state.wallet.accounts);
   const chainId = networks?.items[networks.activeNetwork]?.chainId;
@@ -75,7 +76,7 @@ export const SideBarView = ({ address }: Props) => {
         isOpen={accountDetailsOpen}
         setIsOpen={setAccountDetailsOpen}
       >
-        <AccountDetailsModal address={address} />
+        <AccountDetailsModal address={address} addressIndex={addressIndex} />
       </PopInStyled>
       <PopIn
         isOpen={infoModalOpen}
@@ -113,13 +114,14 @@ export const SideBarView = ({ address }: Props) => {
         <AccountImageStyled address={address} connected={wallet.connected} />
       </AccountDetails>
 
-      <AccountLabel>My account</AccountLabel>
+      <AccountLabel>Account {addressIndex + 1} </AccountLabel>
       <RowDiv>
         <InfoIcon onClick={() => setInfoModalOpen(true)}>i</InfoIcon>
         <AccountSwitchModal
           currentAddress={address}
           starkName={starkName}
-          accounts={accounts}
+          accounts={accounts.map((account) => account.address)}
+          accountsIndex={accounts.map((account) => account.addressIndex)}
         />
         <PopperTooltip content="Copied!" closeTrigger="click">
           <CopyIcon

--- a/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.view.tsx
@@ -120,8 +120,7 @@ export const SideBarView = ({ address, addressIndex }: Props) => {
         <AccountSwitchModal
           currentAddress={address}
           starkName={starkName}
-          accounts={accounts.map((account) => account.address)}
-          accountsIndex={accounts.map((account) => account.addressIndex)}
+          accounts={accounts.map((account) => account)}
         />
         <PopperTooltip content="Copied!" closeTrigger="click">
           <CopyIcon

--- a/packages/wallet-ui/src/slices/walletSlice.ts
+++ b/packages/wallet-ui/src/slices/walletSlice.ts
@@ -8,8 +8,9 @@ export interface WalletState {
   connected: boolean;
   isLoading: boolean;
   forceReconnect: boolean;
-  accounts: string[];
+  accounts: Account[];
   currentAccount: string;
+  currentAccountIndex: number;
   erc20TokenBalances: Erc20TokenBalance[];
   erc20TokenBalanceSelected: Erc20TokenBalance;
   transactions: Transaction[];
@@ -23,6 +24,7 @@ const initialState: WalletState = {
   forceReconnect: false,
   accounts: [],
   currentAccount: '',
+  currentAccountIndex: 0,
   erc20TokenBalances: [],
   erc20TokenBalanceSelected: {} as Erc20TokenBalance,
   transactions: [],
@@ -53,15 +55,19 @@ export const walletSlice = createSlice({
     ) => {
       const accountsToInsert = Array.isArray(payload) ? payload : [payload];
 
-      const accountSet = new Set(state.accounts);
+      const accountSet = new Set(
+        state.accounts.map((account) => account.address),
+      ); // Create a set of addresses
+
       for (const account of accountsToInsert) {
         if (!accountSet.has(account.address)) {
-          state.accounts.push(account.address);
+          state.accounts.push(account);
         }
       }
     },
     setCurrentAccount: (state, { payload }: { payload: Account }) => {
       state.currentAccount = payload.address;
+      state.currentAccountIndex = payload.addressIndex;
     },
     setErc20TokenBalances: (state, { payload }) => {
       state.erc20TokenBalances = payload;

--- a/packages/wallet-ui/src/slices/walletSlice.ts
+++ b/packages/wallet-ui/src/slices/walletSlice.ts
@@ -9,8 +9,7 @@ export interface WalletState {
   isLoading: boolean;
   forceReconnect: boolean;
   accounts: Account[];
-  currentAccount: string;
-  currentAccountIndex: number;
+  currentAccount?: Account;
   erc20TokenBalances: Erc20TokenBalance[];
   erc20TokenBalanceSelected: Erc20TokenBalance;
   transactions: Transaction[];
@@ -23,8 +22,7 @@ const initialState: WalletState = {
   isLoading: false,
   forceReconnect: false,
   accounts: [],
-  currentAccount: '',
-  currentAccountIndex: 0,
+  currentAccount: undefined,
   erc20TokenBalances: [],
   erc20TokenBalanceSelected: {} as Erc20TokenBalance,
   transactions: [],
@@ -57,7 +55,7 @@ export const walletSlice = createSlice({
 
       const accountSet = new Set(
         state.accounts.map((account) => account.address),
-      ); // Create a set of addresses
+      );
 
       for (const account of accountsToInsert) {
         if (!accountSet.has(account.address)) {
@@ -66,8 +64,7 @@ export const walletSlice = createSlice({
       }
     },
     setCurrentAccount: (state, { payload }: { payload: Account }) => {
-      state.currentAccount = payload.address;
-      state.currentAccountIndex = payload.addressIndex;
+      state.currentAccount = payload;
     },
     setErc20TokenBalances: (state, { payload }) => {
       state.erc20TokenBalances = payload;
@@ -115,7 +112,7 @@ export const walletSlice = createSlice({
     },
     clearAccounts: (state) => {
       state.accounts = [];
-      state.currentAccount = '';
+      state.currentAccount = undefined;
     },
     resetWallet: (state) => {
       return {

--- a/packages/wallet-ui/src/types/index.ts
+++ b/packages/wallet-ui/src/types/index.ts
@@ -33,6 +33,7 @@ export type Account = {
   upgradeRequired: boolean;
   deployRequired: boolean;
   chainId: string;
+  addressIndex: number;
 };
 
 export type Network = {


### PR DESCRIPTION
This PR adds the support of infinite account to Wallet-UI 

Changes : 

- The "My Account" is replaced by "Account X" where is X is the account number (accountIndex + 1) 
- The list of accounts now uses the Account Icon and Account name and short address for better UI/UX
- When the account number is higher than 3 a scrollbar appears 


See the video below : 


https://github.com/user-attachments/assets/dfcfe21b-4197-4510-91b3-c21fdcc925d3

