### PR TITLE
feat: account list contextual menu with hide/unhide and copy address feature

### DIFF
--- a/packages/wallet-ui/src/assets/locales/en.json
+++ b/packages/wallet-ui/src/assets/locales/en.json
@@ -145,6 +145,12 @@
     "gotIt": {
       "message": "GOT IT!"
     },
+    "hide": {
+      "message": "Hide"
+    },
+    "unhide": {
+      "message": "Unhide"
+    },
     "hiddenAccounts": {
       "message": "Hidden accounts"
     },

--- a/packages/wallet-ui/src/assets/locales/fr.json
+++ b/packages/wallet-ui/src/assets/locales/fr.json
@@ -139,6 +139,12 @@
     "gotIt": {
       "message": "COMPRIS !"
     },
+    "hide": {
+      "message": "Masquer"
+    },
+    "unhide": {
+      "message": "Afficher"
+    },
     "hiddenAccounts": {
       "message": "Comptes cachés"
     },

--- a/packages/wallet-ui/src/components/ui/organism/AccountListModal/AccountItem.style.ts
+++ b/packages/wallet-ui/src/components/ui/organism/AccountListModal/AccountItem.style.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { AccountImage } from 'components/ui/atom/AccountImage';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { MenuItem as MuiMenuItem } from '@mui/material';
 
 export const Wrapper = styled.div<{ selected: boolean; visible: boolean }>`
   display: flex;
@@ -27,5 +28,77 @@ export const AccountImageStyled = styled(AccountImage)`
 `;
 
 export const VisibilityIcon = styled(FontAwesomeIcon)`
+  font-size: ${(props) => props.theme.typography.p2.fontSize};
+  color: ${(props) => props.theme.palette.grey.grey2};
+`;
+
+export const AccountItemWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: ${(props) => props.theme.spacing.small};
+  border-bottom: 1px solid ${(props) => props.theme.palette.grey.grey3};
+`;
+
+export const AccountName = styled.div`
+  font-size: ${(props) => props.theme.typography.p1.fontSize};
+  font-weight: bold;
+`;
+
+export const AccountAddress = styled.div`
+  font-size: ${(props) => props.theme.typography.p2.fontSize};
   color: ${(props) => props.theme.palette.grey.grey1};
+`;
+
+export const AccountActions = styled.div`
+  display: flex;
+  align-items: center;
+  position: relative;
+`;
+
+export const VerticalDotsIcon = styled(FontAwesomeIcon).attrs({
+  icon: 'ellipsis-v',
+})`
+  cursor: pointer;
+  font-size: ${(props) => props.theme.typography.p2.fontSize};
+  color: ${(props) => props.theme.palette.grey.grey2};
+`;
+
+export const DropdownMenu = styled.div`
+  position: absolute;
+  top: 100%;
+  right: 0;
+  background-color: ${(props) => props.theme.palette.grey.white};
+  border: 1px solid ${(props) => props.theme.palette.grey.grey3};
+  border-radius: 4px;
+  z-index: 10;
+`;
+
+export const DropdownItem = styled.div`
+  padding: ${(props) => props.theme.spacing.small};
+  cursor: pointer;
+  &:hover {
+    background-color: ${(props) => props.theme.palette.grey.grey2};
+  }
+`;
+
+export const MenuItem = styled(MuiMenuItem)`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start; /* Aligne les éléments à gauche */
+  gap: ${(props) =>
+    props.theme.spacing.small}; /* Espacement entre l'icône et le texte */
+  padding: ${(props) => props.theme.spacing.small};
+  font-size: ${(props) => props.theme.typography.p2.fontSize};
+
+  & > svg {
+    flex-shrink: 0; /* Empêche l'icône de se redimensionner */
+    min-width: 30px;
+  }
+
+  & > span {
+    flex-grow: 1; /* Permet au texte de prendre l'espace restant */
+    text-align: left; /* Aligne le texte à gauche */
+    font-size: ${(props) => props.theme.typography.p2.fontSize};
+  }
 `;

--- a/packages/wallet-ui/src/components/ui/organism/AccountListModal/AccountItem.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AccountListModal/AccountItem.view.tsx
@@ -1,5 +1,5 @@
-import { IconButton } from '@mui/material';
-
+import { IconButton, Menu } from '@mui/material';
+import { useState } from 'react';
 import { Account } from 'types';
 import { formatAddress } from 'utils/utils';
 import {
@@ -7,7 +7,9 @@ import {
   AccountImageStyled,
   VisibilityIcon,
   Wrapper,
+  MenuItem,
 } from './AccountItem.style';
+import { useMultiLanguage } from 'services';
 
 export interface Props {
   account: Account;
@@ -28,12 +30,12 @@ export const AccountItem = ({
   onItemClick,
   onIconButtonClick,
 }: Props) => {
+  const { translate } = useMultiLanguage();
   const { address, accountName } = account;
+  const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
 
   const preventDefaultMouseEvent = (event: React.MouseEvent) => {
-    // Prevent triggering the native behaviour
     event.preventDefault();
-    // Prevent triggering the parent onClick event
     event.stopPropagation();
   };
 
@@ -42,6 +44,7 @@ export const AccountItem = ({
     if (typeof onIconButtonClick === 'function') {
       await onIconButtonClick(account);
     }
+    setMenuAnchorEl(null);
   };
 
   const onClick = async (event: React.MouseEvent) => {
@@ -49,6 +52,20 @@ export const AccountItem = ({
     if (typeof onItemClick === 'function') {
       await onItemClick(account);
     }
+  };
+
+  const handleCopyAddress = () => {
+    navigator.clipboard.writeText(address);
+    setMenuAnchorEl(null); // Ferme le menu après la copie
+  };
+
+  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+    preventDefaultMouseEvent(event);
+    setMenuAnchorEl(event.currentTarget);
+  };
+
+  const handleMenuClose = () => {
+    setMenuAnchorEl(null);
   };
 
   return (
@@ -65,11 +82,31 @@ export const AccountItem = ({
           <div>{formatAddress(address)}</div>
         </div>
       </AccountInfoWrapper>
-      {showIconButton && (
-        <IconButton size="small" onClick={onIconBtnClick}>
-          <VisibilityIcon icon={visible ? 'eye-slash' : 'eye'} />
+      <div>
+        <IconButton
+          size="small"
+          style={{ width: '30px' }}
+          onClick={handleMenuOpen}
+        >
+          <VisibilityIcon icon="ellipsis-vertical" />
         </IconButton>
-      )}
+        <Menu
+          anchorEl={menuAnchorEl}
+          open={Boolean(menuAnchorEl)}
+          onClose={handleMenuClose}
+        >
+          {showIconButton && (
+            <MenuItem onClick={onIconBtnClick}>
+              <VisibilityIcon icon={visible ? 'eye-slash' : 'eye'} />
+              <span>{visible ? translate('hide') : translate('unhide')}</span>
+            </MenuItem>
+          )}
+          <MenuItem onClick={handleCopyAddress}>
+            <VisibilityIcon icon="clone" />
+            <span>{translate('copyToClipboard')}</span>
+          </MenuItem>
+        </Menu>
+      </div>
     </Wrapper>
   );
 };

--- a/packages/wallet-ui/src/components/ui/organism/AccountListModal/AccountItem.view.tsx
+++ b/packages/wallet-ui/src/components/ui/organism/AccountListModal/AccountItem.view.tsx
@@ -35,6 +35,7 @@ export const AccountItem = ({
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
 
   const preventDefaultMouseEvent = (event: React.MouseEvent) => {
+    // Prevent triggering the native behaviour
     event.preventDefault();
     event.stopPropagation();
   };
@@ -54,9 +55,10 @@ export const AccountItem = ({
     }
   };
 
-  const handleCopyAddress = () => {
+  const handleCopyAddress = (event: React.MouseEvent) => {
+    preventDefaultMouseEvent(event);
     navigator.clipboard.writeText(address);
-    setMenuAnchorEl(null); // Ferme le menu après la copie
+    setMenuAnchorEl(null);
   };
 
   const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {


### PR DESCRIPTION
This PR enhances the Account List Modal by introducing a contextual menu that allows users to hide/unhide accounts and copy addresses.


https://github.com/user-attachments/assets/0744e41c-5bd0-4138-acd5-61e3fe1098ae

