### PR TITLE
fix: account list mismatch when reconnecting Snap

### DIFF
--- a/packages/wallet-ui/src/services/useStarkNetSnap.ts
+++ b/packages/wallet-ui/src/services/useStarkNetSnap.ts
@@ -30,7 +30,7 @@ import {
   updateCurrentAccount,
   setWalletConnection,
 } from 'slices/walletSlice';
-import { setActiveNetwork, setNetworks } from 'slices/networkSlice';
+import { setNetworksAndActiveNetwork } from 'slices/networkSlice';
 import { disableLoading, enableLoadingWithMessage } from 'slices/UISlice';
 import {
   Transaction,
@@ -156,13 +156,18 @@ export const useStarkNetSnap = () => {
         console.error('No networks found');
         return;
       }
-      dispatch(setNetworks(networks));
 
       const currentNetwork = await getCurrentNetwork();
       const idx = networks.findIndex(
         (network) => network.chainId === currentNetwork.chainId,
       );
-      dispatch(setActiveNetwork(idx));
+
+      dispatch(
+        setNetworksAndActiveNetwork({
+          networks,
+          activeNetwork: idx,
+        }),
+      );
 
       await initWalletData({
         chainId: currentNetwork.chainId,

--- a/packages/wallet-ui/src/slices/networkSlice.ts
+++ b/packages/wallet-ui/src/slices/networkSlice.ts
@@ -21,6 +21,10 @@ export const networkSlice = createSlice({
     setActiveNetwork: (state, action) => {
       state.activeNetwork = action.payload;
     },
+    setNetworksAndActiveNetwork: (state, action) => {
+      state.items = action.payload.networks;
+      state.activeNetwork = action.payload.activeNetwork;
+    },
     resetNetwork: () => {
       return {
         ...initialState,
@@ -29,7 +33,11 @@ export const networkSlice = createSlice({
   },
 });
 
-export const { setNetworks, setActiveNetwork, resetNetwork } =
-  networkSlice.actions;
+export const {
+  setNetworks,
+  setActiveNetwork,
+  setNetworksAndActiveNetwork,
+  resetNetwork,
+} = networkSlice.actions;
 
 export default networkSlice.reducer;

--- a/packages/wallet-ui/src/slices/networkSlice.ts
+++ b/packages/wallet-ui/src/slices/networkSlice.ts
@@ -15,9 +15,6 @@ export const networkSlice = createSlice({
   name: 'network',
   initialState,
   reducers: {
-    setNetworks: (state, action) => {
-      state.items = action.payload;
-    },
     setActiveNetwork: (state, action) => {
       state.activeNetwork = action.payload;
     },
@@ -33,11 +30,7 @@ export const networkSlice = createSlice({
   },
 });
 
-export const {
-  setNetworks,
-  setActiveNetwork,
-  setNetworksAndActiveNetwork,
-  resetNetwork,
-} = networkSlice.actions;
+export const { setActiveNetwork, setNetworksAndActiveNetwork, resetNetwork } =
+  networkSlice.actions;
 
 export default networkSlice.reducer;


### PR DESCRIPTION
## PR Description

The PR introduces a new Redux action: `setNetworksAndActiveNetwork({ networks, activeNetwork })`
- Replaces the two separate dispatches with a single atomic update to both networks and activeNetwork.
- Ensures consistent and up-to-date state when reconnecting to the Snap.
- Avoids race conditions or unnecessary re-renders that could happen between two separate dispatches.