### PR TITLE
fix: the SNAP does not auto update if the version is outdate in get-starknet

### DIFF
--- a/packages/get-starknet/package.json
+++ b/packages/get-starknet/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "async-mutex": "^0.3.2",
+    "semver": "^7.7.1",
     "starknet": "6.11.0"
   }
 }

--- a/packages/get-starknet/src/snap.test.ts
+++ b/packages/get-starknet/src/snap.test.ts
@@ -1,0 +1,191 @@
+import { MetaMaskSnap } from './snap';
+import type { MetaMaskProvider } from './type';
+
+describe('MetaMaskSnap', () => {
+  class MockMetaMaskSnap extends MetaMaskSnap {
+    public override async isSnapRequireUpdate(): Promise<boolean> {
+      return super.isSnapRequireUpdate();
+    }
+
+    public override async isInstalled(): Promise<boolean> {
+      return super.isInstalled();
+    }
+  }
+
+  class MockProvider implements MetaMaskProvider {
+    async request(): Promise<any> {
+      return {};
+    }
+  }
+
+  const createMockProvider = () => {
+    const provider = new MockProvider() as unknown as MetaMaskProvider;
+    const providerSpy = jest.spyOn(provider, 'request');
+    providerSpy.mockReturnThis();
+
+    return {
+      provider,
+      providerSpy,
+    };
+  };
+
+  const createSnapService = ({
+    provider,
+    version = '1.0.0',
+    minVersion = '1.0.0',
+  }: {
+    provider: MetaMaskProvider;
+    version?: string;
+    minVersion?: string;
+  }) => {
+    const snapId = 'snapId';
+
+    const snap = new MockMetaMaskSnap(snapId, version, provider, minVersion);
+    return {
+      snap,
+      provider,
+      snapId,
+    };
+  };
+
+  describe('installIfNot', () => {
+    const version = '1.0.0';
+
+    const createInstallUpdateSpy = () => {
+      const isInstalledSpy = jest.spyOn(MockMetaMaskSnap.prototype, 'isInstalled');
+      const isSnapRequireUpdateSpy = jest.spyOn(MockMetaMaskSnap.prototype, 'isSnapRequireUpdate');
+
+      return { isInstalledSpy, isSnapRequireUpdateSpy };
+    };
+
+    const setupInstallIfNotTest = ({
+      isInstalled,
+      isSnapRequireUpdate,
+    }: {
+      isInstalled: boolean;
+      isSnapRequireUpdate: boolean;
+    }) => {
+      const { provider, providerSpy } = createMockProvider();
+      const { isInstalledSpy, isSnapRequireUpdateSpy } = createInstallUpdateSpy();
+
+      isInstalledSpy.mockResolvedValue(isInstalled);
+      isSnapRequireUpdateSpy.mockResolvedValue(isSnapRequireUpdate);
+
+      const { snap, snapId } = createSnapService({
+        provider,
+        version,
+      });
+
+      providerSpy.mockResolvedValue({
+        [snapId]: {
+          enabled: true,
+        },
+      });
+
+      return { snap, snapId, providerSpy };
+    };
+
+    it('installs the snap if not installed', async () => {
+      const { snap, snapId, providerSpy } = setupInstallIfNotTest({
+        isInstalled: false,
+        isSnapRequireUpdate: false,
+      });
+
+      const result = await snap.installIfNot();
+
+      expect(result).toBe(true);
+      expect(providerSpy).toHaveBeenCalledWith({
+        method: 'wallet_requestSnaps',
+        params: {
+          [snapId]: { version },
+        },
+      });
+    });
+
+    it('does not install the snap if installed', async () => {
+      const { snap, providerSpy } = setupInstallIfNotTest({
+        isInstalled: true,
+        isSnapRequireUpdate: false,
+      });
+
+      const result = await snap.installIfNot();
+
+      expect(result).toBe(true);
+      expect(providerSpy).not.toHaveBeenCalled();
+    });
+
+    it('re-install the snap if the installed version is outdate', async () => {
+      const { snap, snapId, providerSpy } = setupInstallIfNotTest({
+        isInstalled: true,
+        isSnapRequireUpdate: true,
+      });
+
+      const result = await snap.installIfNot();
+
+      expect(result).toBe(true);
+      expect(providerSpy).toHaveBeenCalledWith({
+        method: 'wallet_requestSnaps',
+        params: {
+          [snapId]: { version },
+        },
+      });
+    });
+  });
+
+  describe('isSnapRequireUpdate', () => {
+    const setIsSnapRequireUpdateTest = ({
+      version = '1.0.0',
+      minVersion = '1.0.0',
+    }: {
+      version?: string;
+      minVersion?: string;
+    }) => {
+      const { provider, providerSpy } = createMockProvider();
+
+      const { snap, snapId } = createSnapService({
+        provider,
+        version,
+        minVersion,
+      });
+
+      providerSpy.mockResolvedValue({
+        [snapId]: {
+          enabled: true,
+          version,
+        },
+      });
+
+      return { snap, snapId, providerSpy };
+    };
+
+    it.each([
+      {
+        version: '1.0.0',
+        minVersion: '1.0.0',
+        expected: false,
+      },
+      {
+        version: '1.0.0',
+        minVersion: '1.1.0',
+        expected: true,
+      },
+      {
+        version: '1.0.0',
+        minVersion: '*',
+        expected: false,
+      },
+    ])(
+      'returns $expected if the installed version $version and min required version is $minVersion',
+      async ({ version, minVersion, expected }) => {
+        const { snap } = setIsSnapRequireUpdateTest({
+          version,
+          minVersion,
+        });
+
+        const result = await snap.isSnapRequireUpdate();
+
+        expect(result).toBe(expected);
+      },
+    );
+  });
+});

--- a/packages/get-starknet/src/snap.ts
+++ b/packages/get-starknet/src/snap.ts
@@ -24,12 +24,25 @@ import type {
 } from './type';
 
 export class MetaMaskSnap {
+  /**
+   * The wallet RPC provider.
+   */
   #provider: MetaMaskProvider;
 
+  /**
+   * The ID of the SNAP.
+   */
   #snapId: string;
 
+  /**
+   * The version of the SNAP to install.
+   */
   #version: string;
 
+  /**
+   * The minimum version of the SNAP.
+   * If the installed version is lower than this version, the SNAP will be updated.
+   */
   #minSnapVersion: string;
 
   constructor(snapId: string, version: string, provider: MetaMaskProvider, minSnapVersion?: string) {

--- a/packages/get-starknet/src/snap.ts
+++ b/packages/get-starknet/src/snap.ts
@@ -1,3 +1,4 @@
+import semver from 'semver/preload';
 import type {
   Abi,
   AllowArray,
@@ -13,7 +14,14 @@ import type {
   TypedData,
 } from 'starknet';
 
-import type { AccContract, DeploymentData, MetaMaskProvider, Network, RequestSnapResponse } from './type';
+import type {
+  AccContract,
+  DeploymentData,
+  MetaMaskProvider,
+  Network,
+  RequestSnapResponse,
+  SnapsMetaData,
+} from './type';
 
 export class MetaMaskSnap {
   #provider: MetaMaskProvider;
@@ -22,10 +30,14 @@ export class MetaMaskSnap {
 
   #version: string;
 
-  constructor(snapId: string, version: string, provider: MetaMaskProvider) {
+  #minSnapVersion: string;
+
+  constructor(snapId: string, version: string, provider: MetaMaskProvider, minSnapVersion?: string) {
     this.#provider = provider;
     this.#snapId = snapId;
     this.#version = version;
+    // unless specified, the minSnapVersion is the same as the snapVersion
+    this.#minSnapVersion = minSnapVersion ?? version;
   }
 
   async getPubKey({ userAddress, chainId }: { userAddress: string; chainId?: string }): Promise<string> {
@@ -402,23 +414,26 @@ export class MetaMaskSnap {
   }
 
   async installIfNot(): Promise<boolean> {
-    // if the snap is already installed, return true, to bypass the prompt
-    if (await this.isInstalled()) {
+    if ((await this.isInstalled()) && !(await this.isSnapRequireUpdate())) {
       return true;
     }
+    // `wallet_requestSnaps` will force the SNAP to reconnect,
+    // If the SNAP is not installed, it will be installed
+    // If the SNAP is installed, it will update the SNAP if the version is different
     const response = (await this.#provider.request({
       method: 'wallet_requestSnaps',
       params: {
         [this.#snapId]: { version: this.#version },
       },
     })) as RequestSnapResponse;
+
     if (!response?.[this.#snapId]?.enabled) {
       return false;
     }
     return true;
   }
 
-  async isInstalled() {
+  protected async isInstalled(): Promise<boolean> {
     try {
       await this.#provider.request({
         method: 'wallet_invokeSnap',
@@ -438,5 +453,26 @@ export class MetaMaskSnap {
   #removeUndefined(obj: Record<string, unknown>) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     return Object.fromEntries(Object.entries(obj).filter(([_, val]) => val !== undefined));
+  }
+
+  protected async getInstalledSnaps(): Promise<SnapsMetaData> {
+    return (await this.#provider.request({ method: 'wallet_getSnaps' })) as SnapsMetaData;
+  }
+
+  protected async isSnapRequireUpdate(): Promise<boolean> {
+    const snaps = await this.getInstalledSnaps();
+
+    if (typeof snaps[this.#snapId]?.version !== 'undefined') {
+      // if the minSnapVersion is *, we should always allowed
+      if (this.#minSnapVersion === '*') {
+        return false;
+      }
+
+      const currentVersion = snaps[this.#snapId]?.version.split('-')?.[0];
+
+      return semver.lt(currentVersion, this.#minSnapVersion);
+    }
+
+    return false;
   }
 }

--- a/packages/get-starknet/src/type.ts
+++ b/packages/get-starknet/src/type.ts
@@ -41,3 +41,13 @@ export type RequestSnapResponse = {
     blocked: boolean;
   };
 };
+
+export type SnapsMetaData = {
+  [key in string]: {
+    id: string;
+    version: string;
+    enabled: boolean;
+    blocked: boolean;
+    initialPermissions: string;
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2206,6 +2206,7 @@ __metadata:
     jest: ^29.5.0
     prettier: ^2.7.1
     rimraf: ^3.0.2
+    semver: ^7.7.1
     serve: 14.2.1
     starknet: 6.11.0
     ts-jest: ^29.1.0
@@ -4834,6 +4835,23 @@ __metadata:
     semver: ^7.5.4
     uuid: ^9.0.1
   checksum: 4c350c7a1c881c6af446319942392e6eb62411bff9c512166d816d39702c7b4926a982ebfd56ada317f9332a5416b3211c09e022674cee8272228658977ba851
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^11.0.1":
+  version: 11.2.0
+  resolution: "@metamask/utils@npm:11.2.0"
+  dependencies:
+    "@ethereumjs/tx": ^4.2.0
+    "@metamask/superstruct": ^3.1.0
+    "@noble/hashes": ^1.3.1
+    "@scure/base": ^1.1.3
+    "@types/debug": ^4.1.7
+    debug: ^4.3.4
+    pony-cause: ^2.1.10
+    semver: ^7.5.4
+    uuid: ^9.0.1
+  checksum: f3befb538783f50ac0573468a44ae1331b39318263fd895ff24119f26c57a7c4ab90d4f8593d13bc558023802a07b031aed555c1a096aee0ab6b7ff4cbaa81e1
   languageName: node
   linkType: hard
 
@@ -24483,6 +24501,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.7.1":
+  version: 7.7.1
+  resolution: "semver@npm:7.7.1"
+  bin:
+    semver: bin/semver.js
+  checksum: 586b825d36874007c9382d9e1ad8f93888d8670040add24a28e06a910aeebd673a2eb9e3bf169c6679d9245e66efb9057e0852e70d9daa6c27372aab1dda7104
+  languageName: node
+  linkType: hard
+
 "send@npm:0.18.0":
   version: 0.18.0
   resolution: "send@npm:0.18.0"
@@ -27582,6 +27609,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/jazzicon": "github:metamask/jazzicon#d923914fda6a8795f74c2e66134f73cd72070667"
+    "@metamask/utils": ^11.0.1
     "@mui/icons-material": ^5.6.2
     "@mui/material": ^5.6.2
     "@reduxjs/toolkit": ^1.8.1


### PR DESCRIPTION
This PR is to add a fix for a case that the SNAP does not auto update if the version is outdate in get-starknet

if the SNAP version is outdate , the  get-starknet request workflow will trigger a reconnect workflow to update the SNAP

Changes:
- Add the logic to detect the SNAP version is outdate or not, and trigger re-install
