### PR TITLE
fix: starkscan api integration, update response structure and fix timestamp handling 

### DIFF
--- a/packages/starknet-snap/src/__tests__/helper.ts
+++ b/packages/starknet-snap/src/__tests__/helper.ts
@@ -41,7 +41,7 @@ import {
   PROXY_CONTRACT_HASH,
 } from '../utils/constants';
 import { grindKey } from '../utils/keyPair';
-import { invokeTx, cairo0DeployTx } from './fixture/stark-scan-example.json';
+import { invokeTx } from './fixture/stark-scan-example.json';
 
 /* eslint-disable */
 export type StarknetAccount = AccContract & {
@@ -527,42 +527,70 @@ export function generateStarkScanTransactions({
   cnt?: number;
   txnTypes?: TransactionType[];
 }): StarkScanTransactionsResponse {
+  const toIso = (value: number) => {
+    const ms = value > 1e12 ? value : value * 1000;
+    return new Date(ms).toISOString();
+  };
+
   let transactionStartFrom = startFrom;
   const txs: StarkScanTransaction[] = [];
-  let totalRecordCnt = txnTypes.includes(TransactionType.DEPLOY_ACCOUNT)
+  const totalRecordCnt = txnTypes.includes(TransactionType.DEPLOY_ACCOUNT)
     ? cnt - 1
     : cnt;
+  const tokenAddress = invokeTx.account_calls[0].contract_address;
+  const transferCalldata = invokeTx.account_calls[0].calldata;
 
   for (let i = 0; i < totalRecordCnt; i++) {
-    let newTx = {
-      ...invokeTx,
-      account_calls: [...invokeTx.account_calls],
-    };
-    newTx.sender_address = address;
-    newTx.account_calls[0].caller_address = address;
-    newTx.timestamp = transactionStartFrom;
-    newTx.transaction_hash = validateAndParseAddress(
-      `0x${transactionStartFrom.toString(16)}`,
-    );
+    const timestampIso = toIso(transactionStartFrom);
+    txs.push({
+      blockNumber: 1,
+      timestampIso,
+      txIndex: i,
+      txHash: validateAndParseAddress(`0x${transactionStartFrom.toString(16)}`),
+      kinds: ['token_in', 'contract_call'],
+      counterparty: transferCalldata[0],
+      txType: TransactionType.INVOKE,
+      executionStatus: TransactionExecutionStatus.SUCCEEDED,
+      finalityStatus: TransactionFinalityStatus.ACCEPTED_ON_L1,
+      fromAddress: address,
+      toAddress: tokenAddress,
+      primaryMethod: 'transfer',
+      callCount: 1,
+      methodsDiffer: false,
+      transferCount: 1,
+      topTransferTokenAddress: tokenAddress,
+      topTransferAmount: transferCalldata[1],
+      topTransferStandard: 'erc20',
+    });
     transactionStartFrom -= timestampReduction;
-    txs.push(newTx as unknown as StarkScanTransaction);
   }
 
   if (txnTypes.includes(TransactionType.DEPLOY_ACCOUNT)) {
-    let deployTx = {
-      ...cairo0DeployTx,
-      account_calls: [...cairo0DeployTx.account_calls],
-    };
-    deployTx.contract_address = address;
-    deployTx.transaction_hash = validateAndParseAddress(
-      `0x${transactionStartFrom.toString(16)}`,
-    );
-    txs.push(deployTx as unknown as StarkScanTransaction);
+    txs.push({
+      blockNumber: 1,
+      timestampIso: toIso(transactionStartFrom),
+      txIndex: totalRecordCnt,
+      txHash: validateAndParseAddress(`0x${transactionStartFrom.toString(16)}`),
+      kinds: ['account_deploy'],
+      counterparty: null,
+      txType: TransactionType.DEPLOY_ACCOUNT,
+      executionStatus: TransactionExecutionStatus.SUCCEEDED,
+      finalityStatus: TransactionFinalityStatus.ACCEPTED_ON_L1,
+      fromAddress: address,
+      toAddress: address,
+      primaryMethod: null,
+      callCount: 0,
+      methodsDiffer: false,
+      transferCount: 0,
+      topTransferTokenAddress: null,
+      topTransferAmount: null,
+      topTransferStandard: null,
+    });
   }
 
   return {
-    next_url: null,
-    data: txs,
+    nextCursor: null,
+    items: txs,
   };
 }
 

--- a/packages/starknet-snap/src/__tests__/helper.ts
+++ b/packages/starknet-snap/src/__tests__/helper.ts
@@ -41,7 +41,6 @@ import {
   PROXY_CONTRACT_HASH,
 } from '../utils/constants';
 import { grindKey } from '../utils/keyPair';
-import { invokeTx } from './fixture/stark-scan-example.json';
 
 /* eslint-disable */
 export type StarknetAccount = AccContract & {
@@ -537,8 +536,8 @@ export function generateStarkScanTransactions({
   const totalRecordCnt = txnTypes.includes(TransactionType.DEPLOY_ACCOUNT)
     ? cnt - 1
     : cnt;
-  const tokenAddress = invokeTx.account_calls[0].contract_address;
-  const transferCalldata = invokeTx.account_calls[0].calldata;
+  const tokenAddress = PRELOADED_TOKENS[0].address;
+  const transferCalldata = [address, '1000'];
 
   for (let i = 0; i < totalRecordCnt; i++) {
     const timestampIso = toIso(transactionStartFrom);

--- a/packages/starknet-snap/src/chain/api-client.ts
+++ b/packages/starknet-snap/src/chain/api-client.ts
@@ -69,7 +69,9 @@ export abstract class ApiClient {
       url,
       method,
       headers: {
-        'Content-Type': 'application/json',
+        ...(method === HttpMethod.Post
+          ? { 'Content-Type': 'application/json' }
+          : {}),
         ...headers,
       },
       body:

--- a/packages/starknet-snap/src/chain/data-client/starkscan.test.ts
+++ b/packages/starknet-snap/src/chain/data-client/starkscan.test.ts
@@ -101,10 +101,10 @@ describe('StarkScanClient', () => {
 
   const mockTxByType = (txnType: TransactionType, address: string) => {
     const mockResponse = generateStarkScanTransactions({
-        address,
-        txnTypes: [txnType],
-        cnt: 1,
-      });
+      address,
+      txnTypes: [txnType],
+      cnt: 1,
+    });
     const tx = mockResponse.items[0];
     return tx;
   };
@@ -344,13 +344,11 @@ describe('StarkScanClient', () => {
       const client = createMockClient();
       const result = client.toTransaction(mockTx);
 
-      const { contract_address: contract, calldata: contractCallData } = {
-        contract_address: mockTx.topTransferTokenAddress as string,
-        calldata:
-          mockTx.counterparty && mockTx.topTransferAmount
-            ? [mockTx.counterparty, mockTx.topTransferAmount]
-            : [],
-      };
+      const contract = mockTx.topTransferTokenAddress as string;
+      const contractCallData =
+        mockTx.counterparty && mockTx.topTransferAmount
+          ? [mockTx.counterparty, mockTx.topTransferAmount]
+          : [];
 
       expect(result).toStrictEqual({
         txnHash: mockTx.txHash,
@@ -458,18 +456,14 @@ describe('StarkScanClient', () => {
       const mockTx = await prepareMockTx();
 
       const client = createMockClient();
-      expect(client.getSenderAddress(mockTx)).toStrictEqual(
-        mockTx.fromAddress,
-      );
+      expect(client.getSenderAddress(mockTx)).toStrictEqual(mockTx.fromAddress);
     });
 
     it('returns the contract address if it is a deploy transaction', async () => {
       const mockTx = await prepareMockTx(TransactionType.DEPLOY_ACCOUNT);
 
       const client = createMockClient();
-      expect(client.getSenderAddress(mockTx)).toStrictEqual(
-        mockTx.toAddress,
-      );
+      expect(client.getSenderAddress(mockTx)).toStrictEqual(mockTx.toAddress);
     });
 
     it('returns an empty string if the sender address is null', async () => {
@@ -479,7 +473,6 @@ describe('StarkScanClient', () => {
       expect(
         client.getSenderAddress({
           ...mockTx,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           fromAddress: null,
         }),
       ).toBe('');

--- a/packages/starknet-snap/src/chain/data-client/starkscan.test.ts
+++ b/packages/starknet-snap/src/chain/data-client/starkscan.test.ts
@@ -81,7 +81,7 @@ describe('StarkScanClient', () => {
   const mockApiSuccess = ({
     fetchSpy,
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    response = { data: [], next_url: null },
+    response = { items: [], nextCursor: null },
   }: {
     fetchSpy: jest.SpyInstance;
     response?: StarkScanTransactionsResponse;
@@ -101,11 +101,11 @@ describe('StarkScanClient', () => {
 
   const mockTxByType = (txnType: TransactionType, address: string) => {
     const mockResponse = generateStarkScanTransactions({
-      address,
-      txnTypes: [txnType],
-      cnt: 1,
-    });
-    const tx = mockResponse.data[0];
+        address,
+        txnTypes: [txnType],
+        cnt: 1,
+      });
+    const tx = mockResponse.items[0];
     return tx;
   };
 
@@ -113,11 +113,11 @@ describe('StarkScanClient', () => {
     it.each([
       {
         network: STARKNET_SEPOLIA_TESTNET_NETWORK,
-        expectedUrl: 'https://api-sepolia.starkscan.co/api/v0',
+        expectedUrl: 'https://api.starkscan.co',
       },
       {
         network: STARKNET_MAINNET_NETWORK,
-        expectedUrl: 'https://api.starkscan.co/api/v0',
+        expectedUrl: 'https://api.starkscan.co',
       },
     ])(
       'returns the api url if the chain id is $network.name',
@@ -159,7 +159,7 @@ describe('StarkScanClient', () => {
     it('fetches data', async () => {
       const { fetchSpy } = createMockFetch();
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      const expectedResponse = { data: [], next_url: null };
+      const expectedResponse = { items: [], nextCursor: null };
       mockApiSuccess({ fetchSpy, response: expectedResponse });
 
       const client = createMockClient();
@@ -185,8 +185,7 @@ describe('StarkScanClient', () => {
         method: 'GET',
         body: undefined,
         headers: {
-          'Content-Type': 'application/json',
-          'x-api-key': apiKey,
+          'X-Starkscan-Api-Key': apiKey,
         },
       });
     });
@@ -232,10 +231,11 @@ describe('StarkScanClient', () => {
       // - it's timestamp is greater than the `tillTo`
       // - it's transaction type is `DEPLOY_ACCOUNT`
       expect(result).toHaveLength(
-        mockResponse.data.filter(
+        mockResponse.items.filter(
           (tx) =>
-            tx.transaction_type === TransactionType.DEPLOY_ACCOUNT ||
-            tx.timestamp >= to,
+            tx.txType === TransactionType.DEPLOY_ACCOUNT ||
+            (tx.timestampIso &&
+              Math.floor(Date.parse(tx.timestampIso) / 1000) >= to),
         ).length,
       );
       expect(
@@ -258,7 +258,7 @@ describe('StarkScanClient', () => {
       expect(result).toStrictEqual([]);
     });
 
-    it('continue to fetch if next_url is presented', async () => {
+    it('continue to fetch if nextCursor is presented', async () => {
       const account = await mockAccount();
       const { fetchSpy } = createMockFetch();
       // generate the to timestamp which is 100 days ago
@@ -272,19 +272,17 @@ describe('StarkScanClient', () => {
         address: account.address,
         cnt: 10,
       });
-      const firstPageUrl = `https://api-sepolia.starkscan.co/api/v0/transactions?contract_address=${account.address}&order_by=desc&limit=100`;
-      const nextPageUrl = `https://api-sepolia.starkscan.co/api/v0/transactions?contract_address=${account.address}&order_by=desc&cursor=MTcyNDc1OTQwNzAwMDAwNjAwMDAwMA%3D%3D`;
+      const firstPageUrl = `https://api.starkscan.co/v1/SN_SEPOLIA/address/${account.address}/transactions?limit=100`;
+      const nextCursor = 'opaque-cursor-1';
+      const nextPageUrl = `https://api.starkscan.co/v1/SN_SEPOLIA/address/${account.address}/transactions?limit=100&cursor=${nextCursor}`;
 
-      // mock the first page response, which contains the next_url
       mockApiSuccess({
         fetchSpy,
         response: {
-          data: mockPage1Response.data,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          next_url: nextPageUrl,
+          items: mockPage1Response.items,
+          nextCursor,
         },
       });
-      // mock the send page response
       mockApiSuccess({ fetchSpy, response: mockPage2Response });
 
       const client = createMockClient();
@@ -346,21 +344,26 @@ describe('StarkScanClient', () => {
       const client = createMockClient();
       const result = client.toTransaction(mockTx);
 
-      const { contract_address: contract, calldata: contractCallData } =
-        mockTx.account_calls[0];
+      const { contract_address: contract, calldata: contractCallData } = {
+        contract_address: mockTx.topTransferTokenAddress as string,
+        calldata:
+          mockTx.counterparty && mockTx.topTransferAmount
+            ? [mockTx.counterparty, mockTx.topTransferAmount]
+            : [],
+      };
 
       expect(result).toStrictEqual({
-        txnHash: mockTx.transaction_hash,
-        txnType: mockTx.transaction_type,
+        txnHash: mockTx.txHash,
+        txnType: mockTx.txType,
         chainId: STARKNET_SEPOLIA_TESTNET_NETWORK.chainId,
         senderAddress: account.address,
-        contractAddress: '',
-        timestamp: mockTx.timestamp,
-        finalityStatus: mockTx.transaction_finality_status,
-        executionStatus: mockTx.transaction_execution_status,
-        failureReason: mockTx.revert_error ?? '',
-        maxFee: mockTx.max_fee,
-        actualFee: mockTx.actual_fee,
+        contractAddress: mockTx.toAddress,
+        timestamp: Math.floor(Date.parse(mockTx.timestampIso as string) / 1000),
+        finalityStatus: mockTx.finalityStatus,
+        executionStatus: mockTx.executionStatus,
+        failureReason: '',
+        maxFee: '0',
+        actualFee: null,
         accountCalls: {
           [contract]: [
             {
@@ -372,7 +375,7 @@ describe('StarkScanClient', () => {
             },
           ],
         },
-        version: mockTx.version,
+        version: 3,
         dataVersion: TransactionDataVersion.V2,
       });
     });
@@ -388,19 +391,19 @@ describe('StarkScanClient', () => {
       const result = client.toTransaction(mockTx);
 
       expect(result).toStrictEqual({
-        txnHash: mockTx.transaction_hash,
-        txnType: mockTx.transaction_type,
+        txnHash: mockTx.txHash,
+        txnType: mockTx.txType,
         chainId: STARKNET_SEPOLIA_TESTNET_NETWORK.chainId,
         senderAddress: account.address,
         contractAddress: account.address,
-        timestamp: mockTx.timestamp,
-        finalityStatus: mockTx.transaction_finality_status,
-        executionStatus: mockTx.transaction_execution_status,
-        failureReason: mockTx.revert_error ?? '',
-        maxFee: mockTx.max_fee,
-        actualFee: mockTx.actual_fee,
+        timestamp: Math.floor(Date.parse(mockTx.timestampIso as string) / 1000),
+        finalityStatus: mockTx.finalityStatus,
+        executionStatus: mockTx.executionStatus,
+        failureReason: '',
+        maxFee: null,
+        actualFee: null,
         accountCalls: null,
-        version: mockTx.version,
+        version: 3,
         dataVersion: TransactionDataVersion.V2,
       });
     });
@@ -456,7 +459,7 @@ describe('StarkScanClient', () => {
 
       const client = createMockClient();
       expect(client.getSenderAddress(mockTx)).toStrictEqual(
-        mockTx.sender_address,
+        mockTx.fromAddress,
       );
     });
 
@@ -465,7 +468,7 @@ describe('StarkScanClient', () => {
 
       const client = createMockClient();
       expect(client.getSenderAddress(mockTx)).toStrictEqual(
-        mockTx.contract_address,
+        mockTx.toAddress,
       );
     });
 
@@ -477,7 +480,7 @@ describe('StarkScanClient', () => {
         client.getSenderAddress({
           ...mockTx,
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          sender_address: null,
+          fromAddress: null,
         }),
       ).toBe('');
     });

--- a/packages/starknet-snap/src/chain/data-client/starkscan.ts
+++ b/packages/starknet-snap/src/chain/data-client/starkscan.ts
@@ -207,7 +207,14 @@ export class StarkScanClient extends ApiClient implements IDataClient {
 
     let transaction: V2Transaction;
 
-    if (!this.isDeployTransaction(tx)) {
+    if (this.isDeployTransaction(tx)) {
+      transaction = newDeployTransaction({
+        txnHash,
+        senderAddress,
+        chainId,
+        txnVersion,
+      });
+    } else {
       const tokenAddress = topTransferTokenAddress ?? tx.toAddress ?? '';
       const calldata =
         counterparty && topTransferAmount
@@ -227,13 +234,6 @@ export class StarkScanClient extends ApiClient implements IDataClient {
               },
             ]
           : [],
-        txnVersion,
-      });
-    } else {
-      transaction = newDeployTransaction({
-        txnHash,
-        senderAddress,
-        chainId,
         txnVersion,
       });
     }

--- a/packages/starknet-snap/src/chain/data-client/starkscan.ts
+++ b/packages/starknet-snap/src/chain/data-client/starkscan.ts
@@ -27,32 +27,44 @@ export class StarkScanClient extends ApiClient implements IDataClient {
 
   protected options: StarkScanOptions;
 
-  protected deploySelectorName = 'constructor';
-
   constructor(network: Network, options: StarkScanOptions) {
     super();
     this.network = network;
     this.options = options;
   }
 
-  protected get baseUrl(): string {
+  protected get chain(): string {
     switch (this.network.chainId) {
       case constants.StarknetChainId.SN_SEPOLIA:
-        return 'https://api-sepolia.starkscan.co/api/v0';
+        return 'SN_SEPOLIA';
       case constants.StarknetChainId.SN_MAIN:
-        return 'https://api.starkscan.co/api/v0';
+        return 'SN_MAIN';
       default:
         throw new InvalidNetworkError();
     }
   }
 
-  protected getApiUrl(endpoint: string): string {
-    return `${this.baseUrl}${endpoint}`;
+  protected get baseUrl(): string {
+    switch (this.network.chainId) {
+      case constants.StarknetChainId.SN_SEPOLIA:
+      case constants.StarknetChainId.SN_MAIN:
+        return 'https://api.starkscan.co';
+      default:
+        throw new InvalidNetworkError();
+    }
+  }
+
+  protected getApiUrl(address: string, cursor?: string): string {
+    let url = `${this.baseUrl}/v1/${this.chain}/address/${address}/transactions?limit=${this.limit}`;
+    if (cursor) {
+      url += `&cursor=${encodeURIComponent(cursor)}`;
+    }
+    return url;
   }
 
   protected getHttpHeaders(): HttpHeaders {
     return {
-      'x-api-key': this.options.apiKey,
+      'X-Starkscan-Api-Key': this.options.apiKey,
     };
   }
 
@@ -78,26 +90,20 @@ export class StarkScanClient extends ApiClient implements IDataClient {
 
   /**
    * Fetches the transactions for a given contract address.
-   * The transactions are fetched in descending order and it will include the deploy transaction.
+   * The transactions are fetched newest-first and include the deploy transaction when found.
    *
    * @param address - The address of the contract to fetch the transactions for.
-   * @param to - The filter includes transactions with a timestamp that is >= a specified value, but the deploy transaction is always included regardless of its timestamp.
+   * @param to - Unix timestamp; include txs at or after this time. Deploy txs are always included.
    * @returns A Promise that resolve an array of Transaction object.
    */
   async getTransactions(address: string, to: number): Promise<Transaction[]> {
-    let apiUrl = this.getApiUrl(
-      `/transactions?contract_address=${address}&order_by=desc&limit=${this.limit}`,
-    );
+    let apiUrl = this.getApiUrl(address);
 
     const txs: Transaction[] = [];
     let deployTxFound = false;
     let process = true;
     let timestamp = 0;
 
-    // Scan the transactions in descending order by timestamp
-    // Include the transaction if:
-    // - it's timestamp is greater than the `tillTo` AND
-    // - there is an next data to fetch
     while (process && (timestamp === 0 || timestamp >= to)) {
       process = false;
 
@@ -107,7 +113,7 @@ export class StarkScanClient extends ApiClient implements IDataClient {
         requestName: 'getTransactions',
       });
 
-      for (const data of result.data) {
+      for (const data of result.items) {
         const tx = this.toTransaction(data);
         const isDeployTx = this.isDeployTransaction(data);
 
@@ -116,29 +122,17 @@ export class StarkScanClient extends ApiClient implements IDataClient {
         }
 
         timestamp = tx.timestamp;
-        // Only include the records that newer than or equal to the `to` timestamp from the same batch of result
-        // If there is an deploy transaction from the result, it should included too.
-        // e.g
-        // to: 1000
-        // [
-        //   { timestamp: 1100, transaction_type: "invoke"  }, <-- include
-        //   { timestamp: 900, transaction_type: "invoke" }, <-- exclude
-        //   { timestamp: 100, transaction_type: "deploy" }  <-- include
-        // ]
         if (timestamp >= to || isDeployTx) {
           txs.push(tx);
         }
       }
 
-      if (result.next_url) {
-        apiUrl = result.next_url;
+      if (result.nextCursor) {
+        apiUrl = this.getApiUrl(address, result.nextCursor);
         process = true;
       }
     }
 
-    // In case no deploy transaction found from above,
-    // then scan the transactions in asc order by timestamp,
-    // the deploy transaction should usually be the first transaction from the list
     if (!deployTxFound) {
       const deployTx = await this.getDeployTransaction(address);
       deployTx && txs.push(deployTx);
@@ -154,19 +148,14 @@ export class StarkScanClient extends ApiClient implements IDataClient {
    * @returns A Promise that resolve the Transaction object or null if the transaction can not be found.
    */
   async getDeployTransaction(address: string): Promise<Transaction | null> {
-    // Fetch the first 5 transactions to find the deploy transaction
-    // The deploy transaction usually is the first transaction from the list
-    const apiUrl = this.getApiUrl(
-      `/transactions?contract_address=${address}&order_by=asc&limit=5`,
-    );
-
+    const apiUrl = this.getApiUrl(address);
     const result = await this.sendApiRequest<StarkScanTransactionsResponse>({
       apiUrl,
       responseStruct: StarkScanTransactionsResponseStruct,
       requestName: 'getTransactions',
     });
 
-    for (const data of result.data) {
+    for (const data of result.items) {
       if (this.isDeployTransaction(data)) {
         return this.toTransaction(data);
       }
@@ -176,62 +165,68 @@ export class StarkScanClient extends ApiClient implements IDataClient {
   }
 
   protected isDeployTransaction(tx: StarkScanTransaction): boolean {
-    return tx.transaction_type === TransactionType.DEPLOY_ACCOUNT;
+    return tx.txType === TransactionType.DEPLOY_ACCOUNT;
   }
 
   protected getContractAddress(tx: StarkScanTransaction): string {
-    // backfill the contract address if it is null
-    return tx.contract_address ?? '';
+    return tx.toAddress ?? tx.topTransferTokenAddress ?? '';
   }
 
   protected getSenderAddress(tx: StarkScanTransaction): string {
-    let sender = tx.sender_address;
-
     if (this.isDeployTransaction(tx)) {
-      // if it is a deploy transaction, the contract address is the sender address
-      sender = tx.contract_address as unknown as string;
+      return tx.toAddress ?? tx.fromAddress ?? '';
     }
+    return tx.fromAddress ?? '';
+  }
 
-    // backfill the sender address if it is null
-    return sender ?? '';
+  protected toUnixTimestamp(timestampIso: string | null): number {
+    if (!timestampIso) {
+      return 0;
+    }
+    const ms = Date.parse(timestampIso);
+    return Number.isNaN(ms) ? 0 : Math.floor(ms / 1000);
   }
 
   protected toTransaction(tx: StarkScanTransaction): Transaction {
-    /* eslint-disable @typescript-eslint/naming-convention, camelcase */
     const {
-      transaction_hash: txnHash,
-      transaction_type: txnType,
-      timestamp,
-      transaction_finality_status: finalityStatus,
-      transaction_execution_status: executionStatus,
-      max_fee,
-      actual_fee: actualFee,
-      revert_error,
-      // account_calls representing the calls to invoke from the account contract, it can be multiple
-      // If the transaction is a deploy transaction, the account_calls is a empty array
-      account_calls: calls,
-      version: txnVersion,
+      txHash: txnHash,
+      txType: txnType,
+      timestampIso,
+      finalityStatus,
+      executionStatus,
+      topTransferTokenAddress,
+      topTransferAmount,
+      counterparty,
+      primaryMethod,
     } = tx;
 
     const { chainId } = this.network;
     const senderAddress = this.getSenderAddress(tx);
-    const failureReason = revert_error ?? '';
-    const maxFee = max_fee ?? '0';
+    const timestamp = this.toUnixTimestamp(timestampIso);
+    const txnVersion = 3;
 
     let transaction: V2Transaction;
 
-    // eslint-disable-next-line no-negated-condition
     if (!this.isDeployTransaction(tx)) {
+      const tokenAddress = topTransferTokenAddress ?? tx.toAddress ?? '';
+      const calldata =
+        counterparty && topTransferAmount
+          ? [counterparty, topTransferAmount]
+          : [];
       transaction = newInvokeTransaction({
         txnHash,
         senderAddress,
         chainId,
-        maxFee,
-        calls: calls.map((call) => ({
-          contractAddress: call.contract_address,
-          entrypoint: call.selector,
-          calldata: call.calldata,
-        })),
+        maxFee: '0',
+        calls: tokenAddress
+          ? [
+              {
+                contractAddress: tokenAddress,
+                entrypoint: primaryMethod ?? 'transfer',
+                calldata,
+              },
+            ]
+          : [],
         txnVersion,
       });
     } else {
@@ -245,16 +240,14 @@ export class StarkScanClient extends ApiClient implements IDataClient {
 
     return {
       ...transaction,
-      // Override the fields from the StarkScanTransaction
       timestamp,
-      finalityStatus,
-      executionStatus,
-      actualFee,
-      maxFee,
+      finalityStatus: finalityStatus ?? transaction.finalityStatus,
+      executionStatus: executionStatus ?? transaction.executionStatus,
+      actualFee: null,
+      maxFee: this.isDeployTransaction(tx) ? null : '0',
       contractAddress: this.getContractAddress(tx),
-      failureReason,
-      txnType,
+      failureReason: executionStatus === 'REVERTED' ? 'REVERTED' : '',
+      txnType: (txnType as TransactionType) ?? transaction.txnType,
     };
-    /* eslint-enable */
   }
 }

--- a/packages/starknet-snap/src/chain/data-client/starkscan.type.ts
+++ b/packages/starknet-snap/src/chain/data-client/starkscan.type.ts
@@ -1,12 +1,5 @@
 import type { Infer } from 'superstruct';
-import {
-  array,
-  boolean,
-  nullable,
-  number,
-  object,
-  string,
-} from 'superstruct';
+import { array, boolean, nullable, number, object, string } from 'superstruct';
 
 export const StarkScanTransactionStruct = object({
   blockNumber: number(),

--- a/packages/starknet-snap/src/chain/data-client/starkscan.type.ts
+++ b/packages/starknet-snap/src/chain/data-client/starkscan.type.ts
@@ -1,48 +1,39 @@
-import {
-  TransactionExecutionStatus,
-  TransactionFinalityStatus,
-  TransactionType,
-} from 'starknet';
 import type { Infer } from 'superstruct';
-import { array, nullable, number, object, string, enums } from 'superstruct';
-
-/* eslint-disable @typescript-eslint/naming-convention */
-const NullableStringStruct = nullable(string());
-const NullableStringArrayStruct = nullable(array(string()));
-
-export const StarkScanAccountCallStruct = object({
-  contract_address: string(),
-  calldata: array(string()),
-  selector: string(),
-});
+import {
+  array,
+  boolean,
+  nullable,
+  number,
+  object,
+  string,
+} from 'superstruct';
 
 export const StarkScanTransactionStruct = object({
-  transaction_hash: string(),
-  transaction_finality_status: enums(Object.values(TransactionFinalityStatus)),
-  transaction_execution_status: enums(
-    Object.values(TransactionExecutionStatus),
-  ),
-  transaction_type: enums(Object.values(TransactionType)),
-  // The transaction version, 1 or 3, where 3 represents the fee will be paid in STRK
-  version: number(),
-  max_fee: NullableStringStruct,
-  actual_fee: NullableStringStruct,
-  nonce: NullableStringStruct,
-  contract_address: NullableStringStruct,
-  calldata: NullableStringArrayStruct,
-  sender_address: NullableStringStruct,
-  timestamp: number(),
-  revert_error: NullableStringStruct,
-  account_calls: array(StarkScanAccountCallStruct),
+  blockNumber: number(),
+  timestampIso: nullable(string()),
+  txIndex: number(),
+  txHash: string(),
+  kinds: array(string()),
+  counterparty: nullable(string()),
+  txType: nullable(string()),
+  executionStatus: nullable(string()),
+  finalityStatus: nullable(string()),
+  fromAddress: nullable(string()),
+  toAddress: nullable(string()),
+  primaryMethod: nullable(string()),
+  callCount: nullable(number()),
+  methodsDiffer: nullable(boolean()),
+  transferCount: nullable(number()),
+  topTransferTokenAddress: nullable(string()),
+  topTransferAmount: nullable(string()),
+  topTransferStandard: nullable(string()),
 });
-
-export type StarkScanAccountCall = Infer<typeof StarkScanAccountCallStruct>;
 
 export type StarkScanTransaction = Infer<typeof StarkScanTransactionStruct>;
 
 export const StarkScanTransactionsResponseStruct = object({
-  next_url: nullable(string()),
-  data: array(StarkScanTransactionStruct),
+  items: array(StarkScanTransactionStruct),
+  nextCursor: nullable(string()),
 });
 
 export type StarkScanTransactionsResponse = Infer<
@@ -52,4 +43,3 @@ export type StarkScanTransactionsResponse = Infer<
 export type StarkScanOptions = {
   apiKey: string;
 };
-/* eslint-enable */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect how wallet transaction history is fetched and normalized; incomplete v1 mapping (synthetic invokes, missing fees/revert detail) could skew displayed activity until further API fields are wired.
> 
> **Overview**
> **StarkScan transaction fetching** is updated from the legacy `/api/v0` contract endpoints to **`https://api.starkscan.co/v1/{SN_SEPOLIA|SN_MAIN}/address/{address}/transactions`**, with **`nextCursor`**-based pagination instead of **`next_url`**, and auth via **`X-Starkscan-Api-Key`** (Sepolia no longer uses a separate host).
> 
> Response types and mapping are aligned with the new payload: list fields **`items`** / **`nextCursor`**, per-tx **`txHash`**, **`txType`**, **`timestampIso`**, **`fromAddress`** / **`toAddress`**, and transfer summary fields. **`toTransaction`** now derives Unix time from ISO strings, treats deploy vs invoke from **`txType`**, and builds invoke **`accountCalls`** from **`topTransferTokenAddress`**, **`counterparty`**, **`topTransferAmount`**, and **`primaryMethod`** rather than **`account_calls`**. Fees and version are largely **stubbed** (`maxFee`/`actualFee`, fixed version **3**) where the v1 shape no longer exposes the old fields.
> 
> Shared **`ApiClient`** only sets **`Content-Type: application/json`** on **POST** requests so GET StarkScan calls are not sent with a JSON content type. Tests and **`generateStarkScanTransactions`** mocks were rewritten to match the v1 schema (fixture JSON import removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f86a0be432e51bacf54fb41fd7b2ff0e3f8bc87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->