### PR TITLE
chore: currentAccount is always defined in walletSlice redux state

### DIFF
--- a/packages/wallet-ui/src/App.tsx
+++ b/packages/wallet-ui/src/App.tsx
@@ -19,7 +19,6 @@ import 'toastr2/dist/toastr.min.css';
 import { NoMetamaskModal } from 'components/ui/organism/NoMetamaskModal';
 import { MinVersionModal } from './components/ui/organism/MinVersionModal';
 import { useHasMetamask } from 'hooks/useHasMetamask';
-import { DUMMY_ADDRESS } from 'utils/constants';
 import { DeployModal } from 'components/ui/organism/DeployModal';
 
 library.add(fas, far);
@@ -40,7 +39,7 @@ function App() {
   const { currentAccount } = useAppSelector((state) => state.wallet);
   const { hasMetamask } = useHasMetamask();
   const chainId = networks.items?.[networks.activeNetwork]?.chainId;
-  const address = currentAccount?.address ?? DUMMY_ADDRESS;
+  const address = currentAccount.address;
 
   useEffect(() => {
     if (!provider) {

--- a/packages/wallet-ui/src/components/pages/Home/Home.view.tsx
+++ b/packages/wallet-ui/src/components/pages/Home/Home.view.tsx
@@ -3,7 +3,6 @@ import { Header } from 'components/ui/organism/Header';
 import { SideBar } from 'components/ui/organism/SideBar';
 import { RightPart, Wrapper, NoTransactions } from './Home.style';
 import { useAppSelector } from 'hooks/redux';
-import { DUMMY_ADDRESS } from 'utils/constants';
 
 export const HomeView = () => {
   const { erc20TokenBalanceSelected, transactions } = useAppSelector(
@@ -11,7 +10,7 @@ export const HomeView = () => {
   );
   const loader = useAppSelector((state) => state.UI.loader);
   const currentAccount = useAppSelector((state) => state.wallet.currentAccount);
-  const address = currentAccount?.address ?? DUMMY_ADDRESS;
+  const address = currentAccount.address;
   const { upgradeModalVisible } = useAppSelector((state) => state.modals);
 
   return (

--- a/packages/wallet-ui/src/components/ui/molecule/TransactionsList/TransactionsList.view.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/TransactionsList/TransactionsList.view.tsx
@@ -24,7 +24,7 @@ export const TransactionsListView = ({ transactions }: Props) => {
   } = wallet;
 
   useEffect(() => {
-    if (chainId && currentAccount && erc20TokenBalanceSelected.address) {
+    if (chainId && erc20TokenBalanceSelected.address) {
       clearTimeout(timeoutHandle.current); // cancel the timeout that was in-flight
       timeoutHandle.current = setTimeout(
         () =>
@@ -45,7 +45,7 @@ export const TransactionsListView = ({ transactions }: Props) => {
 
   useEffect(
     () => {
-      if (chainId && currentAccount && erc20TokenBalanceSelected.address) {
+      if (chainId && erc20TokenBalanceSelected.address) {
         clearTimeout(timeoutHandle.current); // cancel the timeout that was in-flight
         getTransactions(
           currentAccount.address,

--- a/packages/wallet-ui/src/components/ui/organism/AccountDetailsModal/AccountDetailsModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AccountDetailsModal/AccountDetailsModal.view.tsx
@@ -12,14 +12,13 @@ import {
 import { openExplorerTab } from 'utils/utils';
 import { useAppSelector } from 'hooks/redux';
 import { useStarkNetSnap } from 'services';
-import { DUMMY_ADDRESS } from 'utils/constants';
 
 export const AccountDetailsModalView = () => {
   const networks = useAppSelector((state) => state.networks);
   const currentAccount = useAppSelector((state) => state.wallet.currentAccount);
   const { getPrivateKeyFromAddress } = useStarkNetSnap();
   const chainId = networks?.items[networks.activeNetwork]?.chainId;
-  const address = currentAccount?.address ?? DUMMY_ADDRESS;
+  const address = currentAccount.address;
   const addressIndex = currentAccount?.addressIndex ?? 0;
   return (
     <div>

--- a/packages/wallet-ui/src/components/ui/organism/AccountSwitchModal/AccountSwitchModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AccountSwitchModal/AccountSwitchModal.view.tsx
@@ -14,7 +14,6 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { AccountsHeader } from './AccountsHeader';
 import { VisibleAccountsList } from './VisibleAccountsList';
 import { HiddenAccountsList } from './HiddenAccountsList';
-import { DUMMY_ADDRESS } from 'utils/constants';
 import { Account } from 'types';
 import Toastr from 'toastr2';
 
@@ -65,7 +64,7 @@ export const AccountSwitchModalView = ({ full, starkName }: Props) => {
       hiddenAccounts.push(account);
     }
   }
-  const currentAddress = currentAccount?.address ?? DUMMY_ADDRESS;
+  const currentAddress = currentAccount.address;
   const displayName = full
     ? starkName ?? currentAddress
     : starkName

--- a/packages/wallet-ui/src/components/ui/organism/AddTokenModal/AddTokenModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AddTokenModal/AddTokenModal.view.tsx
@@ -100,21 +100,19 @@ export const AddTokenModalView = ({ closeModal }: Props) => {
           enabled={enabled}
           onClick={async () => {
             try {
-              if (currentAccount) {
-                const newToken = await addErc20Token(
-                  fields.address,
-                  fields.name,
-                  fields.symbol,
-                  parseFloat(fields.decimal),
-                  chainId,
-                  currentAccount.address,
-                );
-                if (newToken) {
-                  setErc20TokenBalance(newToken);
-                  toastr.success('Token added successfully');
-                }
-                closeModal();
+              const newToken = await addErc20Token(
+                fields.address,
+                fields.name,
+                fields.symbol,
+                parseFloat(fields.decimal),
+                chainId,
+                currentAccount.address,
+              );
+              if (newToken) {
+                setErc20TokenBalance(newToken);
+                toastr.success('Token added successfully');
               }
+              closeModal();
             } catch (err) {
               toastr.error('Error while adding token');
             }

--- a/packages/wallet-ui/src/components/ui/organism/Header/SendSummaryModal/SendSummaryModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/Header/SendSummaryModal/SendSummaryModal.view.tsx
@@ -81,32 +81,30 @@ export const SendSummaryModalView = ({
 
   useEffect(() => {
     const fetchGasFee = () => {
-      if (currentAccount) {
-        setGasFeesError(false);
-        setEstimatingGas(true);
-        const amountBN = ethers.utils.parseUnits(
-          amount,
-          wallet.erc20TokenBalanceSelected.decimals,
-        );
-        const callData = address + ',' + amountBN.toString() + ',0';
-        estimateFees(
-          wallet.erc20TokenBalanceSelected.address,
-          ContractFuncName.Transfer,
-          callData,
-          currentAccount.address,
-          chainId,
-          selectedFeeToken === FeeToken.STRK
-            ? constants.TRANSACTION_VERSION.V3
-            : undefined,
-        )
-          .then((response) => {
-            setGasFees(response);
-            setEstimatingGas(false);
-          })
-          .catch(() => {
-            toastr.error('Error when trying to calculate the gas fees');
-          });
-      }
+      setGasFeesError(false);
+      setEstimatingGas(true);
+      const amountBN = ethers.utils.parseUnits(
+        amount,
+        wallet.erc20TokenBalanceSelected.decimals,
+      );
+      const callData = address + ',' + amountBN.toString() + ',0';
+      estimateFees(
+        wallet.erc20TokenBalanceSelected.address,
+        ContractFuncName.Transfer,
+        callData,
+        currentAccount.address,
+        chainId,
+        selectedFeeToken === FeeToken.STRK
+          ? constants.TRANSACTION_VERSION.V3
+          : undefined,
+      )
+        .then((response) => {
+          setGasFees(response);
+          setEstimatingGas(false);
+        })
+        .catch(() => {
+          toastr.error('Error when trying to calculate the gas fees');
+        });
     };
     fetchGasFee();
   }, [currentAccount]);
@@ -171,45 +169,43 @@ export const SendSummaryModalView = ({
   }, [amount, wallet.erc20TokenBalanceSelected]);
 
   const handleConfirmClick = () => {
-    if (currentAccount) {
-      const amountBN = ethers.utils.parseUnits(
-        amount,
-        wallet.erc20TokenBalanceSelected.decimals,
-      );
-      const callData = address + ',' + amountBN.toString() + ',0';
-      sendTransaction(
-        wallet.erc20TokenBalanceSelected.address,
-        ContractFuncName.Transfer,
-        callData,
-        currentAccount.address,
-        gasFees.suggestedMaxFee,
-        chainId,
-        selectedFeeToken,
-      )
-        .then((result) => {
-          if (result) {
-            toastr.success('Transaction sent successfully');
-            getTransactions(
-              currentAccount.address,
-              wallet.erc20TokenBalanceSelected.address,
-              10,
-              chainId,
-              false,
-              true,
-            ).catch((err) => {
-              console.error(
-                `handleConfirmClick: error from getTransactions: ${err}`,
-              );
-            });
-          } else {
-            toastr.info('Transaction rejected by user');
-          }
-        })
-        .catch(() => {
-          toastr.error('Error while sending the transaction');
-        });
-      closeModal && closeModal();
-    }
+    const amountBN = ethers.utils.parseUnits(
+      amount,
+      wallet.erc20TokenBalanceSelected.decimals,
+    );
+    const callData = address + ',' + amountBN.toString() + ',0';
+    sendTransaction(
+      wallet.erc20TokenBalanceSelected.address,
+      ContractFuncName.Transfer,
+      callData,
+      currentAccount.address,
+      gasFees.suggestedMaxFee,
+      chainId,
+      selectedFeeToken,
+    )
+      .then((result) => {
+        if (result) {
+          toastr.success('Transaction sent successfully');
+          getTransactions(
+            currentAccount.address,
+            wallet.erc20TokenBalanceSelected.address,
+            10,
+            chainId,
+            false,
+            true,
+          ).catch((err) => {
+            console.error(
+              `handleConfirmClick: error from getTransactions: ${err}`,
+            );
+          });
+        } else {
+          toastr.info('Transaction rejected by user');
+        }
+      })
+      .catch(() => {
+        toastr.error('Error while sending the transaction');
+      });
+    closeModal && closeModal();
   };
 
   const totalAmountDisplay = () => {

--- a/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.view.tsx
@@ -38,7 +38,7 @@ export const SideBarView = () => {
   const [addTokenOpen, setAddTokenOpen] = useState(false);
   const { getStarkName } = useStarkNetSnap();
   const [starkName, setStarkName] = useState<string | undefined>(undefined);
-  const address = currentAccount?.address ?? DUMMY_ADDRESS;
+  const address = currentAccount.address;
   const addressIndex = currentAccount?.addressIndex ?? 0;
   const ref = useRef<HTMLDivElement>();
 

--- a/packages/wallet-ui/src/slices/walletSlice.ts
+++ b/packages/wallet-ui/src/slices/walletSlice.ts
@@ -3,13 +3,14 @@ import { Account } from 'types';
 import { Erc20TokenBalance } from 'types';
 import { Transaction } from 'types';
 import { ethers } from 'ethers';
+import { DUMMY_ADDRESS } from 'utils/constants';
 
 export interface WalletState {
   connected: boolean;
   isLoading: boolean;
   forceReconnect: boolean;
   accounts: Account[];
-  currentAccount?: Account;
+  currentAccount: Account;
   erc20TokenBalances: Erc20TokenBalance[];
   erc20TokenBalanceSelected: Erc20TokenBalance;
   transactions: Transaction[];
@@ -22,7 +23,10 @@ const initialState: WalletState = {
   isLoading: false,
   forceReconnect: false,
   accounts: [],
-  currentAccount: undefined,
+  currentAccount: {
+    address: DUMMY_ADDRESS,
+    addressIndex: 0,
+  } as Account,
   erc20TokenBalances: [],
   erc20TokenBalanceSelected: {} as Erc20TokenBalance,
   transactions: [],
@@ -122,7 +126,10 @@ export const walletSlice = createSlice({
     },
     clearAccounts: (state) => {
       state.accounts = [];
-      state.currentAccount = undefined;
+      state.currentAccount = {
+        address: DUMMY_ADDRESS,
+        addressIndex: 0,
+      } as Account;
     },
     resetWallet: (state) => {
       return {


### PR DESCRIPTION
This PR is to remove the many use of DUMMY_ADDRESS throughout the code base by using a dummy account at the redux state level. 