### PR TITLE
chore: add get-starknet proxying for dapp testing

### DIFF
--- a/packages/get-starknet/package.json
+++ b/packages/get-starknet/package.json
@@ -13,6 +13,10 @@
   },
   "scripts": {
     "start": "GET_STARKNET_PUBLIC_PATH=http://localhost:8082/ SNAP_ID=local:http://localhost:8081 yarn build && webpack-cli serve --config webpack.config.local.js",
+    "proxy:local": "GET_STARKNET_PROXY_TARGET=local mitmproxy -s scripts/proxy-local.py",
+    "proxy:local:web": "GET_STARKNET_PROXY_TARGET=local mitmweb -s scripts/proxy-local.py",
+    "proxy:dev": "GET_STARKNET_PROXY_TARGET=dev mitmproxy -s scripts/proxy-local.py",
+    "proxy:dev:web": "GET_STARKNET_PROXY_TARGET=dev mitmweb -s scripts/proxy-local.py",
     "clean": "rimraf dist",
     "build": "webpack --config webpack.config.build.js",
     "prettier": "prettier --write \"src/**/*.ts\"",

--- a/packages/get-starknet/scripts/README.md
+++ b/packages/get-starknet/scripts/README.md
@@ -1,0 +1,129 @@
+# Local get-starknet Proxy Setup
+
+This directory contains scripts to proxy requests from the production get-starknet CDN to your local development server, allowing you to test local changes on external dapps.
+
+## Prerequisites
+
+1. **Python 3.7+** - Required for mitmproxy
+2. **mitmproxy** - Install via pip:
+   ```bash
+   pip install mitmproxy
+   ```
+   Or via homebrew (macOS):
+   ```bash
+   brew install mitmproxy
+   ```
+
+## Quick Start
+
+1. **Start the local get-starknet dev server:**
+   ```bash
+   cd packages/get-starknet
+   yarn start
+   ```
+   This will start the dev server on `http://localhost:8082`
+
+2. **Start the mitmproxy:**
+   ```bash
+   cd packages/get-starknet
+   mitmproxy -s scripts/proxy-local.py
+   ```
+   
+   Or use the npm script:
+   ```bash
+   yarn proxy:local
+   ```
+
+   The proxy will run on port `8888` (default).
+
+3. **Configure your system/browser to use the proxy:**
+   
+   **Option A: macOS System Proxy (Recommended - applies to all apps):**
+   ```bash
+   cd packages/get-starknet
+   ./scripts/setup-proxy.sh
+   ```
+   This automatically configures macOS system proxy settings. To disable later:
+   ```bash
+   ./scripts/disable-proxy.sh
+   ```
+   
+   **Option B: Browser-only proxy:**
+   - **Chrome/Edge**: Use a proxy extension like [Proxy SwitchOmega](https://chrome.google.com/webstore/detail/proxy-switchomega/padekgcemlokbadohgkifijomclgjgif) or [FoxyProxy](https://chrome.google.com/webstore/detail/foxyproxy-standard/gcknhkkoolaabfmlnjonogaaifnjlfnp)
+   - **Firefox**: Settings → Network Settings → Manual proxy configuration
+     - HTTP Proxy: `localhost`, Port: `8888`
+     - Check "Use this proxy server for all protocols"
+   - **Safari**: System Preferences → Network → Advanced → Proxies
+     - Check "Web Proxy (HTTP)" and "Secure Web Proxy (HTTPS)"
+     - Server: `localhost`, Port: `8888`
+
+4. **Install mitmproxy CA certificate** (one-time setup):
+   - When you first visit a site through the proxy, mitmproxy will generate a CA certificate
+   - Open `http://mitm.it` in your browser while the proxy is running
+   - Download and install the certificate for your platform:
+     - **macOS**: Download the certificate, double-click to install, then add it to Keychain and trust it
+     - **Windows**: Download and install the certificate, then trust it in Certificate Manager
+     - **Linux**: Follow the instructions on the mitm.it page
+
+5. **Visit an external dapp** - Requests to `https://snaps.consensys.io/starknet/get-starknet/v1/*` will be automatically redirected to your local server at `http://localhost:8082/*`
+
+## How It Works
+
+The proxy script (`proxy-local.py`) intercepts HTTP/HTTPS requests and:
+
+1. **Detects requests** to the production CDN: `https://snaps.consensys.io/starknet/get-starknet/v1/*`
+2. **Redirects them** to the local development server: `http://localhost:8082/*`
+3. **Preserves the path** - e.g., `/remoteEntry.js`, `/main.*.js`, etc.
+4. **Adds CORS headers** to ensure cross-origin requests work properly
+
+**Important**: mitmproxy is an HTTP proxy, which means applications (browsers, curl, etc.) must be configured to use it. It cannot intercept traffic automatically without being configured as a proxy. This is why `curl -x http://localhost:8888` works, but regular `curl` doesn't - you need to configure your system or browser to route traffic through the proxy.
+
+## Alternative mitmproxy Interfaces
+
+- **mitmproxy** (console UI): `mitmproxy -s scripts/proxy-local.py`
+- **mitmweb** (web UI): `mitmweb -s scripts/proxy-local.py` - Opens a web interface at `http://127.0.0.1:8081`
+- **mitmdump** (console output): `mitmdump -s scripts/proxy-local.py` - Shows all requests in console
+
+## Troubleshooting
+
+### Certificate Issues
+
+If you see SSL/TLS errors:
+- Make sure you've installed the mitmproxy CA certificate
+- On macOS, you may need to trust the certificate in Keychain Access
+- Try visiting `http://mitm.it` again to re-download the certificate
+
+### Proxy Not Working
+
+- Verify the local dev server is running on port 8082
+- Check that your browser is configured to use the proxy
+- Look at the mitmproxy console for redirect messages like `[PROXY] Redirecting: ...`
+- Try using `mitmweb` to see a visual interface of all requests
+
+### CORS Errors
+
+The script automatically adds CORS headers, but if you still see CORS errors:
+- Check that the response headers are being set correctly
+- Verify the local dev server also has CORS enabled (it should via webpack.config.local.js)
+- Try clearing your browser cache
+
+### Port Conflicts
+
+If port 8888 is already in use:
+- Change the port in the mitmproxy command: `mitmproxy -p 8889 -s scripts/proxy-local.py`
+- Update your browser proxy settings to use the new port
+
+## Example Output
+
+When working correctly, you should see output like:
+```
+[PROXY] Redirecting: https://snaps.consensys.io/starknet/get-starknet/v1/remoteEntry.js -> http://localhost:8082/remoteEntry.js
+[PROXY] Redirecting: https://snaps.consensys.io/starknet/get-starknet/v1/main.abc123.js -> http://localhost:8082/main.abc123.js
+```
+
+## Stopping the Proxy
+
+Press `Ctrl+C` in the terminal where mitmproxy is running, or close the terminal window.
+
+Don't forget to disable the proxy in your browser settings when you're done testing!
+

--- a/packages/get-starknet/scripts/disable-proxy.sh
+++ b/packages/get-starknet/scripts/disable-proxy.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Helper script to disable macOS system proxy settings
+
+set -e
+
+echo "🔧 Disabling macOS system proxy settings..."
+echo ""
+
+# Check if running on macOS
+if [[ "$OSTYPE" != "darwin"* ]]; then
+    echo "❌ This script is for macOS only."
+    exit 1
+fi
+
+# Get the active network service (usually Wi-Fi or Ethernet)
+ACTIVE_SERVICE=$(networksetup -listallnetworkservices | grep -E "^(Wi-Fi|Ethernet)" | head -1)
+
+if [ -z "$ACTIVE_SERVICE" ]; then
+    echo "❌ Could not find active network service (Wi-Fi or Ethernet)"
+    exit 1
+fi
+
+echo "📡 Active network service: $ACTIVE_SERVICE"
+echo ""
+
+# Disable proxy
+echo "Disabling HTTP proxy..."
+networksetup -setwebproxystate "$ACTIVE_SERVICE" off
+
+echo "Disabling HTTPS proxy..."
+networksetup -setsecurewebproxystate "$ACTIVE_SERVICE" off
+
+echo ""
+echo "✅ System proxy disabled successfully!"
+echo ""
+

--- a/packages/get-starknet/scripts/proxy-local.py
+++ b/packages/get-starknet/scripts/proxy-local.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+mitmproxy script to redirect get-starknet requests from production to local or dev.
+
+This script intercepts get-starknet requests and redirects them based on configuration:
+- Set GET_STARKNET_PROXY_TARGET=local to redirect to localhost:8082
+- Set GET_STARKNET_PROXY_TARGET=dev to redirect to dev.snaps.consensys.io
+- Default: local
+
+Usage:
+    # Use local development server
+    GET_STARKNET_PROXY_TARGET=local mitmproxy -s scripts/proxy-local.py
+    
+    # Use dev server
+    GET_STARKNET_PROXY_TARGET=dev mitmproxy -s scripts/proxy-local.py
+    
+    # Or use mitmweb/mitmdump
+    GET_STARKNET_PROXY_TARGET=dev mitmweb -s scripts/proxy-local.py
+"""
+
+import os
+from mitmproxy import http
+
+
+# Production CDN host
+PRODUCTION_HOST = "snaps.consensys.io"
+# Development CDN host
+DEV_HOST = "dev.snaps.consensys.io"
+# Local development server
+LOCAL_SERVER = "http://localhost:8082"
+
+# Get proxy target from environment variable (default: dev)
+PROXY_TARGET = os.environ.get("GET_STARKNET_PROXY_TARGET", "dev").lower()
+
+def request(flow: http.HTTPFlow) -> None:
+    """
+    Intercept HTTP requests and redirect get-starknet requests based on configuration.
+    """
+    # Only handle get-starknet requests
+    if PRODUCTION_HOST in flow.request.pretty_host and "/starknet/get-starknet/v1/" in flow.request.path:
+        original_url = flow.request.pretty_url
+        
+        # Extract the path after the prefix
+        path_prefix = "/starknet/get-starknet/v1/"
+        path_after_prefix = flow.request.path[len(path_prefix):]
+        
+        # Log original request
+        print(f"[PROXY] Intercepted get-starknet: {original_url}")
+        print(f"[PROXY] Proxy target: {PROXY_TARGET}")
+        
+        if PROXY_TARGET == "dev":
+            # Redirect to dev environment
+            flow.request.host = DEV_HOST
+            # Keep the same scheme (https) and path
+            flow.request.headers["Host"] = DEV_HOST
+            
+            new_url = f"{flow.request.scheme}://{DEV_HOST}{flow.request.path}"
+            print(f"[PROXY] Redirected to dev: {original_url} → {new_url}")
+        
+        else:  # default to local
+            # Redirect to local server
+            flow.request.scheme = "http"
+            flow.request.host = "localhost"
+            flow.request.port = 8082
+            flow.request.path = f"/{path_after_prefix}"
+            flow.request.headers["Host"] = "localhost:8082"
+            
+            new_url = f"{LOCAL_SERVER}{flow.request.path}"
+            print(f"[PROXY] Redirected to local: {original_url} → {new_url}")
+
+def response(flow: http.HTTPFlow) -> None:
+    """
+    Modify response headers to ensure CORS works properly.
+    """
+    # Add CORS headers if the response is from our local server
+    if flow.request.host == "localhost" and flow.request.port == 8082:
+        flow.response.headers["Access-Control-Allow-Origin"] = "*"
+        flow.response.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, PATCH, OPTIONS"
+        flow.response.headers["Access-Control-Allow-Headers"] = "X-Requested-With, content-type, Authorization"
+        flow.response.headers["Access-Control-Allow-Credentials"] = "true"
+        
+        # Log response for debugging
+        if flow.response.status_code != 200:
+            print(f"[PROXY] ⚠️  Response status: {flow.response.status_code} for {flow.request.path}")
+    
+    # Log non-200 responses from dev environment for debugging
+    elif flow.request.host == DEV_HOST and flow.response.status_code != 200:
+        print(f"[PROXY] ⚠️  Dev response status: {flow.response.status_code} for {flow.request.path}")

--- a/packages/get-starknet/scripts/setup-proxy.sh
+++ b/packages/get-starknet/scripts/setup-proxy.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Helper script to configure macOS system proxy settings for mitmproxy
+# This sets the HTTP and HTTPS proxy to localhost:8888
+
+set -e
+
+PROXY_HOST="127.0.0.1"
+PROXY_PORT="8088"
+
+echo "🔧 Configuring macOS system proxy settings..."
+echo "   Proxy: $PROXY_HOST:$PROXY_PORT"
+echo ""
+
+# Check if running on macOS
+if [[ "$OSTYPE" != "darwin"* ]]; then
+    echo "❌ This script is for macOS only."
+    echo "   For other systems, configure proxy manually in your browser/system settings."
+    exit 1
+fi
+
+# Get the active network service (usually Wi-Fi or Ethernet)
+ACTIVE_SERVICE=$(networksetup -listallnetworkservices | grep -E "^(Wi-Fi|Ethernet)" | head -1)
+
+if [ -z "$ACTIVE_SERVICE" ]; then
+    echo "❌ Could not find active network service (Wi-Fi or Ethernet)"
+    exit 1
+fi
+
+echo "📡 Active network service: $ACTIVE_SERVICE"
+echo ""
+
+# Set HTTP proxy
+echo "Setting HTTP proxy..."
+networksetup -setwebproxy "$ACTIVE_SERVICE" "$PROXY_HOST" "$PROXY_PORT"
+
+# Set HTTPS proxy
+echo "Setting HTTPS proxy..."
+networksetup -setsecurewebproxy "$ACTIVE_SERVICE" "$PROXY_HOST" "$PROXY_PORT"
+
+# Enable proxy
+echo "Enabling proxy..."
+networksetup -setwebproxystate "$ACTIVE_SERVICE" on
+networksetup -setsecurewebproxystate "$ACTIVE_SERVICE" on
+
+echo ""
+echo "✅ System proxy configured successfully!"
+echo ""
+echo "⚠️  IMPORTANT: Install mitmproxy CA certificate:"
+echo "   1. Make sure mitmproxy is running"
+echo "   2. Visit http://mitm.it in your browser"
+echo "   3. Download and install the certificate for macOS"
+echo ""
+echo "To disable the proxy later, run:"
+echo "   ./scripts/disable-proxy.sh"
+echo ""
+

--- a/packages/get-starknet/webpack.config.local.js
+++ b/packages/get-starknet/webpack.config.local.js
@@ -16,6 +16,7 @@ module.exports = (env) =>
       static: path.join(__dirname, 'dist/webpack'),
       compress: true,
       port: 8082,
+      allowedHosts: 'all', // Allow all hosts - needed for proxy
       headers: {
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Primarily dev tooling, but it introduces proxy scripts that can intercept HTTPS traffic and changes `webpack-dev-server` host validation (`allowedHosts: 'all'`), which could be misused if run in unsafe environments.
> 
> **Overview**
> Adds a mitmproxy-based workflow for testing local `get-starknet` changes against external dapps by redirecting production CDN requests (`snaps.consensys.io/starknet/get-starknet/v1/*`) to either `localhost:8082` or `dev.snaps.consensys.io` via `GET_STARKNET_PROXY_TARGET`.
> 
> Includes new `yarn proxy:*` scripts, macOS helper scripts to enable/disable system proxy, and updates the local webpack dev server to allow all hosts for proxying and to ensure CORS headers are present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6049cec805d193493bc51fff51e57d1cc0d56733. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->