### PR TITLE
fix: enhance performance by muting unnecessary state subscription in UI

### DIFF
--- a/packages/wallet-ui/src/App.tsx
+++ b/packages/wallet-ui/src/App.tsx
@@ -37,7 +37,7 @@ function App() {
   } = useAppSelector((state) => state.modals);
   const { loader } = useAppSelector((state) => state.UI);
   const networks = useAppSelector((state) => state.networks);
-  const { currentAccount } = useAppSelector((state) => state.wallet);
+  const currentAccount = useAppSelector((state) => state.wallet.currentAccount);
   const { hasMetamask } = useHasMetamask();
   const chainId = networks.items?.[networks.activeNetwork]?.chainId;
   const address = currentAccount.address;

--- a/packages/wallet-ui/src/App.tsx
+++ b/packages/wallet-ui/src/App.tsx
@@ -26,9 +26,10 @@ library.add(fas, far);
 function App() {
   const { initSnap, initWalletData, checkConnection, loadLocale } =
     useStarkNetSnap();
-  const { connected, forceReconnect, provider } = useAppSelector(
-    (state) => state.wallet,
-  );
+  const connected = useAppSelector((state) => state.wallet.connected);
+  const forceReconnect = useAppSelector((state) => state.wallet.forceReconnect);
+  const provider = useAppSelector((state) => state.wallet.provider);
+  const currentAccount = useAppSelector((state) => state.wallet.currentAccount);
   const {
     infoModalVisible,
     minVersionModalVisible,
@@ -37,7 +38,6 @@ function App() {
   } = useAppSelector((state) => state.modals);
   const { loader } = useAppSelector((state) => state.UI);
   const networks = useAppSelector((state) => state.networks);
-  const currentAccount = useAppSelector((state) => state.wallet.currentAccount);
   const { hasMetamask } = useHasMetamask();
   const chainId = networks.items?.[networks.activeNetwork]?.chainId;
   const address = currentAccount.address;

--- a/packages/wallet-ui/src/components/pages/Home/Home.view.tsx
+++ b/packages/wallet-ui/src/components/pages/Home/Home.view.tsx
@@ -6,12 +6,12 @@ import { useAppSelector } from 'hooks/redux';
 import { useMultiLanguage } from 'services';
 
 export const HomeView = () => {
-  const { erc20TokenBalanceSelected, transactions } = useAppSelector(
-    (state) => state.wallet,
+  const erc20TokenBalanceSelected = useAppSelector(
+    (state) => state.wallet.erc20TokenBalanceSelected,
   );
+  const transactions = useAppSelector((state) => state.wallet.transactions);
+  const { address } = useAppSelector((state) => state.wallet.currentAccount);
   const loader = useAppSelector((state) => state.UI.loader);
-  const currentAccount = useAppSelector((state) => state.wallet.currentAccount);
-  const address = currentAccount.address;
   const { upgradeModalVisible } = useAppSelector((state) => state.modals);
   const { translate } = useMultiLanguage();
 

--- a/packages/wallet-ui/src/components/ui/molecule/AssetsList/AssetsList.view.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/AssetsList/AssetsList.view.tsx
@@ -9,11 +9,16 @@ import { ASSETS_PRICE_REFRESH_FREQUENCY } from 'utils/constants';
 
 export const AssetsListView = () => {
   const { setErc20TokenBalance, refreshTokensUSDPrice } = useStarkNetSnap();
-  const wallet = useAppSelector((state) => state.wallet);
+  const erc20TokenBalances = useAppSelector(
+    (state) => state.wallet.erc20TokenBalances,
+  );
+  const erc20TokenBalanceSelected = useAppSelector(
+    (state) => state.wallet.erc20TokenBalanceSelected,
+  );
   const timeoutHandle = useRef(setTimeout(() => {}));
 
   useEffect(() => {
-    if (wallet.erc20TokenBalances?.length > 0) {
+    if (erc20TokenBalances?.length > 0) {
       clearTimeout(timeoutHandle.current); // cancel the timeout that was in-flight
       timeoutHandle.current = setTimeout(
         () => refreshTokensUSDPrice(),
@@ -22,7 +27,7 @@ export const AssetsListView = () => {
       return () => clearTimeout(timeoutHandle.current);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [wallet.erc20TokenBalances]);
+  }, [erc20TokenBalances]);
 
   const handleClick = (asset: Erc20TokenBalance) => {
     setErc20TokenBalance(asset);
@@ -30,12 +35,12 @@ export const AssetsListView = () => {
 
   return (
     <Wrapper<FC<IListProps<Erc20TokenBalance>>>
-      data={wallet.erc20TokenBalances}
+      data={erc20TokenBalances}
       render={(asset) => (
         <AssetListItem
           asset={asset}
           onClick={() => handleClick(asset)}
-          selected={wallet.erc20TokenBalanceSelected.address === asset.address}
+          selected={erc20TokenBalanceSelected.address === asset.address}
         />
       )}
       keyExtractor={(asset) => asset.address}

--- a/packages/wallet-ui/src/components/ui/molecule/TransactionsList/TransactionListItem/TransactionListItem.view.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/TransactionsList/TransactionListItem/TransactionListItem.view.tsx
@@ -40,19 +40,23 @@ function toCamelCase(str: string) {
 }
 
 export const TransactionListItemView = ({ transaction }: Props) => {
-  const wallet = useAppSelector((state) => state.wallet);
-  const tokenAddress = wallet.erc20TokenBalanceSelected.address;
+  const { translate } = useMultiLanguage();
+  const erc20TokenBalances = useAppSelector(
+    (state) => state.wallet.erc20TokenBalances,
+  );
+  const erc20TokenBalanceSelected = useAppSelector(
+    (state) => state.wallet.erc20TokenBalanceSelected,
+  );
+  const locale = useAppSelector((state) => state.wallet.locale);
   const [currencySymbol, setCurrencySymbol] = useState('N/A');
   const [txnValue, setTxnValue] = useState('0');
   const [txnUsdValue, setTxnUsdValue] = useState('0.00');
-  const { translate } = useMultiLanguage();
-
-  const { locale } = useAppSelector((state) => state.wallet);
+  const tokenAddress = erc20TokenBalanceSelected.address;
 
   useEffect(() => {
     const fetchData = async () => {
       // Find the matching token
-      const foundToken = wallet.erc20TokenBalances.find((token) =>
+      const foundToken = erc20TokenBalances.find((token) =>
         ethers.BigNumber.from(token.address).eq(
           ethers.BigNumber.from(tokenAddress),
         ),

--- a/packages/wallet-ui/src/components/ui/molecule/TransactionsList/TransactionsList.view.tsx
+++ b/packages/wallet-ui/src/components/ui/molecule/TransactionsList/TransactionsList.view.tsx
@@ -14,14 +14,15 @@ interface Props {
 export const TransactionsListView = ({ transactions }: Props) => {
   const { getTransactions } = useStarkNetSnap();
   const networks = useAppSelector((state) => state.networks);
-  const wallet = useAppSelector((state) => state.wallet);
+  const currentAccount = useAppSelector((state) => state.wallet.currentAccount);
+  const erc20TokenBalanceSelected = useAppSelector(
+    (state) => state.wallet.erc20TokenBalanceSelected,
+  );
+  const walletTransactions = useAppSelector(
+    (state) => state.wallet.transactions,
+  );
   const timeoutHandle = useRef(setTimeout(() => {}));
   const chainId = networks.items[networks.activeNetwork]?.chainId;
-  const {
-    currentAccount,
-    erc20TokenBalanceSelected,
-    transactions: walletTransactions,
-  } = wallet;
 
   useEffect(() => {
     if (chainId && erc20TokenBalanceSelected.address) {
@@ -69,7 +70,7 @@ export const TransactionsListView = ({ transactions }: Props) => {
 
   return (
     <Wrapper<FC<IListProps<Transaction>>>
-      data={transactions.length > 0 ? transactions : wallet.transactions}
+      data={transactions.length > 0 ? transactions : walletTransactions}
       render={(transaction) => (
         <TransactionListItem transaction={transaction} />
       )}

--- a/packages/wallet-ui/src/components/ui/organism/AccountSwitchModal/AccountSwitchModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AccountSwitchModal/AccountSwitchModal.view.tsx
@@ -28,8 +28,7 @@ export const AccountSwitchModalView = ({ full, starkName }: Props) => {
   const networks = useAppSelector((state) => state.networks);
   const currentAccount = useAppSelector((state) => state.wallet.currentAccount);
   const accounts = useAppSelector((state) => state.wallet.accounts);
-  const { switchAccount, hideAccount, unHideAccount } =
-    useStarkNetSnap();
+  const { switchAccount, hideAccount, unHideAccount } = useStarkNetSnap();
   const { translate } = useMultiLanguage();
   const chainId = networks?.items[networks.activeNetwork]?.chainId;
 

--- a/packages/wallet-ui/src/components/ui/organism/AccountSwitchModal/AccountSwitchModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AccountSwitchModal/AccountSwitchModal.view.tsx
@@ -24,7 +24,8 @@ interface Props {
 
 export const AccountSwitchModalView = ({ full, starkName }: Props) => {
   const networks = useAppSelector((state) => state.networks);
-  const { currentAccount, accounts } = useAppSelector((state) => state.wallet);
+  const currentAccount = useAppSelector((state) => state.wallet.currentAccount);
+  const accounts = useAppSelector((state) => state.wallet.accounts);
   const { switchAccount, addNewAccount, hideAccount, unHideAccount } =
     useStarkNetSnap();
   const { translate } = useMultiLanguage();

--- a/packages/wallet-ui/src/components/ui/organism/AddTokenModal/AddTokenModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AddTokenModal/AddTokenModal.view.tsx
@@ -27,7 +27,7 @@ export const AddTokenModalView = ({ closeModal }: Props) => {
   const { translate } = useMultiLanguage();
   const [enabled, setEnabled] = useState(false);
   const networks = useAppSelector((state) => state.networks);
-  const { currentAccount } = useAppSelector((state) => state.wallet);
+  const currentAccount = useAppSelector((state) => state.wallet.currentAccount);
   const chainId = networks?.items[networks.activeNetwork].chainId;
   const [isValidAddress, setIsValidAddress] = useState(false);
   const [fields, setFields] = useState({
@@ -36,6 +36,7 @@ export const AddTokenModalView = ({ closeModal }: Props) => {
     symbol: '',
     decimal: '',
   });
+
   const handleChange = (fieldName: string, fieldValue: string) => {
     setFields((prevFields) => ({
       ...prevFields,

--- a/packages/wallet-ui/src/components/ui/organism/Header/Header.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/Header/Header.view.tsx
@@ -17,27 +17,25 @@ interface Props {
 }
 
 export const HeaderView = ({ address }: Props) => {
+  const { updateTokenBalance } = useStarkNetSnap();
+  const { translate } = useMultiLanguage();
   const [receiveOpen, setReceiveOpen] = useState(false);
   const [sendOpen, setSendOpen] = useState(false);
   const networks = useAppSelector((state) => state.networks);
-  const wallet = useAppSelector((state) => state.wallet);
-  const { updateTokenBalance } = useStarkNetSnap();
-  const { translate } = useMultiLanguage();
+  const erc20TokenBalanceSelected = useAppSelector(
+    (state) => state.wallet.erc20TokenBalanceSelected,
+  );
   const timeoutHandle = useRef(setTimeout(() => {}));
 
   const getUSDValue = () => {
     const amountFloat = parseFloat(
       ethers.utils.formatUnits(
-        wallet.erc20TokenBalanceSelected.amount,
-        wallet.erc20TokenBalanceSelected.decimals,
+        erc20TokenBalanceSelected.amount,
+        erc20TokenBalanceSelected.decimals,
       ),
     );
-    if (wallet.erc20TokenBalanceSelected.usdPrice)
-      return getAmountPrice(
-        wallet.erc20TokenBalanceSelected,
-        amountFloat,
-        false,
-      );
+    if (erc20TokenBalanceSelected.usdPrice)
+      return getAmountPrice(erc20TokenBalanceSelected, amountFloat, false);
     return '';
   };
 
@@ -47,7 +45,7 @@ export const HeaderView = ({ address }: Props) => {
       clearTimeout(timeoutHandle.current); // cancel the timeout that was in-flight
       timeoutHandle.current = setTimeout(async () => {
         await updateTokenBalance(
-          wallet.erc20TokenBalanceSelected.address,
+          erc20TokenBalanceSelected.address,
           address,
           chain,
         );
@@ -55,7 +53,7 @@ export const HeaderView = ({ address }: Props) => {
       return () => clearTimeout(timeoutHandle.current);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [wallet.erc20TokenBalanceSelected]);
+  }, [erc20TokenBalanceSelected]);
 
   const handleSendClick = () => {
     setSendOpen(true);
@@ -65,10 +63,8 @@ export const HeaderView = ({ address }: Props) => {
     <Wrapper>
       <AssetQuantity
         USDValue={getUSDValue()}
-        currencyValue={getSpendableTotalBalance(
-          wallet.erc20TokenBalanceSelected,
-        )}
-        currency={wallet.erc20TokenBalanceSelected.symbol}
+        currencyValue={getSpendableTotalBalance(erc20TokenBalanceSelected)}
+        currency={erc20TokenBalanceSelected.symbol}
         size="big"
         centered
       />

--- a/packages/wallet-ui/src/components/ui/organism/Header/SendModal/SendModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/Header/SendModal/SendModal.view.tsx
@@ -30,7 +30,9 @@ interface Props {
 export const SendModalView = ({ closeModal }: Props) => {
   const networks = useAppSelector((state) => state.networks);
   const chainId = networks?.items[networks.activeNetwork]?.chainId;
-  const wallet = useAppSelector((state) => state.wallet);
+  const erc20TokenBalanceSelected = useAppSelector(
+    (state) => state.wallet.erc20TokenBalanceSelected,
+  );
   const { getAddrFromStarkName } = useStarkNetSnap();
   const { translate } = useMultiLanguage();
   const [summaryModalOpen, setSummaryModalOpen] = useState(false);
@@ -63,9 +65,9 @@ export const SendModalView = ({ closeModal }: Props) => {
         if (fieldValue !== '' && fieldValue !== '.') {
           const inputAmount = ethers.utils.parseUnits(
             fieldValue,
-            wallet.erc20TokenBalanceSelected.decimals,
+            erc20TokenBalanceSelected.decimals,
           );
-          const userBalance = wallet.erc20TokenBalanceSelected.amount;
+          const userBalance = erc20TokenBalanceSelected.amount;
           if (inputAmount.gt(userBalance)) {
             setErrors((prevErrors) => ({
               ...prevErrors,
@@ -166,8 +168,8 @@ export const SendModalView = ({ closeModal }: Props) => {
               value={fields.amount}
               error={errors.amount !== '' ? true : false}
               helperText={errors.amount}
-              decimalsMax={wallet.erc20TokenBalanceSelected.decimals}
-              asset={wallet.erc20TokenBalanceSelected}
+              decimalsMax={erc20TokenBalanceSelected.decimals}
+              asset={erc20TokenBalanceSelected}
             />
             <SeparatorSmall />
             <div>

--- a/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.view.tsx
@@ -30,11 +30,14 @@ import { PopperTooltip } from 'components/ui/molecule/PopperTooltip';
 export const SideBarView = () => {
   const networks = useAppSelector((state) => state.networks);
   const currentAccount = useAppSelector((state) => state.wallet.currentAccount);
+  const erc20TokenBalances = useAppSelector(
+    (state) => state.wallet.erc20TokenBalances,
+  );
+  const connected = useAppSelector((state) => state.wallet.connected);
   const chainId = networks?.items[networks.activeNetwork]?.chainId;
   const [listOverflow, setListOverflow] = useState(false);
   const [infoModalOpen, setInfoModalOpen] = useState(false);
   const [accountDetailsOpen, setAccountDetailsOpen] = useState(false);
-  const wallet = useAppSelector((state) => state.wallet);
   const [addTokenOpen, setAddTokenOpen] = useState(false);
   const { getStarkName } = useStarkNetSnap();
   const { translate } = useMultiLanguage();
@@ -52,7 +55,7 @@ export const SideBarView = () => {
         setListOverflow(false);
       }
     }
-  }, [wallet.erc20TokenBalances]);
+  }, [erc20TokenBalances]);
 
   useEffect(() => {
     if (address && address !== defaultAccount.address) {
@@ -108,7 +111,7 @@ export const SideBarView = () => {
           </AccountDetailsContent>
         }
       >
-        <AccountImageStyled address={address} connected={wallet.connected} />
+        <AccountImageStyled address={address} connected={connected} />
       </AccountDetails>
 
       <AccountLabel>

--- a/packages/wallet-ui/src/services/useMultiLanguage.ts
+++ b/packages/wallet-ui/src/services/useMultiLanguage.ts
@@ -1,7 +1,7 @@
 import { useAppSelector } from 'hooks/redux';
 
 export const useMultiLanguage = () => {
-  const { translations } = useAppSelector((state) => state.wallet);
+  const translations = useAppSelector((state) => state.wallet.translations);
 
   const translate = (key: string, ...args: (string | undefined)[]): string => {
     const template = translations[key]?.message ?? `{${key}}`;

--- a/packages/wallet-ui/src/services/useSnap.ts
+++ b/packages/wallet-ui/src/services/useSnap.ts
@@ -16,7 +16,7 @@ export type SnapsMetaData = {
 };
 
 export const useSnap = () => {
-  const { provider } = useAppSelector((state) => state.wallet);
+  const provider = useAppSelector((state) => state.wallet.provider);
   const snapId = process.env.REACT_APP_SNAP_ID
     ? process.env.REACT_APP_SNAP_ID
     : 'local:http://localhost:8081';

--- a/packages/wallet-ui/src/services/useStarkNetSnap.ts
+++ b/packages/wallet-ui/src/services/useStarkNetSnap.ts
@@ -58,9 +58,10 @@ export const useStarkNetSnap = () => {
     snapId,
   } = useSnap();
   const { loader } = useAppSelector((state) => state.UI);
-  const { erc20TokenBalances, accounts } = useAppSelector(
-    (state) => state.wallet,
+  const erc20TokenBalances = useAppSelector(
+    (state) => state.wallet.erc20TokenBalances,
   );
+  const accounts = useAppSelector((state) => state.wallet.accounts);
 
   const connectToSnap = () => {
     dispatch(enableLoadingWithMessage('Connecting...'));


### PR DESCRIPTION
This PR is to fix the redux state on UI components to only subscribe the state that it needed, 

to avoid updating a state and cause all component re-render

e.g 
- at T1 Component A subscribes the wallet state, however it only use 1 of the props - 'xx' from the wallet state;
```
const wallet = useAppSelector((state) => state.wallet)
const varToUse = wallet.xx
```
- at T2, we update a props - 'yy' on wallet
- at T3, Component A will be re-render, which not expected

### Change:
- change `useAppSelector((state) => state.wallet)` to `useAppSelector((state) => state.wallet.{xxxxx}` to only subscribe the state that it needed