### PR TITLE
revert: "chore: use oidc publish"

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,10 +3,6 @@ name: Publish NPM
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
-  id-token: write  # Required for OIDC
-
 jobs:
   prepare-deployment:
     environment: production
@@ -147,4 +143,5 @@ jobs:
         run: |
           npm publish ./packages/starknet-snap --tag "$TAG" --access public
         env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           TAG: ${{ needs.prepare-deployment.outputs.TAG }}


### PR DESCRIPTION
Reverts Consensys/starknet-snap#571

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production NPM release workflow and changes authentication/permissions for publishing, which can break releases or affect publishing credentials if misconfigured.
> 
> **Overview**
> Updates the `Publish NPM` GitHub Actions workflow to stop using OIDC-based publishing permissions and instead authenticate `npm publish` with `NODE_AUTH_TOKEN` from `secrets.NPM_TOKEN`.
> 
> This also removes the top-level `permissions` block (including `id-token: write`), shifting away from workflow-wide OIDC settings while keeping job-level `contents: write` where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48ecd1234b2eac547ebd4ef1c8969de4a05900e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->