### PR TITLE
chore(wallet-ui): hide the `HiddenAccount` button if there is only 1 visible account

### DIFF
--- a/packages/wallet-ui/src/components/ui/organism/AccountListModal/AccountItem.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AccountListModal/AccountItem.view.tsx
@@ -13,9 +13,10 @@ export interface Props {
   account: Account;
   selected?: boolean;
   visible: boolean;
+  showIconButton?: boolean;
   scrollToRef?: React.RefObject<HTMLDivElement> | null;
   onItemClick?: (account: Account) => Promise<void>;
-  onIconButtonClick: (account: Account) => Promise<void>;
+  onIconButtonClick?: (account: Account) => Promise<void>;
 }
 
 export const AccountItem = ({
@@ -23,6 +24,7 @@ export const AccountItem = ({
   account,
   visible,
   scrollToRef,
+  showIconButton = true,
   onItemClick,
   onIconButtonClick,
 }: Props) => {
@@ -37,7 +39,9 @@ export const AccountItem = ({
 
   const onIconBtnClick = async (event: React.MouseEvent) => {
     preventDefaultMouseEvent(event);
-    await onIconButtonClick(account);
+    if (typeof onIconButtonClick === 'function') {
+      await onIconButtonClick(account);
+    }
   };
 
   const onClick = async (event: React.MouseEvent) => {
@@ -61,9 +65,11 @@ export const AccountItem = ({
           <div>{formatAddress(address)}</div>
         </div>
       </AccountInfoWrapper>
-      <IconButton size="small" onClick={onIconBtnClick}>
-        <VisibilityIcon icon={visible ? 'eye-slash' : 'eye'} />
-      </IconButton>
+      {showIconButton && (
+        <IconButton size="small" onClick={onIconBtnClick}>
+          <VisibilityIcon icon={visible ? 'eye-slash' : 'eye'} />
+        </IconButton>
+      )}
     </Wrapper>
   );
 };

--- a/packages/wallet-ui/src/components/ui/organism/AccountListModal/AccountList.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AccountListModal/AccountList.view.tsx
@@ -28,14 +28,15 @@ export const AccountListModalView = ({
   onClose: () => void;
   onAddAccountClick: () => void;
 }) => {
-  const {
-    switchAccount: switchSnapAccount,
-    hideAccount: hideSnapAccount,
-    unHideAccount: showSnapAccount,
-  } = useStarkNetSnap();
+  const { switchAccount: switchSnapAccount } = useStarkNetSnap();
   const { translate } = useMultiLanguage();
-  const { visibleAccounts, hiddenAccounts, canHideAccount } =
-    useAccountVisibility();
+  const {
+    visibleAccounts,
+    hiddenAccounts,
+    canHideAccount,
+    hideAccount,
+    showAccount,
+  } = useAccountVisibility();
   const currentNework = useCurrentNetwork();
   const { address: currentAddress } = useCurrentAccount();
   const [visibility, setVisibility] = useState(true);
@@ -45,23 +46,6 @@ export const AccountListModalView = ({
   const switchAccount = async (account: Account) => {
     onClose();
     await switchSnapAccount(chainId, account.address);
-  };
-
-  const hideAccount = async (account: Account) => {
-    if (canHideAccount) {
-      await hideSnapAccount({
-        chainId,
-        address: account.address,
-        currentAddress,
-      });
-    }
-  };
-
-  const showAccount = async (account: Account) => {
-    await showSnapAccount({
-      chainId,
-      address: account.address,
-    });
   };
 
   return (

--- a/packages/wallet-ui/src/hooks/index.ts
+++ b/packages/wallet-ui/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './redux';
 export * from './useCurrentNetwork';
 export * from './useCurrentAccount';
 export * from './useScrollTo';
+export * from './useAccountVisibility';

--- a/packages/wallet-ui/src/hooks/useAccountVisibility.ts
+++ b/packages/wallet-ui/src/hooks/useAccountVisibility.ts
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+
+import { Account } from 'types';
+import { useAppSelector } from './redux';
+
+/**
+ * A hook to get the list of visible and hidden accounts.
+ *
+ * @returns the list of visible and hidden accounts and a boolean indicating if an account can be hidden
+ */
+export const useAccountVisibility = () => {
+  const accounts = useAppSelector((state) => state.wallet.accounts);
+
+  // Use useMemo to avoid re-rendering the component when the state changes
+  const [visibleAccounts, hiddenAccounts] = useMemo(() => {
+    const visibleAccounts: Account[] = [];
+    const hiddenAccounts: Account[] = [];
+    for (const account of accounts) {
+      // account.visibility = `undefined` refer to the case when previous account state doesnt include this field
+      // hence we consider it is `visible`
+      if (account.visibility === undefined || account.visibility === true) {
+        visibleAccounts.push(account);
+      } else {
+        hiddenAccounts.push(account);
+      }
+    }
+    return [visibleAccounts, hiddenAccounts];
+  }, [accounts]);
+
+  // An account can be hidden only if there are more than one visible account
+  const canHideAccount = visibleAccounts.length > 1;
+
+  return { visibleAccounts, hiddenAccounts, canHideAccount };
+};


### PR DESCRIPTION
This PR is to hide the `HiddenAccount` button if there is only 1 visible account

### Change
- Add `showIconButton` flag on `AccountItem` to indicate if the  `HiddenAccount` button visible or not
- Add `useAccountVisibility` hook to consolidate the logic for account visibility management
