### PR TITLE
chore: refine account name management UI

### DIFF
--- a/packages/wallet-ui/src/assets/locales/en.json
+++ b/packages/wallet-ui/src/assets/locales/en.json
@@ -318,6 +318,9 @@
     },
     "youCannotHideLastAccount": {
       "message": "You cannot hide the last remaining account."
+    },
+    "accountNameLengthError": {
+      "message": "Account name must be between {1} and {2} characters."
     }
   }
 }

--- a/packages/wallet-ui/src/assets/locales/fr.json
+++ b/packages/wallet-ui/src/assets/locales/fr.json
@@ -312,6 +312,9 @@
     },
     "youCannotHideLastAccount": {
       "message": "Vous ne pouvez pas masquer le dernier compte restant."
+    },
+    "accountNameLengthError": {
+      "message": "Le nom du compte doit comporter entre {1} et {2} caractères."
     }
   }
 }

--- a/packages/wallet-ui/src/components/ui/organism/AccountDetailsModal/AccountDetailsModal.style.ts
+++ b/packages/wallet-ui/src/components/ui/organism/AccountDetailsModal/AccountDetailsModal.style.ts
@@ -30,18 +30,32 @@ export const AccountImageStyled = styled(AccountImage)`
 `;
 
 export const TitleDiv = styled.div`
+  margin-bottom: 25px;
+`;
+
+export const RowDiv = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  margin-bottom: 24px;
-  margin-left: 52px;
+  justify-content: center;
+`;
+
+export const ErrorMsg = styled.div`
+  text-align: center;
+  color: ${(props) => props.theme.palette.error.main};
+  font-size: ${(props) => props.theme.typography.c1.fontSize};
+  font-weight: ${(props) => props.theme.typography.c1.fontSize};
+  font-family: ${(props) => props.theme.typography.c1.fontFamily};
 `;
 
 export const Title = styled.div`
   font-size: ${(props) => props.theme.typography.h3.fontSize};
   font-weight: ${(props) => props.theme.typography.h3.fontSize};
   font-family: ${(props) => props.theme.typography.h3.fontFamily};
-  margin-right: 13px;
+  word-break: break-word;
+  max-width: 200px;
+  text-align: left;
+  line-height: 1.4;
 `;
 
 export const ModifyIcon = styled(FontAwesomeIcon).attrs((props) => ({
@@ -98,7 +112,6 @@ export const IconButton = styled.button<{ disabled: boolean }>`
   opacity: ${(props) => (props.disabled ? 0.5 : 1)};
   cursor: ${(props) => (props.disabled ? 'not-allowed' : 'pointer')};
   border: none;
-  cursor: pointer;
   margin-left: 6px;
   font-size: 14px;
   color: #333;
@@ -117,7 +130,7 @@ export const AccountNameInput = styled.input`
   border: 1px solid #ccc;
   border-radius: 4px;
   outline: none;
-  width: 150px;
+  width: 200px;
   text-align: center;
   transition: border-color 0.2s;
 

--- a/packages/wallet-ui/src/components/ui/organism/AccountDetailsModal/AccountDetailsModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AccountDetailsModal/AccountDetailsModal.view.tsx
@@ -40,7 +40,7 @@ export const AccountDetailsModalView = () => {
       trimedAccountName.length <= maxLength &&
         trimedAccountName.length >= minLength,
     );
-  }, [accountName]);
+  }, [accountName, minLength, maxLength]);
 
   const onAccountNameUpdate = async () => {
     const trimedAccountName = accountName.trim();

--- a/packages/wallet-ui/src/components/ui/organism/AccountSwitchModal/AddAccountModal/AddAccountModal.style.ts
+++ b/packages/wallet-ui/src/components/ui/organism/AccountSwitchModal/AddAccountModal/AddAccountModal.style.ts
@@ -42,3 +42,11 @@ export const ButtonsWrapper = styled.div`
   border-radius: 0px 0px 8px 8px;
   width: ${(props) => props.theme.modal.base};
 `;
+
+export const ErrorMsg = styled.div`
+  text-align: center;
+  color: ${(props) => props.theme.palette.error.main};
+  font-size: ${(props) => props.theme.typography.c1.fontSize};
+  font-weight: ${(props) => props.theme.typography.c1.fontSize};
+  font-family: ${(props) => props.theme.typography.c1.fontFamily};
+`;

--- a/packages/wallet-ui/src/components/ui/organism/AccountSwitchModal/AddAccountModal/AddAccountModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AccountSwitchModal/AddAccountModal/AddAccountModal.view.tsx
@@ -1,38 +1,56 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, ChangeEvent } from 'react';
 import { useAppSelector } from 'hooks/redux';
 import { useMultiLanguage, useStarkNetSnap } from 'services';
 import { InputWithLabel } from 'components/ui/molecule/InputWithLabel';
 import {
   ButtonStyled,
   ButtonsWrapper,
+  ErrorMsg,
   FormGroup,
   Space,
   Title,
   Wrapper,
 } from './AddAccountModal.style';
 import { getDefaultAccountName } from 'utils/utils';
+import { ACCOUNT_NAME_LENGTH } from 'utils/constants';
+
 interface Props {
   closeModal: () => void;
 }
 
 export const AddAccountModalView = ({ closeModal }: Props) => {
+  const [minLength, maxLength] = ACCOUNT_NAME_LENGTH;
   const { addNewAccount } = useStarkNetSnap();
   const { translate } = useMultiLanguage();
-  const [enabled, setEnabled] = useState(false);
   const networks = useAppSelector((state) => state.networks);
   const accounts = useAppSelector((state) => state.wallet.accounts);
+  const [enabled, setEnabled] = useState(true);
+  const [accountName, setAccountName] = useState('');
   const chainId = networks?.items[networks.activeNetwork].chainId;
-  const [accountName, setAccountName] = useState(
-    getDefaultAccountName(accounts.length),
-  );
 
   useEffect(() => {
+    const trimedAccountName = accountName.trim();
     setEnabled(
-      accountName.trim() !== '' &&
-        accountName.length <= 20 &&
-        accountName.length >= 1,
+      !trimedAccountName ||
+        (trimedAccountName.length <= maxLength &&
+          trimedAccountName.length >= minLength),
     );
   }, [accountName]);
+
+  const onAccountNameChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setAccountName(event.target.value);
+  };
+
+  const onAddAccount = async () => {
+    const trimedAccountName = accountName.trim();
+    // Reset account name to undefined if it is empty,
+    // so that the default account name is used in Snap
+    await addNewAccount(
+      chainId,
+      trimedAccountName === '' ? undefined : trimedAccountName,
+    );
+    closeModal();
+  };
 
   return (
     <>
@@ -42,29 +60,26 @@ export const AddAccountModalView = ({ closeModal }: Props) => {
         <FormGroup>
           <InputWithLabel
             label={translate('accountName')}
-            placeholder={accountName}
-            onChange={(event) => {
-              const value = event.target.value;
-              setAccountName(
-                value.trim() === ''
-                  ? getDefaultAccountName(accounts.length)
-                  : value,
-              );
-            }}
+            placeholder={getDefaultAccountName(accounts.length)}
+            onChange={onAccountNameChange}
+            maxLength={maxLength}
           />
+          {!enabled && (
+            <ErrorMsg>
+              {translate(
+                'accountNameLengthError',
+                minLength.toString(),
+                maxLength.toString(),
+              )}
+            </ErrorMsg>
+          )}
         </FormGroup>
       </Wrapper>
       <ButtonsWrapper>
         <ButtonStyled onClick={closeModal} backgroundTransparent borderVisible>
           {translate('cancel')}
         </ButtonStyled>
-        <ButtonStyled
-          enabled={enabled}
-          onClick={async () => {
-            await addNewAccount(chainId, accountName);
-            closeModal();
-          }}
-        >
+        <ButtonStyled enabled={enabled} onClick={onAddAccount}>
           {translate('add')}
         </ButtonStyled>
       </ButtonsWrapper>

--- a/packages/wallet-ui/src/components/ui/organism/AccountSwitchModal/AddAccountModal/AddAccountModal.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AccountSwitchModal/AddAccountModal/AddAccountModal.view.tsx
@@ -35,7 +35,7 @@ export const AddAccountModalView = ({ closeModal }: Props) => {
         (trimedAccountName.length <= maxLength &&
           trimedAccountName.length >= minLength),
     );
-  }, [accountName]);
+  }, [accountName, minLength, maxLength]);
 
   const onAccountNameChange = (event: ChangeEvent<HTMLInputElement>) => {
     setAccountName(event.target.value);

--- a/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.style.ts
+++ b/packages/wallet-ui/src/components/ui/organism/SideBar/SideBar.style.ts
@@ -22,6 +22,8 @@ export const AccountLabel = styled.h3`
   align-self: center;
   margin-top: ${(props) => props.theme.spacing.base};
   margin-bottom: 12px;
+  word-break: break-word;
+  width: 200px;
 `;
 
 export const RowDiv = styled.div`

--- a/packages/wallet-ui/src/services/useSnap.ts
+++ b/packages/wallet-ui/src/services/useSnap.ts
@@ -1,4 +1,5 @@
 import { useAppSelector } from 'hooks/redux';
+import { removeUndefined } from 'utils/utils';
 
 export type InvokeSnapParams = {
   method: string;
@@ -38,7 +39,7 @@ export const useSnap = () => {
           snapId,
           request: {
             method,
-            params,
+            params: params ? removeUndefined(params) : params,
           },
         },
       });

--- a/packages/wallet-ui/src/services/useStarkNetSnap.ts
+++ b/packages/wallet-ui/src/services/useStarkNetSnap.ts
@@ -837,7 +837,7 @@ export const useStarkNetSnap = () => {
     });
   };
 
-  const addNewAccount = async (chainId: string, accountName: string) => {
+  const addNewAccount = async (chainId: string, accountName?: string) => {
     dispatch(enableLoadingWithMessage('Adding new account...'));
     try {
       const account = await invokeSnap<Account>({
@@ -889,7 +889,7 @@ export const useStarkNetSnap = () => {
     });
   };
 
-  const setAccountName = async (
+  const updateAccountName = async (
     chainId: string,
     address: string,
     accountName: string,
@@ -954,7 +954,7 @@ export const useStarkNetSnap = () => {
     getCurrentAccount,
     addNewAccount,
     toggleAccountVisibility,
-    setAccountName,
+    updateAccountName,
     setAccount,
     setErc20TokenBalance,
     getPrivateKeyFromAddress,

--- a/packages/wallet-ui/src/utils/constants.ts
+++ b/packages/wallet-ui/src/utils/constants.ts
@@ -72,3 +72,6 @@ export const DEFAULT_FEE_TOKEN = FeeToken.ETH;
 export const MIN_METAMASK_VERSION = '12.5.0';
 
 export const DENY_ERROR_CODE = 113;
+
+// Account name length range - [min, max]
+export const ACCOUNT_NAME_LENGTH = [1, 20];

--- a/packages/wallet-ui/src/utils/utils.ts
+++ b/packages/wallet-ui/src/utils/utils.ts
@@ -263,3 +263,10 @@ export const getDefaultAccountName = (hdIndex = 0) => {
   }
   return `Account ${hdIndex + 1}`;
 };
+
+export const removeUndefined = (obj: Record<string, unknown>) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return Object.fromEntries(
+    Object.entries(obj).filter(([_, val]) => val !== undefined),
+  );
+};


### PR DESCRIPTION
This PR is to refine the name management UI


### Changes:
- Rename `setAccountName` to `updateAccountName` to align the naming convention  
- Add error message for the add account, update account name workflow
- Add Constants to store the account name length requirement
- When add new account, if the name is not given, convert to undefined and let the SNAP to assign a default name