### PR TITLE
chore: use oidc publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,6 +3,10 @@ name: Publish NPM
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  id-token: write  # Required for OIDC
+
 jobs:
   prepare-deployment:
     environment: production
@@ -143,5 +147,4 @@ jobs:
         run: |
           npm publish ./packages/starknet-snap --tag "$TAG" --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           TAG: ${{ needs.prepare-deployment.outputs.TAG }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the release/publishing authentication path; misconfiguration could block releases or unintentionally alter publish permissions, though the change is isolated to CI.
> 
> **Overview**
> Switches the `Publish NPM` GitHub Actions workflow to **OIDC-based publishing** by granting workflow-level `id-token: write` permissions.
> 
> Removes the use of `NODE_AUTH_TOKEN`/`secrets.NPM_TOKEN` during `npm publish`, relying on the runner’s OIDC token flow instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 796a0268445a9925f38b10bb351b42677bdfe741. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->