### PR TITLE
chore: refine account service

### DIFF
--- a/packages/starknet-snap/src/config.ts
+++ b/packages/starknet-snap/src/config.ts
@@ -38,7 +38,7 @@ export type SnapConfig = {
   };
   account: {
     defaultAccountIndex: number;
-  }
+  };
 };
 
 export enum DataClient {
@@ -96,5 +96,5 @@ export const Config: SnapConfig = {
 
   account: {
     defaultAccountIndex: 0,
-  }
+  },
 };

--- a/packages/starknet-snap/src/config.ts
+++ b/packages/starknet-snap/src/config.ts
@@ -36,6 +36,9 @@ export type SnapConfig = {
       txnsInLastNumOfDays: number;
     };
   };
+  account: {
+    defaultAccountIndex: number;
+  }
 };
 
 export enum DataClient {
@@ -90,4 +93,8 @@ export const Config: SnapConfig = {
     STRK_MAINNET,
     STRK_SEPOLIA_TESTNET,
   ],
+
+  account: {
+    defaultAccountIndex: 0,
+  }
 };

--- a/packages/starknet-snap/src/rpcs/add-account.ts
+++ b/packages/starknet-snap/src/rpcs/add-account.ts
@@ -1,6 +1,6 @@
 import { type Infer } from 'superstruct';
 
-import { BaseRequestStruct, AccountStruct, logger } from '../utils';
+import { BaseRequestStruct, AccountStruct } from '../utils';
 import { createAccountService } from '../utils/factory';
 import { ChainRpcController } from './abstract/chain-rpc-controller';
 
@@ -36,17 +36,7 @@ export class AddAccountRpc extends ChainRpcController<
   ): Promise<AddAccountResponse> {
     const accountService = createAccountService(this.network);
 
-    const account = await accountService.deriveAccountByIndex();
-
-    try {
-      // after derive an account, the current account will switch to the new account.
-      // however if the account is failed to switch,
-      // it is better not to throw an error to maintain the user experience.
-      await accountService.switchAccount(this.network.chainId, account);
-    } catch (error) {
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      logger.warn(`Failed to switch account: ${error.message}`);
-    }
+    const account = await accountService.addAccount();
 
     return account.serialize() as unknown as AddAccountResponse;
   }

--- a/packages/starknet-snap/src/rpcs/switch-account.test.ts
+++ b/packages/starknet-snap/src/rpcs/switch-account.test.ts
@@ -41,7 +41,7 @@ describe('SwitchAccountRpc', () => {
     const result = await switchAccount.execute(request);
 
     expect(result).toStrictEqual(await account.serialize());
-    expect(switchAccountSpy).toHaveBeenCalledWith(network.chainId, account);
+    expect(switchAccountSpy).toHaveBeenCalledWith(account);
   });
 
   it('throws `InvalidRequestParamsError` when request parameter is not correct', async () => {

--- a/packages/starknet-snap/src/rpcs/switch-account.ts
+++ b/packages/starknet-snap/src/rpcs/switch-account.ts
@@ -37,11 +37,12 @@ export class SwitchAccountRpc extends AccountRpcController<
    * @returns A promise that resolves to the switched account.
    */
   protected async handleRequest(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     params: SwitchAccountParams,
   ): Promise<SwitchAccountResponse> {
     const accountService = createAccountService(this.network);
 
-    await accountService.switchAccount(params.chainId, this.account);
+    await accountService.switchAccount(this.account);
 
     return (await this.account.serialize()) as unknown as SwitchAccountResponse;
   }

--- a/packages/starknet-snap/src/state/__tests__/helper.ts
+++ b/packages/starknet-snap/src/state/__tests__/helper.ts
@@ -93,9 +93,9 @@ export const mockAccountStateManager = () => {
     AccountStateManager.prototype,
     'getNextIndex',
   );
-  const upsertAccountSpy = jest.spyOn(
+  const updateAccountByAddressSpy = jest.spyOn(
     AccountStateManager.prototype,
-    'upsertAccount',
+    'updateAccountByAddress',
   );
   const getCurrentAccountSpy = jest.spyOn(
     AccountStateManager.prototype,
@@ -103,15 +103,22 @@ export const mockAccountStateManager = () => {
   );
   const switchAccountSpy = jest.spyOn(
     AccountStateManager.prototype,
-    'switchAccount',  
+    'switchAccount',
+  );
+  const addAccountSpy = jest.spyOn(AccountStateManager.prototype, 'addAccount');
+  const setCurrentAccountSpy = jest.spyOn(
+    AccountStateManager.prototype,
+    'setCurrentAccount',
   );
 
   return {
+    setCurrentAccountSpy,
     getCurrentAccountSpy,
     getAccountSpy,
     getNextIndexSpy,
-    upsertAccountSpy,
+    updateAccountByAddressSpy,
     switchAccountSpy,
+    addAccountSpy,
   };
 };
 

--- a/packages/starknet-snap/src/state/__tests__/helper.ts
+++ b/packages/starknet-snap/src/state/__tests__/helper.ts
@@ -97,11 +97,21 @@ export const mockAccountStateManager = () => {
     AccountStateManager.prototype,
     'upsertAccount',
   );
+  const getCurrentAccountSpy = jest.spyOn(
+    AccountStateManager.prototype,
+    'getCurrentAccount',
+  );
+  const switchAccountSpy = jest.spyOn(
+    AccountStateManager.prototype,
+    'switchAccount',  
+  );
 
   return {
+    getCurrentAccountSpy,
     getAccountSpy,
     getNextIndexSpy,
     upsertAccountSpy,
+    switchAccountSpy,
   };
 };
 

--- a/packages/starknet-snap/src/state/account-state-manager.test.ts
+++ b/packages/starknet-snap/src/state/account-state-manager.test.ts
@@ -25,7 +25,7 @@ describe('AccountStateManager', () => {
   };
 
   describe('getAccount', () => {
-    it('returns the account', async () => {
+    it('returns the account by address', async () => {
       const accountsInTestnet = await generateTestnetAccounts();
       await mockStateWithMainnetAccounts(accountsInTestnet);
 
@@ -38,7 +38,20 @@ describe('AccountStateManager', () => {
       expect(result).toStrictEqual(accountsInTestnet[0]);
     });
 
-    it('returns null if the account address can not be found', async () => {
+    it('returns the account by index', async () => {
+      const accountsInTestnet = await generateTestnetAccounts();
+      await mockStateWithMainnetAccounts(accountsInTestnet);
+
+      const stateManager = new AccountStateManager();
+      const result = await stateManager.getAccount({
+        addressIndex: accountsInTestnet[0].addressIndex,
+        chainId: testnetChainId,
+      });
+
+      expect(result).toStrictEqual(accountsInTestnet[0]);
+    });
+
+    it('returns null if the account can not be found', async () => {
       const [accountNotExist, ...accounts] = await generateTestnetAccounts();
       await mockStateWithMainnetAccounts(accounts);
 
@@ -62,6 +75,18 @@ describe('AccountStateManager', () => {
       });
 
       expect(result).toBeNull();
+    });
+
+    it('throws a `Address or addressIndex must be provided` error if both `addressIndex` and `address` have not provided', async () => {
+      const accountsInTestnet = await generateTestnetAccounts();
+      await mockStateWithMainnetAccounts(accountsInTestnet);
+
+      const stateManager = new AccountStateManager();
+      await expect(
+        stateManager.getAccount({
+          chainId: testnetChainId,
+        }),
+      ).rejects.toThrow('Address or addressIndex must be provided');
     });
   });
 
@@ -96,20 +121,39 @@ describe('AccountStateManager', () => {
     });
   });
 
-  describe('upsertAccount', () => {
-    it('adds an account if the account does not exist', async () => {
-      const [account] = await generateTestnetAccounts(1);
-      const state = await mockStateWithMainnetAccounts();
-      const originalAccountsFromState = [...state.accContracts];
+  describe('addAccount', () => {
+    it('add the account if the account does not exist', async () => {
+      const [newAccount, ...accounts] = await generateTestnetAccounts();
+
+      const state = await mockStateWithMainnetAccounts(accounts);
+      const originalAccountsLength = state.accContracts.length;
 
       const stateManager = new AccountStateManager();
-      await stateManager.upsertAccount(account);
+      await stateManager.addAccount(newAccount);
 
-      expect(state.accContracts).toStrictEqual(
-        originalAccountsFromState.concat([account]),
-      );
+      expect(state.accContracts).toHaveLength(originalAccountsLength + 1);
+      expect(
+        state.accContracts.find(
+          (acc) =>
+            acc.address === newAccount.address &&
+            acc.chainId === newAccount.chainId,
+        ),
+      ).toStrictEqual(newAccount);
     });
 
+    it('throws a `Account already exists` error if the account already exist', async () => {
+      const accounts = await generateTestnetAccounts(1);
+      await mockStateWithMainnetAccounts(accounts);
+
+      const stateManager = new AccountStateManager();
+
+      await expect(stateManager.addAccount(accounts[0])).rejects.toThrow(
+        'Account already exists',
+      );
+    });
+  });
+
+  describe('updateAccountByAddress', () => {
     it('updates the account if the account is found', async () => {
       const accounts = await generateTestnetAccounts();
       const updatedAccount = {
@@ -120,7 +164,7 @@ describe('AccountStateManager', () => {
       const originalAccountsLength = state.accContracts.length;
 
       const stateManager = new AccountStateManager();
-      await stateManager.upsertAccount(updatedAccount);
+      await stateManager.updateAccountByAddress(updatedAccount);
 
       expect(state.accContracts).toHaveLength(originalAccountsLength);
       expect(
@@ -130,6 +174,17 @@ describe('AccountStateManager', () => {
             acc.chainId === updatedAccount.chainId,
         ),
       ).toStrictEqual(updatedAccount);
+    });
+
+    it('throws `Account does not exists` error if the account does not exist', async () => {
+      const [account] = await generateTestnetAccounts(1);
+      await mockStateWithMainnetAccounts();
+
+      const stateManager = new AccountStateManager();
+
+      await expect(
+        stateManager.updateAccountByAddress(account),
+      ).rejects.toThrow('Account does not exists');
     });
   });
 
@@ -328,30 +383,19 @@ describe('AccountStateManager', () => {
     };
 
     it('switches the current account', async () => {
-      const { testnetCurrentAccount, state } = await setupSwitchAccountTest();
-      // simulate the account to switch for that contains updated data.
-      const updatedAccountToSwitch = {
-        ...testnetCurrentAccount,
-        upgradeRequired: true,
-      };
+      const { testnetCurrentAccount: accountToSwitch, state } =
+        await setupSwitchAccountTest();
 
       const stateManager = new AccountStateManager();
       await stateManager.switchAccount({
         chainId: testnetChainId,
-        accountToSwitch: updatedAccountToSwitch,
+        accountToSwitch,
       });
-
-      const updatedAccountFromState = state.accContracts.find(
-        (acc) =>
-          acc.chainId === updatedAccountToSwitch.chainId &&
-          acc.address === updatedAccountToSwitch.address,
-      );
 
       expect(state.currentAccount).toHaveProperty(testnetChainId);
       expect(state.currentAccount[testnetChainId]).toStrictEqual(
-        updatedAccountToSwitch,
+        accountToSwitch,
       );
-      expect(updatedAccountFromState).toStrictEqual(updatedAccountToSwitch);
     });
 
     it.each([
@@ -416,6 +460,21 @@ describe('AccountStateManager', () => {
         }),
       ).rejects.toThrow(
         new StateManagerError('Account to switch is not in the same chain'),
+      );
+    });
+  });
+
+  describe('setCurrentAccount', () => {
+    it('sets the current account', async () => {
+      const [testnetCurrentAccount] = await generateTestnetAccounts();
+      const state = await mockStateWithMainnetAccounts([testnetCurrentAccount]);
+
+      const stateManager = new AccountStateManager();
+      await stateManager.setCurrentAccount(testnetCurrentAccount);
+
+      expect(state.currentAccount).toHaveProperty(testnetChainId);
+      expect(state.currentAccount[testnetChainId]).toStrictEqual(
+        testnetCurrentAccount,
       );
     });
   });

--- a/packages/starknet-snap/src/state/account-state-manager.ts
+++ b/packages/starknet-snap/src/state/account-state-manager.ts
@@ -3,10 +3,18 @@ import type { IFilter } from './filter';
 import {
   AddressFilter as BaseAddressFilter,
   ChainIdFilter as BaseChainIdFilter,
+  NumberFilter,
 } from './filter';
 import { StateManager, StateManagerError } from './state-manager';
 
 export type IAccountFilter = IFilter<AccContract>;
+
+export class AddressIndexFilter
+  extends NumberFilter<AccContract>
+  implements IAccountFilter
+{
+  dataKey = 'addressIndex';
+}
 
 export class AddressFilter
   extends BaseAddressFilter<AccContract>
@@ -42,25 +50,42 @@ export class AccountStateManager extends StateManager<AccContract> {
    * Finds an account in the state that matches the given address and chain ID.
    *
    * @param param - An object containing the address and chain ID to search for.
-   * @param param.address - The address of the account to search for.
    * @param param.chainId - The chain ID of the account to search for.
+   * @param [param.address] - The address of the account to search for.
+   * @param [param.addressIndex] - The address index of the account to search for.
    * @param [state] - The optional SnapState object.
    * @returns A Promise that resolves with the matching AccContract object if found, or null if not found.
+   * @throws {StateManagerError} If both address and addressIndex is not provided.
    */
   async getAccount(
     {
       address,
       chainId,
+      addressIndex,
     }: {
-      address: string;
+      address?: string;
+      addressIndex?: number;
       chainId: string;
     },
     state?: SnapState,
   ): Promise<AccContract | null> {
-    return this.find(
-      [new AddressFilter([address]), new ChainIdFilter([chainId])],
-      state,
-    );
+    try {
+      if (address === undefined && addressIndex === undefined) {
+        throw new Error(`Address or addressIndex must be provided`);
+      }
+
+      const filters: IAccountFilter[] = [new ChainIdFilter([chainId])];
+      if (address !== undefined) {
+        filters.push(new AddressFilter([address]));
+      }
+      if (addressIndex !== undefined) {
+        filters.push(new AddressIndexFilter([addressIndex]));
+      }
+
+      return this.find(filters, state);
+    } catch (error) {
+      throw new StateManagerError(error.message);
+    }
   }
 
   /**
@@ -89,27 +114,53 @@ export class AccountStateManager extends StateManager<AccContract> {
   }
 
   /**
-   * Upserts an account in the state.
+   * Update an account by address in the state.
    *
-   * @param data - The AccContract object to upsert.
-   * @throws {StateManagerError} If an error occurs while updating the state.
+   * @param account - The AccContract object to update.
+   * @throws {StateManagerError} If the account does not exist in the state.
    */
-  async upsertAccount(data: AccContract): Promise<void> {
+  async updateAccountByAddress(account: AccContract): Promise<void> {
     try {
       await this.update(async (state: SnapState) => {
+        const { chainId, address } = account;
+
         const accountInState = await this.getAccount(
           {
-            address: data.address,
-            chainId: data.chainId,
+            address,
+            chainId,
           },
           state,
         );
 
-        if (accountInState) {
-          this.updateEntity(accountInState, data);
-        } else {
-          state.accContracts.push(data);
+        if (!accountInState) {
+          throw new Error(`Account does not exists`);
         }
+
+        this.updateEntity(accountInState, account);
+      });
+    } catch (error) {
+      throw new StateManagerError(error.message);
+    }
+  }
+
+  /**
+   * Add an account in the state.
+   *
+   * @param account - The AccContract object to add.
+   * @throws {StateManagerError} If an error occurs while updating the state.
+   */
+  async addAccount(account: AccContract): Promise<void> {
+    try {
+      await this.update(async (state: SnapState) => {
+        const { chainId, address, addressIndex } = account;
+
+        if (
+          await this.isAccountExist({ address, addressIndex, chainId }, state)
+        ) {
+          throw new Error(`Account already exists`);
+        }
+
+        state.accContracts.push(account);
       });
     } catch (error) {
       throw new StateManagerError(error.message);
@@ -153,14 +204,11 @@ export class AccountStateManager extends StateManager<AccContract> {
    * The next index is referring to the length of `accContracts` for the chain ID is used.
    *
    * @param chainId - The chain ID.
+   * @param state
    * @returns A Promise that resolves to the next index.
    */
-  async getNextIndex(chainId: string): Promise<number> {
-    let idx = 0;
-    await this.update(async (state: SnapState) => {
-      idx = (await this.findAccounts({ chainId }, state)).length;
-    });
-    return idx;
+  async getNextIndex(chainId: string, state?: SnapState): Promise<number> {
+    return (await this.findAccounts({ chainId }, state)).length;
   }
 
   /**
@@ -187,7 +235,7 @@ export class AccountStateManager extends StateManager<AccContract> {
   }): Promise<void> {
     try {
       await this.update(async (state: SnapState) => {
-        const accountInState = await this.getAccount(
+        const accountToHideFromState = await this.getAccount(
           {
             address,
             chainId,
@@ -195,27 +243,28 @@ export class AccountStateManager extends StateManager<AccContract> {
           state,
         );
 
-        if (!accountInState) {
-          throw new StateManagerError(`Account does not exist`);
+        if (!accountToHideFromState) {
+          throw new Error(`Account does not exist`);
         }
 
-        accountInState.visibility = visibility;
+        accountToHideFromState.visibility = visibility;
 
-        // if the current account is the account to be hide,
-        // switch to the next visible account
-        if (!this.#isAccountVisible(accountInState)) {
+        // if the current account is the account to hide, switch to the next visible account
+        if (!this.#isAccountVisible(accountToHideFromState)) {
           const currentAccount = await this.getCurrentAccount(
-            { chainId: accountInState.chainId },
+            { chainId },
             state,
           );
 
-          if (currentAccount?.addressIndex === accountInState.addressIndex) {
+          if (
+            currentAccount?.addressIndex === accountToHideFromState.addressIndex
+          ) {
             const accountToSwitch = await this.#getNextVisibleAccount(
-              accountInState,
+              accountToHideFromState,
               state,
             );
             if (!accountToSwitch) {
-              throw new StateManagerError(
+              throw new Error(
                 `No visible accounts found, at least one account should be visible`,
               );
             }
@@ -350,19 +399,44 @@ export class AccountStateManager extends StateManager<AccContract> {
         }
 
         this.#setCurrentAccount(accountToSwitch, state);
-
-        // due to the account may contains legacy data,
-        // this is a hack to ensure the account is updated
-        this.updateEntity(accountInState, accountToSwitch);
       });
     } catch (error) {
       throw new StateManagerError(error.message);
     }
   }
 
+  async isAccountExist(
+    {
+      address,
+      addressIndex,
+      chainId,
+    }: { address: string; addressIndex: number; chainId: string },
+    state,
+  ): Promise<boolean> {
+    const snapState = state ?? (await this.get());
+    return (
+      this.getCollection(snapState).find(
+        (data) =>
+          (data.address === address || data.addressIndex === addressIndex) &&
+          data.chainId === chainId,
+      ) !== undefined
+    );
+  }
+
   #setCurrentAccount(account: AccContract, state: SnapState) {
     const { chainId } = account;
     state.currentAccount = state.currentAccount ?? {};
     state.currentAccount[chainId] = account;
+  }
+
+  /**
+   * Sets the current account for the specified chain ID without processing swtichAccount logic.
+   *
+   * @param account - The `AccContract` object to set as the current account.
+   */
+  async setCurrentAccount(account: AccContract): Promise<void> {
+    await this.update(async (state: SnapState) => {
+      this.#setCurrentAccount(account, state);
+    });
   }
 }

--- a/packages/starknet-snap/src/utils/exceptions.ts
+++ b/packages/starknet-snap/src/utils/exceptions.ts
@@ -113,3 +113,9 @@ export class InsufficientFundsError extends SnapError {
     super(message ?? 'Insufficient Funds');
   }
 }
+
+export class AccountMissMatchError extends SnapError {
+  constructor(message?: string) {
+    super(message ?? 'Account address does not match the address in the state');
+  }
+}

--- a/packages/starknet-snap/src/wallet/account/service.test.ts
+++ b/packages/starknet-snap/src/wallet/account/service.test.ts
@@ -2,10 +2,13 @@ import { generateMnemonic } from 'bip39';
 
 import { AccountService } from '.';
 import { generateKeyDeriver } from '../../__tests__/helper';
+import { Config } from '../../config';
 import { mockAccountStateManager } from '../../state/__tests__/helper';
-import { AccountStateManager } from '../../state/account-state-manager';
 import { STARKNET_SEPOLIA_TESTNET_NETWORK } from '../../utils/constants';
-import { AccountNotFoundError } from '../../utils/exceptions';
+import {
+  AccountMissMatchError,
+  AccountNotFoundError,
+} from '../../utils/exceptions';
 import { createAccountService } from '../../utils/factory';
 import * as snapUtils from '../../utils/snap';
 import {
@@ -57,60 +60,22 @@ describe('AccountService', () => {
       );
       await mockSnapDeriver(mnemonicString);
 
-      const { getNextIndexSpy, upsertAccountSpy } = mockAccountStateManager();
-
       mockAccountContractReader({});
 
-      getNextIndexSpy.mockResolvedValue(hdIndex);
-
       return {
-        upsertAccountSpy,
-        getNextIndexSpy,
         getCairoContractSpy,
         account: accountObj,
       };
     };
 
-    it('derives an account with the auto increment index', async () => {
-      const hdIndex = 0;
-      const {
-        getNextIndexSpy,
-        getCairoContractSpy,
-        upsertAccountSpy,
-        account,
-      } = await setupDeriveAccountByIndexTest(hdIndex);
-
-      const service = createAccountService(network);
-      const result = await service.deriveAccountByIndex();
-
-      expect(getNextIndexSpy).toHaveBeenCalled();
-      expect(upsertAccountSpy).toHaveBeenCalledWith(await result.serialize());
-      expect(getCairoContractSpy).toHaveBeenCalledWith(account.publicKey);
-      expect(result).toBeInstanceOf(Account);
-      expect(result).toHaveProperty('accountContract', account.accountContract);
-      expect(result).toHaveProperty('address', account.address);
-      expect(result).toHaveProperty('chainId', account.chainId);
-      expect(result).toHaveProperty('privateKey', account.privateKey);
-      expect(result).toHaveProperty('publicKey', account.publicKey);
-      expect(result).toHaveProperty('hdIndex', hdIndex);
-      expect(result).toHaveProperty('addressSalt', account.publicKey);
-      expect(result).toHaveProperty('metadata', DefaultAccountMetaData);
-    });
-
     it('derives an account with the given index', async () => {
       const hdIndex = 2;
-      const {
-        getNextIndexSpy,
-        getCairoContractSpy,
-        account,
-        upsertAccountSpy,
-      } = await setupDeriveAccountByIndexTest(hdIndex);
+      const { getCairoContractSpy, account } =
+        await setupDeriveAccountByIndexTest(hdIndex);
 
       const service = createAccountService(network);
       const result = await service.deriveAccountByIndex(hdIndex);
 
-      expect(getNextIndexSpy).not.toHaveBeenCalled();
-      expect(upsertAccountSpy).toHaveBeenCalledWith(await result.serialize());
       expect(getCairoContractSpy).toHaveBeenCalledWith(account.publicKey);
       expect(result).toBeInstanceOf(Account);
       expect(result).toHaveProperty('accountContract', account.accountContract);
@@ -141,14 +106,16 @@ describe('AccountService', () => {
 
   describe('deriveAccountFromAddress', () => {
     const setupDeriveAccountByAddressTest = async () => {
-      const getAccountSpy = jest.spyOn(
-        AccountStateManager.prototype,
-        'getAccount',
-      );
       const deriveAccountByIndexSpy = jest.spyOn(
         AccountService.prototype,
         'deriveAccountByIndex',
       );
+
+      const { updateAccountByAddressSpy, getAccountSpy } =
+        mockAccountStateManager();
+
+      updateAccountByAddressSpy.mockReturnThis();
+
       mockAccountContractReader({});
 
       const { accountObj: account } = await createAccountObject(network, 0);
@@ -158,25 +125,26 @@ describe('AccountService', () => {
       return {
         deriveAccountByIndexSpy,
         getAccountSpy,
+        updateAccountByAddressSpy,
         account,
       };
     };
 
     it('derives an account by address', async () => {
-      const { getAccountSpy, deriveAccountByIndexSpy, account } =
-        await setupDeriveAccountByAddressTest();
+      const {
+        getAccountSpy,
+        updateAccountByAddressSpy,
+        deriveAccountByIndexSpy,
+        account,
+      } = await setupDeriveAccountByAddressTest();
 
-      const jsonData = {
-        ...(await account.serialize()),
-        visibility: false,
-      };
-
-      getAccountSpy.mockResolvedValue(jsonData);
+      const jsonData = await account.serialize();
 
       const service = createAccountService(network);
       await service.deriveAccountByAddress(account.address);
 
       expect(getAccountSpy).toHaveBeenCalled();
+      expect(updateAccountByAddressSpy).toHaveBeenCalledWith(jsonData);
       expect(deriveAccountByIndexSpy).toHaveBeenCalledWith(
         account.hdIndex,
         jsonData,
@@ -195,16 +163,30 @@ describe('AccountService', () => {
         service.deriveAccountByAddress(account.address),
       ).rejects.toThrow(AccountNotFoundError);
     });
+
+    it('throws `AccountMissMatchError` if the derived address is not match with state', async () => {
+      const { account, deriveAccountByIndexSpy } =
+        await setupDeriveAccountByAddressTest();
+
+      const { accountObj: accountWithDifferentAddress } =
+        await createAccountObject(network, 1);
+
+      deriveAccountByIndexSpy.mockResolvedValue(accountWithDifferentAddress);
+
+      const service = createAccountService(network);
+
+      await expect(
+        service.deriveAccountByAddress(account.address),
+      ).rejects.toThrow(AccountMissMatchError);
+    });
   });
 
   describe('getCurrentAccount', () => {
     // To test the case when the account is not selected,
-    // make sure the mock account is not derived from 0.
-    const setupGetCurrentAccountTest = async (hdIndex = 1) => {
-      const getCurrentAccountSpy = jest.spyOn(
-        AccountStateManager.prototype,
-        'getCurrentAccount',
-      );
+    const setupGetCurrentAccountTest = async ({ hdIndex }) => {
+      const { addAccountSpy, getCurrentAccountSpy, getAccountSpy } =
+        mockAccountStateManager();
+
       const deriveAccountByIndexSpy = jest.spyOn(
         AccountService.prototype,
         'deriveAccountByIndex',
@@ -212,68 +194,119 @@ describe('AccountService', () => {
       mockAccountContractReader({});
 
       const { accountObj } = await createAccountObject(network, hdIndex);
-      getCurrentAccountSpy.mockResolvedValue(await accountObj.serialize());
+      const accountJsonData = await accountObj.serialize();
+
       deriveAccountByIndexSpy.mockResolvedValue(accountObj);
+      getCurrentAccountSpy.mockResolvedValue(accountJsonData);
+      getAccountSpy.mockResolvedValue(accountJsonData);
+      addAccountSpy.mockReturnThis();
 
       return {
         deriveAccountByIndexSpy,
         getCurrentAccountSpy,
+        addAccountSpy,
+        getAccountSpy,
         accountObj,
       };
     };
 
-    it('returns the selected `Account` object', async () => {
-      const { accountObj, getCurrentAccountSpy, deriveAccountByIndexSpy } =
-        await setupGetCurrentAccountTest();
+    it('returns the selected `Account` object if the current account has been set', async () => {
+      const { accountObj, addAccountSpy, deriveAccountByIndexSpy } =
+        await setupGetCurrentAccountTest({ hdIndex: 1 });
+      const accountJsonData = await accountObj.serialize();
 
       const service = createAccountService(network);
       const result = await service.getCurrentAccount();
 
+      expect(result).toStrictEqual(accountObj);
+      expect(addAccountSpy).not.toHaveBeenCalled();
       expect(deriveAccountByIndexSpy).toHaveBeenCalledWith(
         result.hdIndex,
-        await accountObj.serialize(),
+        accountJsonData,
       );
-      expect(getCurrentAccountSpy).toHaveBeenCalledWith({
-        chainId: accountObj.chainId,
-      });
-      expect(result).toStrictEqual(accountObj);
     });
 
-    it('returns a `Account` object that derived from index 0 if no account selected', async () => {
-      const defaultIndex = 0;
-      const { accountObj, getCurrentAccountSpy, deriveAccountByIndexSpy } =
-        await setupGetCurrentAccountTest(defaultIndex);
+    it('returns a `Account` object that derived from index 0 if the current account has not been set', async () => {
+      const defaultIndex = Config.account.defaultAccountIndex;
+      const {
+        accountObj,
+        getCurrentAccountSpy,
+        deriveAccountByIndexSpy,
+        getAccountSpy,
+        addAccountSpy,
+      } = await setupGetCurrentAccountTest({ hdIndex: defaultIndex });
+      // Simulate the case when the current account has not been set.
       getCurrentAccountSpy.mockResolvedValue(null);
+      getAccountSpy.mockResolvedValue(null);
+      const accountJsonData = await accountObj.serialize();
 
       const service = createAccountService(network);
       const result = await service.getCurrentAccount();
 
+      expect(result).toStrictEqual(accountObj);
+      expect(result.hdIndex).toStrictEqual(defaultIndex);
+      expect(addAccountSpy).toHaveBeenCalledWith(accountJsonData);
       expect(deriveAccountByIndexSpy).toHaveBeenCalledWith(
         defaultIndex,
         undefined,
       );
-      expect(result).toStrictEqual(accountObj);
-      expect(result.hdIndex).toStrictEqual(defaultIndex);
+    });
+
+    it('throws `AccountNotFoundError` if the current account is set but the account does not exist from state', async () => {
+      const defaultIndex = Config.account.defaultAccountIndex;
+      const { getAccountSpy } = await setupGetCurrentAccountTest({
+        hdIndex: defaultIndex,
+      });
+      // Simulate the case when the current account is set, but the account does not exist from state.
+      getAccountSpy.mockResolvedValue(null);
+
+      const service = createAccountService(network);
+      await expect(service.getCurrentAccount()).rejects.toThrow(
+        AccountNotFoundError,
+      );
     });
   });
 
   describe('switchAccount', () => {
     it('switches the account for the network', async () => {
-      const switchAccountSpy = jest.spyOn(
-        AccountStateManager.prototype,
-        'switchAccount',
-      );
+      const { switchAccountSpy } = mockAccountStateManager();
       switchAccountSpy.mockResolvedValue();
       mockAccountContractReader({});
       const { accountObj } = await createAccountObject(network, 0);
 
       const service = createAccountService(network);
-      await service.switchAccount(accountObj.chainId, accountObj);
+      await service.switchAccount(accountObj);
 
       expect(switchAccountSpy).toHaveBeenCalledWith({
         chainId: accountObj.chainId,
         accountToSwitch: await accountObj.serialize(),
       });
+    });
+  });
+
+  describe('addAccount', () => {
+    it('addd the account for the network', async () => {
+      const { addAccountSpy, getNextIndexSpy, setCurrentAccountSpy } =
+        mockAccountStateManager();
+      const nextIndex = 1;
+      const deriveAccountByIndexSpy = jest.spyOn(
+        AccountService.prototype,
+        'deriveAccountByIndex',
+      );
+      addAccountSpy.mockReturnThis();
+      getNextIndexSpy.mockResolvedValue(nextIndex);
+      mockAccountContractReader({});
+      const { accountObj } = await createAccountObject(network, nextIndex);
+      deriveAccountByIndexSpy.mockResolvedValue(accountObj);
+      const accountJsonData = await accountObj.serialize();
+
+      const service = createAccountService(network);
+      const result = await service.addAccount();
+
+      expect(result).toStrictEqual(accountObj);
+      expect(addAccountSpy).toHaveBeenCalledWith(accountJsonData);
+      expect(setCurrentAccountSpy).toHaveBeenCalledWith(accountJsonData);
+      expect(deriveAccountByIndexSpy).toHaveBeenCalledWith(nextIndex);
     });
   });
 });

--- a/packages/starknet-snap/src/wallet/account/service.ts
+++ b/packages/starknet-snap/src/wallet/account/service.ts
@@ -152,6 +152,9 @@ export class AccountService {
 
       const accountJsonData = await account.serialize();
 
+      // While getting the current account,
+      // if the account is not found in the state, add it to the state.
+      // Otherwise, it is not necessary to update it to the state.
       if (accountInState === null) {
         await this.accountStateMgr.addAccount(accountJsonData);
         await this.accountStateMgr.setCurrentAccount(accountJsonData);
@@ -207,7 +210,7 @@ export class AccountService {
   /**
    * A safeguard to ensure the derived account address is match with the provided address.
    * Expecting the derived account should have the same address with the given one.
-   * 
+   *
    * @param account - The derived account.
    * @param address - The address to compare.
    * @throws `AccountMissMatchError` if the derived account address does not match the provided address.

--- a/packages/starknet-snap/src/wallet/account/service.ts
+++ b/packages/starknet-snap/src/wallet/account/service.ts
@@ -1,7 +1,11 @@
+import { Config } from '../../config';
 import { AccountStateManager } from '../../state/account-state-manager';
 import type { AccContract, Network } from '../../types/snapState';
-import { getBip44Deriver } from '../../utils';
-import { AccountNotFoundError } from '../../utils/exceptions';
+import { getBip44Deriver, logger } from '../../utils';
+import {
+  AccountMissMatchError,
+  AccountNotFoundError,
+} from '../../utils/exceptions';
 import { Account } from './account';
 import { AccountContractDiscovery } from './discovery';
 import { AccountKeyPair } from './keypair';
@@ -31,49 +35,37 @@ export class AccountService {
    * Derives a BIP44 node from an index and constructs a new `Account` object using the derived private key and public key.
    * The `Account` object is assigned a `CairoAccountContract` contract and is then serialized and persisted to the state.
    *
-   * @param [index] - Optional. The hd index to derive the account from. If not provided, the next index will be used.
+   * @param hdIndex - The hd index to derive the account from. If not provided, the next index will be used.
    * @param [jsonData] - Optional. The jsonData to assign to the account.
-   * @returns A promise that resolves to the newly created `Account` object.
+   * @returns A promise that resolves to a `Account` object.
    */
   async deriveAccountByIndex(
-    index?: number,
+    hdIndex: number,
     jsonData?: AccContract,
   ): Promise<Account> {
-    const { chainId } = this.network;
+    // Derive a BIP44 node from an index. e.g m/44'/60'/0'/0/{hdIndex}
+    const deriver = await getBip44Deriver();
+    const node = await deriver(hdIndex);
 
-    // use `withTransaction` to ensure that the state is not modified if an error occurs.
-    return this.accountStateMgr.withTransaction(async () => {
-      let hdIndex = index;
-      if (hdIndex === undefined) {
-        hdIndex = await this.accountStateMgr.getNextIndex(chainId);
-      }
+    // Grind a new private key and public key from the derived node.
+    // Private key and public key are independent from the account contract.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const { privateKey, publicKey } = new AccountKeyPair(node.privateKey!);
 
-      // Derive a BIP44 node from an index. e.g m/44'/60'/0'/0/{hdIndex}
-      const deriver = await getBip44Deriver();
-      const node = await deriver(hdIndex);
+    const accountContract =
+      await this.accountContractDiscoveryService.getContract(publicKey);
 
-      // Grind a new private key and public key from the derived node.
-      // Private key and public key are independent from the account contract.
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const { privateKey, publicKey } = new AccountKeyPair(node.privateKey!);
-
-      const accountContract =
-        await this.accountContractDiscoveryService.getContract(publicKey);
-
-      const account = new Account({
-        privateKey,
-        publicKey,
-        chainId: this.network.chainId,
-        hdIndex,
-        addressSalt: publicKey,
-        accountContract,
-        jsonData,
-      });
-
-      await this.accountStateMgr.upsertAccount(await account.serialize());
-
-      return account;
+    const account = new Account({
+      privateKey,
+      publicKey,
+      chainId: this.network.chainId,
+      hdIndex,
+      addressSalt: publicKey,
+      accountContract,
+      jsonData,
     });
+
+    return account;
   }
 
   /**
@@ -82,55 +74,147 @@ export class AccountService {
    *
    * @param address - The address of the account to derive.
    * @returns A promise that resolves to the derived `Account` object.
+   * @throws `AccountNotFoundError` if the account is not found in the state.
+   * @throws `AccountMissMatchError` if the derived account address does not match the provided address.
    */
   async deriveAccountByAddress(address: string): Promise<Account> {
-    const accountFromState = await this.accountStateMgr.getAccount({
-      address,
-      chainId: this.network.chainId,
-    });
+    return await this.accountStateMgr.withTransaction(async (state) => {
+      const accountFromState = await this.accountStateMgr.getAccount(
+        {
+          address,
+          chainId: this.network.chainId,
+        },
+        state,
+      );
 
-    if (accountFromState) {
-      return await this.deriveAccountByIndex(
+      if (!accountFromState) {
+        throw new AccountNotFoundError();
+      }
+
+      const account = await this.deriveAccountByIndex(
         accountFromState.addressIndex,
         accountFromState,
       );
-    }
 
-    throw new AccountNotFoundError();
+      this.ensureAccountAddressMatch(account, accountFromState.address);
+
+      // Ensure the derived account is in sync with the state.
+      await this.accountStateMgr.updateAccountByAddress(
+        await account.serialize(),
+      );
+
+      return account;
+    });
   }
 
   /**
    * Gets the selected account for the network.
-   * if there is no account selected, return an account with index 0.
+   * If there is no account selected, return an account with index 0.
    *
    * @returns A promise that resolves to a `Account` object.
    */
   async getCurrentAccount(): Promise<Account> {
-    const activeAccount = await this.accountStateMgr.getCurrentAccount({
-      chainId: this.network.chainId,
+    const { chainId } = this.network;
+
+    return await this.accountStateMgr.withTransaction(async (state) => {
+      const currentAccount = await this.accountStateMgr.getCurrentAccount(
+        {
+          chainId,
+        },
+        state,
+      );
+
+      // `currentAccount` may be absent if the account state is new / it was upgrade from a previous version, fallback to use the default account index.
+      const addressIndex =
+        currentAccount?.addressIndex ?? Config.account.defaultAccountIndex;
+
+      const accountInState = await this.accountStateMgr.getAccount(
+        {
+          chainId,
+          addressIndex,
+        },
+        state,
+      );
+
+      // Edge case, the account in the state should always exist if current account has set.
+      if (currentAccount && !accountInState) {
+        logger.error(
+          'Account in state is missing, but current account has been set.',
+        );
+        throw new AccountNotFoundError();
+      }
+
+      // In case the `currentAccount`'s metadata is out-of-date, derive the account with the data from state is more reliable.
+      const account = await this.deriveAccountByIndex(
+        addressIndex,
+        accountInState ?? undefined,
+      );
+
+      const accountJsonData = await account.serialize();
+
+      if (accountInState === null) {
+        await this.accountStateMgr.addAccount(accountJsonData);
+        await this.accountStateMgr.setCurrentAccount(accountJsonData);
+      } else {
+        this.ensureAccountAddressMatch(account, accountInState.address);
+      }
+
+      return account;
     });
-    // Active account only be undefined if the account state is new.
-    // In that case, we will derive a index 0 account with default metadata.
-    return await this.deriveAccountByIndex(
-      activeAccount ? activeAccount.addressIndex : 0,
-      activeAccount ?? undefined,
-    );
   }
 
   /**
    * Switches the account for the network.
    * The account to switch must be in the same chain.
    *
-   * @param chainId - The chain ID.
    * @param accountToSwitch - The account to switch to.
    */
-  async switchAccount(
-    chainId: string,
-    accountToSwitch: Account,
-  ): Promise<void> {
+  async switchAccount(accountToSwitch: Account): Promise<void> {
+    const { chainId } = this.network;
+
     await this.accountStateMgr.switchAccount({
       chainId,
       accountToSwitch: await accountToSwitch.serialize(),
     });
+  }
+
+  /**
+   * Add a account for the network.
+   * And set the current account to the newly added account.
+   *
+   * @returns A promise that resolves to an `Account` object.
+   */
+  async addAccount(): Promise<Account> {
+    const { chainId } = this.network;
+
+    return await this.accountStateMgr.withTransaction(async (state) => {
+      const nextIndex = await this.accountStateMgr.getNextIndex(chainId, state);
+
+      const account = await this.deriveAccountByIndex(nextIndex);
+
+      const accountJsonData = await account.serialize();
+
+      await this.accountStateMgr.addAccount(accountJsonData);
+
+      // Always set the current account to the newly added account.
+      // Hence, the client side does not need to call `switchAccount` after adding a new account.
+      await this.accountStateMgr.setCurrentAccount(accountJsonData);
+
+      return account;
+    });
+  }
+
+  /**
+   * A safeguard to ensure the derived account address is match with the provided address.
+   * Expecting the derived account should have the same address with the given one.
+   * 
+   * @param account - The derived account.
+   * @param address - The address to compare.
+   * @throws `AccountMissMatchError` if the derived account address does not match the provided address.
+   */
+  protected ensureAccountAddressMatch(account: Account, address: string): void {
+    if (account.address !== address) {
+      throw new AccountMissMatchError();
+    }
   }
 }


### PR DESCRIPTION
This PR is to refine the account service and fix some edge case bug

### Changes:
- It will be not longer auto update the account state from `deriveAccountByIndex`, instead the update process split into the workflow that using this method:
  - Update the account state after derive account by address to make sure it sync the data
  - Add the account to state when adding a new account
  - Add the account to state when get the current account if the current account not yet set
- Add validation to make sure the state can only store 1 address per account index 
- remove `upsertAccount` from AccountStateManager to replace by more specific purpose method -`updateAccountByAddress`,`addAccount`