### PR TITLE
feat: persist account visibility in UI to enhance performance

### DIFF
--- a/packages/wallet-ui/src/hooks/index.ts
+++ b/packages/wallet-ui/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './redux';
 export * from './useCurrentNetwork';
 export * from './useCurrentAccount';
 export * from './useScrollTo';
+export * from './useAccountVisibility';

--- a/packages/wallet-ui/src/hooks/useAccountVisibility.ts
+++ b/packages/wallet-ui/src/hooks/useAccountVisibility.ts
@@ -1,0 +1,98 @@
+import { useMemo } from 'react';
+
+import { useStarkNetSnap } from 'services';
+import { Account } from 'types';
+import { setAccountVisibility } from 'slices/walletSlice';
+import { useAppDispatch, useAppSelector } from './redux';
+import { useCurrentNetwork } from './useCurrentNetwork';
+import { useCurrentAccount } from './useCurrentAccount';
+
+export class MinAccountToHideError extends Error {}
+
+export class SwitchAccountError extends Error {}
+
+/**
+ * A hook to manage account visibility
+ *
+ * @returns {visibleAccounts, hiddenAccounts, showAccount, hideAccount}
+ */
+export const useAccountVisibility = () => {
+  const dispatch = useAppDispatch();
+  const { switchAccount } = useStarkNetSnap();
+  const currentNework = useCurrentNetwork();
+  const currentAccount = useCurrentAccount();
+  const visibilities = useAppSelector(
+    (state) => state.wallet.visibility[currentNework.chainId],
+  );
+  const accounts = useAppSelector((state) => state.wallet.accounts);
+  const chainId = currentNework?.chainId;
+
+  // Use useMemo to avoid re-rendering the component when the state changes
+  const [visibleAccounts, hiddenAccounts] = useMemo(() => {
+    const visibleAccounts: Account[] = [];
+    const hiddenAccounts: Account[] = [];
+    for (const account of accounts) {
+      // account.visibility = `undefined` refer to the case when previous account state doesnt include this field
+      // hence we consider it is `visible`
+      if (
+        !Object.prototype.hasOwnProperty.call(
+          visibilities,
+          account.addressIndex,
+        ) ||
+        visibilities[account.addressIndex] === true
+      ) {
+        visibleAccounts.push(account);
+      } else {
+        hiddenAccounts.push(account);
+      }
+    }
+    return [visibleAccounts, hiddenAccounts];
+  }, [accounts, visibilities, chainId]);
+
+  const hideAccount = async (account: Account) => {
+    if (visibleAccounts.length < 2) {
+      throw new MinAccountToHideError();
+    }
+
+    toggleAccountVisibility(account, false);
+
+    if (account.addressIndex === currentAccount.addressIndex) {
+      // Find the next account by using the next ascending addressIndex.
+      const nextAccount = visibleAccounts
+        .sort((a, b) => a.addressIndex - b.addressIndex)
+        .find(
+          (account) => account.addressIndex !== currentAccount.addressIndex,
+        );
+
+      if (nextAccount) {
+        if ((await switchAccount(chainId, account.address)) === undefined) {
+          // `switchAccount` will not return an account if it fails / error
+          // Therefore, when account switch fails, we need to rollback the state
+          toggleAccountVisibility(account, true);
+          throw new SwitchAccountError();
+        }
+      }
+    }
+  };
+
+  const showAccount = async (account: Account) => {
+    toggleAccountVisibility(account, true);
+  };
+
+  const toggleAccountVisibility = (account: Account, visibility: boolean) => {
+    dispatch(
+      setAccountVisibility({
+        chainId,
+        index: account.addressIndex,
+        visibility: visibility,
+      }),
+    );
+  };
+
+  return {
+    visibleAccounts,
+    hiddenAccounts,
+    showAccount,
+    hideAccount,
+  };
+};

--- a/packages/wallet-ui/src/services/useStarkNetSnap.ts
+++ b/packages/wallet-ui/src/services/useStarkNetSnap.ts
@@ -214,58 +214,6 @@ export const useStarkNetSnap = () => {
     dispatch(disableLoading());
   };
 
-  const hideAccount = async ({
-    chainId,
-    address,
-    currentAddress,
-  }: {
-    chainId: string;
-    address: string;
-    currentAddress: string;
-  }) => {
-    try {
-      if (!loader.isLoading) {
-        dispatch(
-          enableLoadingWithMessage(`Hiding account ${shortenAddress(address)}`),
-        );
-      }
-      const account = await toggleAccountVisibility(chainId, address, false);
-      dispatch(updateAccount({ address, updates: { visibility: false } }));
-      if (account.address !== currentAddress) {
-        await initWalletData({
-          account,
-          chainId,
-        });
-      }
-    } catch (error) {
-      const toastr = new Toastr();
-      toastr.error('Failed to hide the account');
-    } finally {
-      dispatch(disableLoading());
-    }
-  };
-
-  const unHideAccount = async ({
-    chainId,
-    address,
-  }: {
-    chainId: string;
-    address: string;
-  }) => {
-    if (!loader.isLoading) {
-      dispatch(enableLoadingWithMessage(`Loading...`));
-    }
-    try {
-      await toggleAccountVisibility(chainId, address, true);
-      dispatch(updateAccount({ address, updates: { visibility: true } }));
-    } catch (err) {
-      const toastr = new Toastr();
-      toastr.error('Failed to show the account');
-    } finally {
-      dispatch(disableLoading());
-    }
-  };
-
   const setAccount = async (chainId: string, currentAccount: Account) => {
     const { upgradeRequired, deployRequired } = currentAccount;
 
@@ -948,8 +896,6 @@ export const useStarkNetSnap = () => {
     loadLocale,
     getNetworks,
     getAccounts,
-    hideAccount,
-    unHideAccount,
     switchAccount,
     getCurrentAccount,
     addNewAccount,

--- a/packages/wallet-ui/src/slices/walletSlice.ts
+++ b/packages/wallet-ui/src/slices/walletSlice.ts
@@ -5,6 +5,7 @@ import { Transaction } from 'types';
 import { ethers } from 'ethers';
 import { defaultAccount } from 'utils/constants';
 import defaultLocale from '../assets/locales/en.json';
+import { constants } from 'starknet';
 
 export interface WalletState {
   connected: boolean;
@@ -19,6 +20,9 @@ export interface WalletState {
   transactions: Transaction[];
   transactionDeploy?: Transaction;
   provider?: any; //TODO: metamask SDK is not export types
+  visibility: {
+    [key: string]: Record<string, boolean>;
+  };
 }
 
 const initialState: WalletState = {
@@ -34,12 +38,20 @@ const initialState: WalletState = {
   transactions: [],
   transactionDeploy: undefined,
   provider: undefined,
+  visibility: {
+    [constants.StarknetChainId.SN_MAIN]: {},
+    [constants.StarknetChainId.SN_SEPOLIA]: {},
+  },
 };
 
 export const walletSlice = createSlice({
   name: 'wallet',
   initialState,
   reducers: {
+    setAccountVisibility: (state, { payload }) => {
+      const { chainId, index, visibility } = payload;
+      state.visibility[chainId][index] = visibility;
+    },
     setLocale: (state, { payload }) => {
       state.locale = payload;
     },
@@ -155,6 +167,7 @@ export const walletSlice = createSlice({
 });
 
 export const {
+  setAccountVisibility,
   setWalletConnection,
   setForceReconnect,
   setCurrentAccount,

--- a/packages/wallet-ui/src/store/store.ts
+++ b/packages/wallet-ui/src/store/store.ts
@@ -16,7 +16,7 @@ const persistConfig = {
 const walletPersistConfig = {
   key: 'wallet',
   storage,
-  whitelist: ['forceReconnect'],
+  whitelist: ['forceReconnect', 'visibility'],
 };
 
 const networkPersistConfig = {


### PR DESCRIPTION
This PR is to enhance the UI performance while hide/showing an account

With current implementation, it require an loading for hide and showing account operation, which create a non-smooth UX

as the "Visibility" status is not begin use in other DAPP, and likely not in furture
Therefore, it seems better to store in UI with the native UI persistent storage (window local storage)

With this PR, the hide and show operation will not create any blocking UX for end user

### Requirements
- [ ] #516  