### PR TITLE
fix: incorrect truncation in getMaxDecimalsReadable

### DIFF
--- a/packages/wallet-ui/src/utils/utils.ts
+++ b/packages/wallet-ui/src/utils/utils.ts
@@ -121,7 +121,10 @@ export const getMaxDecimalsReadable = (
   if (!trimmedDecimal) return integerPart;
 
   // Limit to max decimals
-  const limitedDecimal = trimmedDecimal.substring(0, DECIMALS_DISPLAYED_MAX_LENGTH);
+  const limitedDecimal = trimmedDecimal.substring(
+    0,
+    DECIMALS_DISPLAYED_MAX_LENGTH,
+  );
 
   return `${integerPart}.${limitedDecimal}`;
 };

--- a/packages/wallet-ui/src/utils/utils.ts
+++ b/packages/wallet-ui/src/utils/utils.ts
@@ -133,7 +133,6 @@ export const getMaxDecimalsReadable = (
   return `${String(Number(integerPart))}.${limitedDecimal}`;
 };
 
-
 export const getAmountPrice = (
   asset: Erc20TokenBalance,
   assetAmount: number,

--- a/packages/wallet-ui/src/utils/utils.ts
+++ b/packages/wallet-ui/src/utils/utils.ts
@@ -106,19 +106,23 @@ export const getMaxDecimalsReadable = (
     ? assetAmount
     : ethers.utils.formatUnits(asset.amount, asset.decimals);
 
-  // If there's no decimal point, just return the string (e.g. "10", "100")
+  // If there's no decimal point, just return normalized integer (e.g. "00010" → "10")
   const indexDecimal = amountStr.indexOf('.');
-  if (indexDecimal === -1) return amountStr;
+  if (indexDecimal === -1) return String(Number(amountStr));
 
   // Limit decimal part to DECIMALS_DISPLAYED_MAX_LENGTH
   const integerPart = amountStr.substring(0, indexDecimal);
   const decimalPart = amountStr.substring(indexDecimal + 1);
 
   // Remove trailing zeros from decimal part
-  const trimmedDecimal = decimalPart.replace(/0+$/, '');
+  let i = decimalPart.length;
+  while (i > 0 && decimalPart[i - 1] === '0') {
+    i--;
+  }
+  const trimmedDecimal = decimalPart.substring(0, i);
 
-  // If there's no significant decimal, just return integer part
-  if (!trimmedDecimal) return integerPart;
+  // If there's no significant decimal, just return normalized integer
+  if (!trimmedDecimal) return String(Number(integerPart));
 
   // Limit to max decimals
   const limitedDecimal = trimmedDecimal.substring(
@@ -126,8 +130,9 @@ export const getMaxDecimalsReadable = (
     DECIMALS_DISPLAYED_MAX_LENGTH,
   );
 
-  return `${integerPart}.${limitedDecimal}`;
+  return `${String(Number(integerPart))}.${limitedDecimal}`;
 };
+
 
 export const getAmountPrice = (
   asset: Erc20TokenBalance,

--- a/packages/wallet-ui/src/utils/utils.ts
+++ b/packages/wallet-ui/src/utils/utils.ts
@@ -105,19 +105,25 @@ export const getMaxDecimalsReadable = (
   const amountStr = assetAmount
     ? assetAmount
     : ethers.utils.formatUnits(asset.amount, asset.decimals);
+
+  // If there's no decimal point, just return the string (e.g. "10", "100")
   const indexDecimal = amountStr.indexOf('.');
-  const decimalPart = amountStr.substring(indexDecimal + 1).split('');
-  const firstNonZeroIndexReverse = decimalPart
-    .reverse()
-    .findIndex((char) => char !== '0');
-  if (firstNonZeroIndexReverse !== -1) {
-    let lastNonZeroIndex = amountStr.length - firstNonZeroIndexReverse;
-    if (lastNonZeroIndex - indexDecimal > DECIMALS_DISPLAYED_MAX_LENGTH) {
-      lastNonZeroIndex = indexDecimal + 1 + DECIMALS_DISPLAYED_MAX_LENGTH;
-    }
-    return amountStr.substring(0, lastNonZeroIndex);
-  }
-  return amountStr.substring(0, indexDecimal);
+  if (indexDecimal === -1) return amountStr;
+
+  // Limit decimal part to DECIMALS_DISPLAYED_MAX_LENGTH
+  const integerPart = amountStr.substring(0, indexDecimal);
+  const decimalPart = amountStr.substring(indexDecimal + 1);
+
+  // Remove trailing zeros from decimal part
+  const trimmedDecimal = decimalPart.replace(/0+$/, '');
+
+  // If there's no significant decimal, just return integer part
+  if (!trimmedDecimal) return integerPart;
+
+  // Limit to max decimals
+  const limitedDecimal = trimmedDecimal.substring(0, DECIMALS_DISPLAYED_MAX_LENGTH);
+
+  return `${integerPart}.${limitedDecimal}`;
 };
 
 export const getAmountPrice = (


### PR DESCRIPTION
## 🐛 Fix incorrect truncation in `getMaxDecimalsReadable`

This PR fixes a bug where integer values like `"100"` were incorrectly truncated to `"1"` due to logic that assumed all inputs had a decimal point. The function now properly checks for the presence of a decimal and avoids applying decimal trimming logic to whole numbers. This ensures values like `"100"` or `"10"` are returned as-is, while still correctly trimming and formatting decimal values.
