### PR TITLE
chore: fix translation wrong keys

### DIFF
--- a/packages/starknet-snap/src/ui/components/SignMessageUI.tsx
+++ b/packages/starknet-snap/src/ui/components/SignMessageUI.tsx
@@ -29,7 +29,7 @@ export const SignMessageUI: SnapComponent<SignMessageUIProps> = ({
   const translate = getTranslator();
   return (
     <Box>
-      <Heading>{translate('signeMessagePrompt')}</Heading>
+      <Heading>{translate('signMessagePrompt')}</Heading>
       <Section>
         <SignerUI address={address} chainId={chainId} />
         <JsonDataUI label={translate('message')} data={typedDataMessage} />


### PR DESCRIPTION
There is a typo we use `translate('signeMessagePrompt')` but it should be `translate('signMessagePrompt')`

signeMessagePrompt => signMessagePrompt