### PR TITLE
fix: snap not working on firefox

### DIFF
--- a/packages/wallet-ui/src/services/useSnap.ts
+++ b/packages/wallet-ui/src/services/useSnap.ts
@@ -40,10 +40,9 @@ export const useSnap = () => {
         method: 'wallet_invokeSnap',
         params: {
           snapId,
-          request: {
-            method,
-            params: params ? removeUndefined(params) : params,
-          },
+          request: !params
+            ? { method }
+            : { method, params: params ? removeUndefined(params) : params },
         },
       });
       return response as unknown as Resp;

--- a/packages/wallet-ui/src/utils/utils.ts
+++ b/packages/wallet-ui/src/utils/utils.ts
@@ -285,9 +285,9 @@ export const removeUndefined = (
   obj: Record<string, unknown>,
 ): Record<string, unknown> => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  return Object.fromEntries(
+  return JSON.parse(JSON.stringify(Object.fromEntries(
     Object.entries(obj).filter(([_, val]) => val !== undefined),
-  );
+  )));
 };
 
 export const formatAddress = (address: string, starkName?: string): string => {

--- a/packages/wallet-ui/src/utils/utils.ts
+++ b/packages/wallet-ui/src/utils/utils.ts
@@ -285,9 +285,13 @@ export const removeUndefined = (
   obj: Record<string, unknown>,
 ): Record<string, unknown> => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  return JSON.parse(JSON.stringify(Object.fromEntries(
-    Object.entries(obj).filter(([_, val]) => val !== undefined),
-  )));
+  return JSON.parse(
+    JSON.stringify(
+      Object.fromEntries(
+        Object.entries(obj).filter(([_, val]) => val !== undefined),
+      ),
+    ),
+  );
 };
 
 export const formatAddress = (address: string, starkName?: string): string => {


### PR DESCRIPTION
This PR fixes Snap installation and usage on Firefox latest MetaMask. 

## Issue 1: In firefox calling `invokeSnap` with undefined fails, so we change this 

```
          request: {
            method,
            params: params ? removeUndefined(params) : params,
          },
```

by this 

```
          request: !params
            ? { method }
            : { method, params: params ? removeUndefined(params) : params },
``` 


## Issue 2: In firefox calling invokeSnap with an [Object] fails. We need to stringily and parse it with json to get a real plain object. 

We add `JSON.parse(JSON.stringify( .... ))` before returning in the removeUndefined utility function.

